### PR TITLE
Fix update-bazel test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,8 +2,13 @@
 
 filegroup(
     name = "package-srcs",
-    srcs = glob(["**"], exclude=["bazel-*/**", ".git/**"]),
-    tags = ["automanaged"],
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "bazel-*/**",
+            ".git/**",
+        ],
+    ),
     visibility = ["//visibility:private"],
 )
 

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -22,13 +22,6 @@ if [[ -n "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then # Running inside bazel
 elif ! command -v bazel &>/dev/null; then
   echo "Install bazel at https://bazel.build" >&2
   exit 1
-elif ! bazel query @com_github_bazelbuild_bazel_gazelle//cmd/gazelle &>/dev/null; then
-  (
-    set -o xtrace
-    bazel run //hack:bootstrap-testinfra
-    bazel run //hack:update-bazel
-  )
-  exit 0
 else
   (
     set -o xtrace


### PR DESCRIPTION
Automanaging the `package-srcs` was causing kazel and gazelle to fight; see #5 

Also removed redundant subroutine from script; `//hack:bootstrap-testinfra` doesn't exist anymore.