### PR TITLE
Correctly map protos for .pb.go files.

### DIFF
--- a/cmd/summarizer/summary/summarizer_service.pb.go
+++ b/cmd/summarizer/summary/summarizer_service.pb.go
@@ -22,11 +22,11 @@ package summarizer_service
 import (
 	context "context"
 	fmt "fmt"
+	response "github.com/GoogleCloudPlatform/testgrid/pb/response"
+	summary "github.com/GoogleCloudPlatform/testgrid/pb/summary"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	math "math"
-	response "pb/response"
-	summary "pb/summary"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -58,9 +58,9 @@ protoc_grpc = "plugins=grpc"
 # Go package import path. Each mapping entry is prefixed with the keyword "M".
 # Reference the https://github.com/golang/protobuf "Parameters" section.
 proto_importmap = ",".join([
-    "Mconfig/config.proto=github.com/GoogleCloudPlatform/testgrid/config",
-    "Msummary/summary.proto=github.com/GoogleCloudPlatform/testgrid/summary",
-    "Mcmd/summarizer/response/types.proto=github.com/GoogleCloudPlatform/testgrid/cmd/summarizer/response",
+    "Mpb/config/config.proto=github.com/GoogleCloudPlatform/testgrid/pb/config",
+    "Mpb/summary/summary.proto=github.com/GoogleCloudPlatform/testgrid/pb/summary",
+    "Mpb/response/types.proto=github.com/GoogleCloudPlatform/testgrid/pb/response",
 ])
 
 sh_binary(

--- a/pb/response/types.pb.go
+++ b/pb/response/types.pb.go
@@ -21,10 +21,10 @@ package response
 
 import (
 	fmt "fmt"
+	config "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	summary "github.com/GoogleCloudPlatform/testgrid/pb/summary"
 	proto "github.com/golang/protobuf/proto"
 	math "math"
-	config "pb/config"
-	summary "pb/summary"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
Using importmap to get the correct import paths when importing protos into other protos.

/assign @fejta 