### PR TITLE
Remove "area/testgrid" label

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,5 +12,3 @@ approvers:
 - fejta
 - Katharine
 - michelle192837
-labels:
-- area/testgrid


### PR DESCRIPTION
Considering the entire repository is testgrid, this label is redundant and should be removed.

Fixes #31