### PR TITLE
Update bazel rules in Workspace

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,9 +26,9 @@ go_repositories()
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "e513c0ac6534810eb7a14bf025a0f159726753f97f74ab7863c650d26e01d677",
-    strip_prefix = "rules_docker-0.9.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.9.0.tar.gz"],
+    sha256 = "413bb1ec0895a8d3249a01edf24b82fd06af3c8633c9fb833a0cb1d4b234d46d",
+    strip_prefix = "rules_docker-0.12.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.12.0.tar.gz"],
 )
 
 load("@io_bazel_rules_docker//repositories:repositories.bzl", _container_repositories = "repositories")
@@ -43,9 +43,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "io_bazel_rules_k8s",
-    commit = "e7ae2825f0296314ac1ecf13e4c9acef66597986",
+    commit = "c7db606023bef31ca5c2ad49942f33c6137cb7f8",
     remote = "https://github.com/bazelbuild/rules_k8s.git",
-    shallow_since = "1565892120 -0400",
+    shallow_since = "1571437004 -0400",
 )
 
 load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")


### PR DESCRIPTION
Required to run `//images:push` due to dependencies using python

Without this, `//images:push` generates the following error (with bazel 1.1.0):

```
----------------
Traceback (most recent call last):
  File "/usr/local/google/home/slchase/.cache/bazel/_bazel_slchase/0cf923e311637c9c17c1bb47ed49455a/execroot/com_github_googlecloudplatform_testgrid/bazel-out/k8-fastbuild/bin/images/push.runfiles/containerregistry/tools/fast_pusher_.py", line 29, in <module>
    from containerregistry.client import docker_creds
  File "/usr/local/google/home/slchase/.cache/bazel/_bazel_slchase/0cf923e311637c9c17c1bb47ed49455a/execroot/com_github_googlecloudplatform_testgrid/bazel-out/k8-fastbuild/bin/images/push.runfiles/containerregistry/client/__init__.py", line 23, in <module>
    from containerregistry.client import docker_creds_
  File "/usr/local/google/home/slchase/.cache/bazel/_bazel_slchase/0cf923e311637c9c17c1bb47ed49455a/execroot/com_github_googlecloudplatform_testgrid/bazel-out/k8-fastbuild/bin/images/push.runfiles/containerregistry/client/docker_creds_.py", line 31, in <module>
    import httplib2
  File "/usr/local/google/home/slchase/.cache/bazel/_bazel_slchase/0cf923e311637c9c17c1bb47ed49455a/execroot/com_github_googlecloudplatform_testgrid/bazel-out/k8-fastbuild/bin/images/push.runfiles/httplib2/__init__.py", line 28, in <module>
    import email.FeedParser
ModuleNotFoundError: No module named 'email.FeedParser'
Traceback (most recent call last):
  File "/usr/local/google/home/slchase/.cache/bazel/_bazel_slchase/0cf923e311637c9c17c1bb47ed49455a/execroot/com_github_googlecloudplatform_testgrid/bazel-out/k8-fastbuild/bin/images/push.runfiles/containerregistry/tools/fast_pusher_.py", line 29, in <module>
    from containerregistry.client import docker_creds
  File "/usr/local/google/home/slchase/.cache/bazel/_bazel_slchase/0cf923e311637c9c17c1bb47ed49455a/execroot/com_github_googlecloudplatform_testgrid/bazel-out/k8-fastbuild/bin/images/push.runfiles/containerregistry/client/__init__.py", line 23, in <module>
    from containerregistry.client import docker_creds_
  File "/usr/local/google/home/slchase/.cache/bazel/_bazel_slchase/0cf923e311637c9c17c1bb47ed49455a/execroot/com_github_googlecloudplatform_testgrid/bazel-out/k8-fastbuild/bin/images/push.runfiles/containerregistry/client/docker_creds_.py", line 31, in <module>
    import httplib2
  File "/usr/local/google/home/slchase/.cache/bazel/_bazel_slchase/0cf923e311637c9c17c1bb47ed49455a/execroot/com_github_googlecloudplatform_testgrid/bazel-out/k8-fastbuild/bin/images/push.runfiles/httplib2/__init__.py", line 28, in <module>
    import email.FeedParser
ModuleNotFoundError: No module named 'email.FeedParser'
----------------
Note: The failure of target @containerregistry//:pusher (with exit code 1) may have been caused by the fact that it is running under Python 3 instead of Python 2. Examine the error to determine if that appears to be the problem. Since this target is built in the host configuration, the only way to change its version is to set --host_force_python=PY2, which affects the entire build.

If this error started occurring in Bazel 0.27 and later, it may be because the Python toolchain now enforces that targets analyzed as PY2 and PY3 run under a Python 2 and Python 3 interpreter, respectively. See https://github.com/bazelbuild/bazel/issues/7899 for more information.
----------------
----------------
Note: The failure of target @containerregistry//:pusher (with exit code 1) may have been caused by the fact that it is running under Python 3 instead of Python 2. Examine the error to determine if that appears to be the problem. Since this target is built in the host configuration, the only way to change its version is to set --host_force_python=PY2, which affects the entire build.

If this error started occurring in Bazel 0.27 and later, it may be because the Python toolchain now enforces that targets analyzed as PY2 and PY3 run under a Python 2 and Python 3 interpreter, respectively. See https://github.com/bazelbuild/bazel/issues/7899 for more information.
----------------
```

/assign @fejta @clarketm 