### PR TITLE
Create state based summarizer

### DIFF
--- a/cmd/summarizer/BUILD.bazel
+++ b/cmd/summarizer/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("//:def.bzl", "make_image")
 
@@ -13,6 +14,29 @@ make_image(
     visibility = ["//visibility:public"],
 )
 
+go_binary(
+    name = "summarizer",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/GoogleCloudPlatform/testgrid/cmd/summarizer",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//config:go_default_library",
+        "//pb/config:go_default_library",
+        "//pb/state:go_default_library",
+        "//pb/summary:go_default_library",
+        "//util/gcs:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go//storage:go_default_library",
+    ],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
@@ -25,4 +49,11 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//pb/config:go_default_library"],
 )

--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -1,0 +1,486 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"compress/zlib"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/golang/protobuf/proto"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleCloudPlatform/testgrid/config"
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+	"github.com/GoogleCloudPlatform/testgrid/pb/summary"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+)
+
+type options struct {
+	config      gcs.Path // gcs://path/to/config/proto
+	creds       string
+	confirm     bool
+	dashboard   string
+	concurrency int
+}
+
+func (o *options) validate() error {
+	if o.config.String() == "" {
+		return errors.New("empty --config")
+	}
+	if o.config.Bucket() == "k8s-testgrid" && o.confirm { // TODO(fejta): remove
+		return fmt.Errorf("--config=%q cannot start with gs://k8s-testgrid", o.config)
+	}
+	if o.concurrency == 0 {
+		o.concurrency = 4 * runtime.NumCPU()
+	}
+	return nil
+}
+
+func gatherOptions() options {
+	var o options
+	flag.Var(&o.config, "config", "gs://path/to/config.pb")
+	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
+	flag.BoolVar(&o.confirm, "confirm", false, "Upload data if set")
+	flag.StringVar(&o.dashboard, "dashboard", "", "Only update named dashboard if set")
+	flag.IntVar(&o.concurrency, "concurrency", 0, "Manually define the number of groups to concurrently update if non-zero")
+	flag.Parse()
+	return o
+}
+
+type groupFinder func(string) (*configpb.TestGroup, *gcs.Path, error)
+
+func main() {
+
+	opt := gatherOptions()
+	if err := opt.validate(); err != nil {
+		logrus.Fatalf("Invalid flags: %v", err)
+	}
+	if !opt.confirm {
+		logrus.Info("--confirm=false (DRY-RUN): will not write to gcs")
+	}
+
+	ctx := context.Background()
+	client, err := gcs.ClientWithCreds(ctx, opt.creds)
+	if err != nil {
+		logrus.Fatalf("Failed to read storage client: %v", err)
+	}
+
+	cfg, err := config.ReadGCS(ctx, client.Bucket(opt.config.Bucket()).Object(opt.config.Object()))
+	if err != nil {
+		logrus.Fatalf("Failed to read %q: %v", opt.config, err)
+	}
+	logrus.Infof("Found %d dashboards", len(cfg.Dashboards))
+
+	dashboards := make(chan *configpb.Dashboard)
+	var wg sync.WaitGroup
+
+	groupFinder := func(name string) (*configpb.TestGroup, *gcs.Path, error) {
+		group := config.FindTestGroup(name, cfg)
+		if group == nil {
+			return nil, nil, nil
+		}
+		path, err := opt.config.ResolveReference(&url.URL{Path: name})
+		return group, path, err
+	}
+
+	for i := 0; i < opt.concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			for dash := range dashboards {
+				if err := updateDashboard(ctx, client, dash, groupFinder); err != nil {
+					logrus.WithField("dashboard", dash.Name).WithError(err).Fatal("Cannot summarize dashboard")
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	for _, d := range cfg.Dashboards {
+		if opt.dashboard != "" && opt.dashboard != d.Name {
+			logrus.WithField("dashboard", d.Name).Info("Skipping")
+			continue
+		}
+		dashboards <- d
+	}
+	close(dashboards)
+	wg.Wait()
+}
+
+func updateDashboard(ctx context.Context, client *storage.Client, dash *configpb.Dashboard, finder groupFinder) error {
+	log := logrus.WithField("dashboard", dash.Name)
+	var badTabs []string
+	var sum summary.DashboardSummary
+	for _, tab := range dash.DashboardTab {
+		s, err := updateTab(ctx, client, tab, finder)
+		if err != nil {
+			log.WithField("tab", tab.Name).WithError(err).Error("Cannot summarize tab")
+			badTabs = append(badTabs, tab.Name)
+		}
+		sum.TabSummaries = append(sum.TabSummaries, s)
+	}
+	if d := len(badTabs); d > 0 {
+		return fmt.Errorf("Failed %d tabs: %s", d, strings.Join(badTabs, ", "))
+	}
+	log.WithField("summary", sum).Info("summarized") // TODO(fejta): write it
+	return nil
+}
+
+func staleHours(tab *configpb.DashboardTab) time.Duration {
+	if tab.AlertOptions == nil {
+		return 0
+	}
+	return time.Duration(tab.AlertOptions.AlertStaleResultsHours) * time.Hour
+}
+
+func updateTab(ctx context.Context, client *storage.Client, tab *configpb.DashboardTab, findGroup groupFinder) (*summary.DashboardTabSummary, error) {
+	groupName := tab.TestGroupName
+	group, groupPath, err := findGroup(groupName)
+	if err != nil {
+		return nil, fmt.Errorf("find group: %v", err)
+	}
+	if group == nil {
+		return nil, fmt.Errorf("not found: %q", groupName)
+	}
+	grid, mod, _, err := loadGrid(ctx, client, *groupPath) // TODO(fejta): track gen
+	if err != nil {
+		return nil, fmt.Errorf("load %q: %v", groupName, err)
+	}
+
+	recent := recentColumns(tab, group)
+	filterGrid(tab, grid, recent)
+
+	latest, latestSeconds := latestRun(grid.Columns)
+	alert := staleAlert(mod, latest, staleHours(tab))
+	failures := failingTestSummaries(grid.Rows)
+	return &summary.DashboardTabSummary{
+		DashboardTabName:     tab.Name,
+		LastUpdateTimestamp:  float64(mod.Unix()),
+		LastRunTimestamp:     float64(latestSeconds),
+		Alert:                alert,
+		FailingTestSummaries: failures,
+		OverallStatus:        overallStatus(grid, recent, alert, failures),
+		// TODO(fejta): Status:               summarize(grid, recent),
+		LatestGreen: latestGreen(grid),
+		// TODO(fejta): BugUrl
+	}, nil
+}
+
+// loadGrid downloads and deserializes the current test group state.
+func loadGrid(ctx context.Context, client *storage.Client, path gcs.Path) (*state.Grid, time.Time, int64, error) {
+	var t time.Time
+	r, err := client.Bucket(path.Bucket()).Object(path.Object()).NewReader(ctx)
+	if err != nil {
+		return nil, t, 0, fmt.Errorf("open %q: %v", path, err)
+	}
+	defer r.Close()
+	zlibReader, err := zlib.NewReader(r)
+	if err != nil {
+		return nil, t, 0, fmt.Errorf("decompress %s: %v", path, err)
+	}
+	buf, err := ioutil.ReadAll(zlibReader)
+	if err != nil {
+		return nil, t, 0, fmt.Errorf("read %s: %v", path, err)
+	}
+	var g state.Grid
+	if err = proto.Unmarshal(buf, &g); err != nil {
+		return nil, t, 0, fmt.Errorf("parse %s: %v", path, err)
+	}
+	return &g, r.Attrs.LastModified, r.Attrs.Generation, nil
+}
+
+// recentColumns returns the configured number of recent columns to summarize, or 5.
+func recentColumns(tab *configpb.DashboardTab, group *configpb.TestGroup) int {
+	return firstFilled(tab.NumColumnsRecent, group.NumColumnsRecent, 5)
+}
+
+func failuresToOpen(tab *configpb.DashboardTab, group *configpb.TestGroup) int {
+	return firstFilled(tab.AlertOptions.NumFailuresToAlert, group.NumFailuresToAlert)
+
+}
+
+// passesToClose returns the number of consecutive passes configured to close an alert, or 1.
+func passesToClose(tab configpb.DashboardTab, group *configpb.TestGroup) int {
+	return firstFilled(tab.AlertOptions.NumPassesToDisableAlert, group.NumPassesToDisableAlert, 1)
+}
+
+// firstFilled returns the first non-empty value, or zero.
+func firstFilled(values ...int32) int {
+	for _, v := range values {
+		if v != 0 {
+			return int(v)
+		}
+	}
+	return 0
+}
+
+// filterGrid truncates the grid to rows with recent results and matching the white/blacklist.
+func filterGrid(tab *configpb.DashboardTab, grid *state.Grid, recent int) error {
+	const (
+		includeFilter = "include-filter-by-regex"
+		excludeFilter = "exclude-filter-by-regex"
+		// TODO(fejta): others, which are not used by testgrid.k8s.io
+	)
+
+	vals, err := url.ParseQuery(tab.BaseOptions)
+	if err != nil {
+		return fmt.Errorf("parse base options %q: %v", tab.BaseOptions, err)
+	}
+
+	grid.Rows = recentRows(grid.Rows, recent)
+
+	for _, include := range vals[includeFilter] {
+		if grid.Rows, err = includeRows(grid.Rows, include); err != nil {
+			return fmt.Errorf("bad %s=%s: %v", includeFilter, include, err)
+		}
+	}
+
+	for _, exclude := range vals[excludeFilter] {
+		if grid.Rows, err = excludeRows(grid.Rows, exclude); err != nil {
+			return fmt.Errorf("bad %s=%s: %v", excludeFilter, exclude, err)
+		}
+	}
+
+	// TODO(fejta): grouping, which is not used by testgrid.k8s.io
+	// TODO(fejta): sorting, unused by testgrid.k8s.io
+	// TODO(fejta): graph, unused by testgrid.k8s.io
+	// TODO(fejta): tabuluar, unused by testgrid.k8s.io
+	return nil
+}
+
+// recentRows returns the subset of rows with at least one recent result
+func recentRows(in []*state.Row, recent int) []*state.Row {
+	var rows []*state.Row
+	for _, r := range in {
+		if state.Row_Result(r.Results[0]) == state.Row_NO_RESULT && int(r.Results[1]) >= recent {
+			continue
+		}
+		rows = append(rows, r)
+	}
+	return rows
+}
+
+// includeRows returns the subset of rows that match the regex
+func includeRows(in []*state.Row, include string) ([]*state.Row, error) {
+	re, err := regexp.Compile(include)
+	if err != nil {
+		return nil, err
+	}
+	var rows []*state.Row
+	for _, r := range in {
+		if !re.MatchString(r.Name) {
+			continue
+		}
+		rows = append(rows, r)
+	}
+	return rows, nil
+}
+
+// excludeRows returns the subset of rows that do not match the regex
+func excludeRows(in []*state.Row, exclude string) ([]*state.Row, error) {
+	re, err := regexp.Compile(exclude)
+	if err != nil {
+		return nil, err
+	}
+	var rows []*state.Row
+	for _, r := range in {
+		if re.MatchString(r.Name) {
+			continue
+		}
+		rows = append(rows, r)
+	}
+	return rows, nil
+}
+
+// latestRun returns the Time (and seconds-since-epoch) of the most recent run.
+func latestRun(columns []*state.Column) (time.Time, int64) {
+	for _, col := range columns {
+		start := int64(col.Started)
+		if start > 0 {
+			return time.Unix(start, 0), start
+		}
+		return time.Time{}, start
+	}
+	return time.Time{}, 0
+}
+
+// staleAlert returns an explanatory message if the latest results are stale.
+func staleAlert(mod, ran time.Time, stale time.Duration) string {
+	if mod.IsZero() {
+		return "no stored results"
+	}
+	if ran.IsZero() {
+		return "no completed results"
+	}
+	if stale == 0 {
+		return ""
+	}
+	now := time.Now()
+	if dur := now.Sub(mod); dur > stale {
+		return fmt.Sprintf("data has not changed since %s (%s old)", mod, dur.Truncate(15*time.Minute))
+	}
+	if dur := now.Sub(ran); dur > stale {
+		return fmt.Sprintf("latest column from %s (%s old)", ran, dur.Truncate(15*time.Minute))
+	}
+	return ""
+}
+
+// failingTestSummaries returns details for every row with an active alert.
+func failingTestSummaries(rows []*state.Row) []*summary.FailingTestSummary {
+	var failures []*summary.FailingTestSummary
+	for _, row := range rows {
+		if row.AlertInfo == nil {
+			continue
+		}
+		alert := row.AlertInfo
+		failures = append(failures, &summary.FailingTestSummary{
+			DisplayName: row.Name,
+			TestName:    row.Id,
+			FailBuildId: alert.FailBuildId,
+			// TODO(fejta): FailTimestamp
+			PassBuildId: alert.PassBuildId,
+			// TODO(fejta): PassTimestamp
+			FailCount:      alert.FailCount,
+			BuildLink:      alert.BuildLink,
+			BuildLinkText:  alert.BuildLinkText,
+			BuildUrlText:   alert.BuildUrlText,
+			FailureMessage: alert.FailureMessage,
+			// TODO(fejta): LinkedBugs
+			// TODO(fejta): FailTestLink
+		})
+	}
+	return failures
+}
+
+// overallStatus determines whether the tab is stale, failing, flaky or healthy.
+func overallStatus(grid *state.Grid, recent int, stale string, alerts []*summary.FailingTestSummary) summary.DashboardTabSummary_TabStatus {
+	if stale != "" {
+		return summary.DashboardTabSummary_STALE
+	}
+	if len(alerts) > 0 {
+		return summary.DashboardTabSummary_FAIL
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	results := results(ctx, grid.Rows)
+	var found bool
+	for _, resultCh := range results {
+		recentResults := recent
+		for result := range resultCh {
+			result = coalesceResult(result)
+			if result == state.Row_NO_RESULT {
+				continue
+			}
+			if result != state.Row_PASS {
+				return summary.DashboardTabSummary_FLAKY
+			}
+			recentResults--
+			if recentResults == 0 {
+				break
+			}
+			found = true
+		}
+
+	}
+	if found {
+		return summary.DashboardTabSummary_PASS
+	}
+	return summary.DashboardTabSummary_UNKNOWN
+}
+
+// latestGreen finds the ID for the most recent column with all passing rows.
+func latestGreen(grid *state.Grid) string {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results := results(ctx, grid.Rows)
+	for _, col := range grid.Columns {
+		var failures bool
+		var passes bool
+		for _, resultCh := range results {
+			result := coalesceResult(<-resultCh)
+			if result == state.Row_PASS {
+				passes = true
+			}
+			if result == state.Row_FLAKY || result == state.Row_FAIL {
+				failures = true
+				break
+			}
+		}
+		if passes && !failures {
+			return col.Extra[0]
+		}
+	}
+	return "no recent greens"
+}
+
+// coalesceResult reduces the result to PASS, NO_RESULT, FAIL or FLAKY.
+func coalesceResult(result state.Row_Result) state.Row_Result {
+	// TODO(fejta): other result types, not used by k8s testgrid
+	const allowRunning = true // TODO(fejta): move to arg, auto-fail old results
+	if result == state.Row_NO_RESULT || result == state.Row_RUNNING && allowRunning {
+		return state.Row_NO_RESULT
+	}
+	if result == state.Row_FAIL || result == state.Row_RUNNING {
+		return state.Row_FAIL
+	}
+	if result == state.Row_FLAKY {
+		return result
+	}
+	return state.Row_PASS
+}
+
+// resultIter returns a channel that outputs the result for each column, decoding the run-length-encoding.
+func resultIter(ctx context.Context, results []int32) <-chan state.Row_Result {
+	out := make(chan state.Row_Result)
+	go func() {
+		defer close(out)
+		for i := 0; i+1 < len(results); i += 2 {
+			result := state.Row_Result(results[i])
+			count := results[i+1]
+			for count > 0 {
+				select {
+				case <-ctx.Done():
+					return
+				case out <- result:
+					count--
+				}
+			}
+		}
+	}()
+	return out
+}
+
+// results returns a per-column result output channel for each row.
+func results(ctx context.Context, rows []*state.Row) map[string]<-chan state.Row_Result {
+	iters := map[string]<-chan state.Row_Result{}
+	for _, r := range rows {
+		iters[r.Name] = resultIter(ctx, r.Results)
+	}
+	return iters
+}

--- a/cmd/summarizer/main_test.go
+++ b/cmd/summarizer/main_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+)
+
+func TestStaleHours(t *testing.T) {
+	cases := []struct {
+		name     string
+		tab      configpb.DashboardTab
+		expected time.Duration
+	}{
+		{
+			name:     "zero without an alert",
+			expected: 0,
+		},
+		{
+			name: "use defined hours when set",
+			tab: configpb.DashboardTab{
+				AlertOptions: &configpb.DashboardTabAlertOptions{
+					AlertStaleResultsHours: 4,
+				},
+			},
+			expected: 4 * time.Hour,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := staleHours(&tc.tab); actual != tc.expected {
+				t.Errorf("actual %v != expected %v", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -375,6 +375,7 @@ func AppendColumn(headers []string, format nameConfig, grid *state.Grid, rows ma
 				r = &state.Row{
 					Name: name,
 					Id:   target,
+					// TODO(fejta): AlertInfo,
 				}
 				rows[name] = r
 				grid.Rows = append(grid.Rows, r)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -65,9 +67,13 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
+github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -115,6 +121,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pb/state/state.pb.go
+++ b/pb/state/state.pb.go
@@ -633,7 +633,6 @@ type Grid struct {
 	// Seconds since epoch for last time this cycle was updated.
 	LastTimeUpdated float64 `protobuf:"fixed64,6,opt,name=last_time_updated,json=lastTimeUpdated,proto3" json:"last_time_updated,omitempty"`
 	// Stored info on previous timing for parts of the update cycle.
-	// TODO(b/63145995): Move last_time_updated, last_alert_mail_time here.
 	UpdateInfo []*UpdateInfo `protobuf:"bytes,8,rep,name=update_info,json=updateInfo,proto3" json:"update_info,omitempty"`
 	// Stored info on default test metadata.
 	TestMetadata []*TestMetadata `protobuf:"bytes,9,rep,name=test_metadata,json=testMetadata,proto3" json:"test_metadata,omitempty"`

--- a/pb/state/state.proto
+++ b/pb/state/state.proto
@@ -184,7 +184,6 @@ message Grid {
   reserved 7;
 
   // Stored info on previous timing for parts of the update cycle.
-  // TODO(b/63145995): Move last_time_updated, last_alert_mail_time here.
   repeated UpdateInfo update_info = 8;
 
   // Stored info on default test metadata.

--- a/repos.bzl
+++ b/repos.bzl
@@ -259,8 +259,8 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "github.com/stretchr/objx",
-        sum = "h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=",
-        version = "v0.1.0",
+        sum = "h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=",
+        version = "v0.1.1",
     )
     go_repository(
         name = "com_github_stretchr_testify",
@@ -522,4 +522,20 @@ def go_repositories():
         importpath = "golang.org/x/mobile",
         sum = "h1:Tus/Y4w3V77xDsGwKUC8a/QrV7jScpU557J77lFffNs=",
         version = "v0.0.0-20190312151609-d3739f865fa6",
+    )
+    go_repository(
+        name = "com_github_konsorten_go_windows_terminal_sequences",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/konsorten/go-windows-terminal-sequences",
+        sum = "h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=",
+        version = "v1.0.1",
+    )
+    go_repository(
+        name = "com_github_sirupsen_logrus",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/sirupsen/logrus",
+        sum = "h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=",
+        version = "v1.4.2",
     )


### PR DESCRIPTION
* Download the config proto
* For each dashboard create a summary for each tab
* For each tab
  - Download the state proto
  - Filter out irrelevant rows
  - Find the latest run, noting if this is stale (also last update to state proto)
  - Extract any active alerts
  - Find the last result with only green tests
  - Decide the overall tab state:
     * stale if results are old
     * failing if there are active alerts
     * passing if all recent results are healthy
     * flaky if there are some failures but no alerts
     * unknown if there are not any results yet

TODO:
* Many more unit tests (let me know if you want logic to come with tests or added later)
* Failing/passing alert timestamps (external proto doesn't yet define these fields)
* Support for functionality that isn't yet being used by testgrid.k8s.io
* Performance improvements:
  - More concurrency, similar to the updater
  - Only update when the state has changed
* Upload the summary protos after creating them