### PR TITLE
Allow reading from k8s-testgrid

### DIFF
--- a/cluster/BUILD.bazel
+++ b/cluster/BUILD.bazel
@@ -16,7 +16,7 @@ load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 
 k8s_objects(
-    name = "dev",
+    name = "prod",
     objects = [
         ":updater",
         ":summarizer",
@@ -29,7 +29,6 @@ k8s_object(
     name = "updater",
     cluster = CLUSTER,
     kind = "Deployment",
-    namespace = "testgrid",
     template = "updater_deployment.yaml",
 )
 
@@ -37,7 +36,6 @@ k8s_object(
     name = "summarizer",
     cluster = CLUSTER,
     kind = "Deployment",
-    namespace = "testgrid",
     template = "summarizer_deployment.yaml",
 )
 

--- a/cluster/summarizer_deployment.yaml
+++ b/cluster/summarizer_deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app: testgrid
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      component: summarizer
   template:
     metadata:
       labels:
@@ -17,7 +21,7 @@ spec:
     spec:
       containers:
       - name: summarizer
-        image: gcr.io/k8s-testgrid/testgrid/summarizer
+        image: gcr.io/k8s-testgrid/summarizer:v20191122-v0.0.1-alpha.2-13-g31a8cc8
         args:
         - --config=gs://k8s-testgrid/beta/config
         - --wait=5m

--- a/cluster/updater_deployment.yaml
+++ b/cluster/updater_deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app: testgrid
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      component: updater
   template:
     metadata:
       labels:
@@ -17,7 +21,7 @@ spec:
     spec:
       containers:
       - name: updater
-        image: gcr.io/fejta-prod/testgrid/updater
+        image: gcr.io/k8s-testgrid/updater:v20191122-v0.0.1-alpha.2-13-g31a8cc8
         args:
         - --config=gs://k8s-testgrid/beta/config
         - --wait=5m

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -68,8 +68,8 @@ func (o *options) validate() error {
 	if o.config.String() == "" {
 		return errors.New("empty --config")
 	}
-	if o.config.Bucket() == "k8s-testgrid" { // TODO(fejta): remove
-		return fmt.Errorf("--config=%s cannot start with gs://k8s-testgrid", o.config)
+	if o.config.Bucket() == "k8s-testgrid" && o.confirm { // TODO(fejta): remove
+		return fmt.Errorf("--config=%s cannot write to gs://k8s-testgrid", o.config)
 	}
 	if o.groupConcurrency == 0 {
 		o.groupConcurrency = 4 * runtime.NumCPU()

--- a/images/push.sh
+++ b/images/push.sh
@@ -56,7 +56,7 @@ fi
 echo -e "Pushing $(color-version ${new_version})" >&2
 # Remove retries after https://github.com/bazelbuild/rules_docker/issues/673
 for i in {1..3}; do
-  if bazel run //images:push; then
+  if bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:push; then
     exit 0
   elif [[ "$i" == 3 ]]; then
     echo "Failed"


### PR DESCRIPTION
* Continue disallowing writing
* Fix-up deployments to include a selector and use correct image path
* Do not overwrite namespace
* Set platform when building images to deploy