### PR TITLE
Improve updater, summarizer, gcs reader

### DIFF
--- a/cluster/summarizer_deployment.yaml
+++ b/cluster/summarizer_deployment.yaml
@@ -22,8 +22,8 @@ spec:
       serviceAccountName: summarizer
       containers:
       - name: summarizer
-        image: gcr.io/k8s-testgrid/summarizer:v20191122-v0.0.1-alpha.2-17-g0ae474d
+        image: gcr.io/k8s-testgrid/summarizer:v20191124-v0.0.1-alpha.2-20-g0a10758
         args:
-        - --config=gs://k8s-testgrid/beta/config
+        - --config=gs://fejternetes/config
         - --confirm
         - --wait=5m

--- a/cluster/updater_deployment.yaml
+++ b/cluster/updater_deployment.yaml
@@ -22,8 +22,8 @@ spec:
       serviceAccountName: updater
       containers:
       - name: updater
-        image: gcr.io/k8s-testgrid/updater:v20191122-v0.0.1-alpha.2-17-g0ae474d
+        image: gcr.io/k8s-testgrid/updater:v20191124-v0.0.1-alpha.2-20-gcc2f776
         args:
-        - --config=gs://k8s-testgrid/beta/config
+        - --config=gs://fejternetes/config
         - --confirm
-        - --wait=5m
+        - --wait=30m

--- a/cmd/updater/BUILD.bazel
+++ b/cmd/updater/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pb/state:go_default_library",
         "//util/gcs:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
         "@ml_vbom_util//sortorder:go_default_library",

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -475,6 +475,19 @@ func TestAlertRow(t *testing.T) {
 			failOpen:  1,
 			passClose: 2,
 		},
+		{
+			name: "running cells advance compressed index",
+			row: state.Row{
+				Results: []int32{
+					int32(state.Row_RUNNING), 1,
+					int32(state.Row_FAIL), 5,
+				},
+				Messages: []string{"running0", "fail1-expected", "fail2", "fail3", "fail4", "fail5"},
+				CellIds:  []string{"wrong", "yep", "no2", "no3", "no4", "no5"},
+			},
+			failOpen: 1,
+			expected: alertInfo(5, "fail1-expected", "yep", columns[5], nil),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
* Use its own bucket rather than a subdir
* Support running continuously if `--wait` is positive
* Update all dashboards even if one fails
* Switch updater to use logrus
* Switch updater to use the configured number of days of results rather than 7
* Advance compressed index on running cells.
* Sort builds from the presubmit directory correctly.

Do you want to break this up?