### PR TITLE
Simplify gcs and updater concurrency

### DIFF
--- a/cluster/updater_deployment.yaml
+++ b/cluster/updater_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: updater
       containers:
       - name: updater
-        image: gcr.io/k8s-testgrid/updater:v20191127-v0.0.1-alpha.2-25-g6958b02
+        image: gcr.io/k8s-testgrid/updater:v20191127-v0.0.1-alpha.2-26-gf421599
         args:
         - --config=gs://fejternetes/config
         - --confirm


### PR DESCRIPTION
* Remove context from gcs.Build, instead require caller to pass one in.
* Ensure updater closes all channels
* Timeout group update, make both and build timeout configurable by flag.
* Fix a potential race where multiple workers encounter an error and try to write to the error channel
* Simplify how we get started and finished
* Simplify how we cancel reading builds
* Add a --debug flag, drop intra-group logging to debug
* Add a periodic progress log about update
* Use x-goog-meta-link instead of link (server no longer returns the latter)