### PR TITLE
Do not cache state, summary values.

### DIFF
--- a/cluster/summarizer_deployment.yaml
+++ b/cluster/summarizer_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: summarizer
       containers:
       - name: summarizer
-        image: gcr.io/k8s-testgrid/summarizer:v20191124-v0.0.1-alpha.2-20-g0a10758
+        image: gcr.io/k8s-testgrid/summarizer:v20191127-v0.0.1-alpha.2-25-g6958b02
         args:
         - --config=gs://fejternetes/config
         - --confirm

--- a/cluster/updater_deployment.yaml
+++ b/cluster/updater_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: updater
       containers:
       - name: updater
-        image: gcr.io/k8s-testgrid/updater:v20191124-v0.0.1-alpha.2-20-gcc2f776
+        image: gcr.io/k8s-testgrid/updater:v20191127-v0.0.1-alpha.2-25-g6958b02
         args:
         - --config=gs://fejternetes/config
         - --confirm

--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -221,7 +221,7 @@ func writeSummary(ctx context.Context, client *storage.Client, path gcs.Path, su
 	if err != nil {
 		return fmt.Errorf("marshal: %v", err)
 	}
-	return gcs.Upload(ctx, client, path, buf, gcs.Default)
+	return gcs.Upload(ctx, client, path, buf, gcs.DefaultAcl, "no-cache") // TODO(fejta): configurable cache value
 }
 
 // pathReader returns a reader for the specified path and last modified, generation metadata.

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -978,8 +978,9 @@ func updateGroup(ctx context.Context, client *storage.Client, tg configpb.TestGr
 	if !write {
 		log.Info("Skipping write")
 	} else {
-		log.Info("Writing")
-		if err := gcs.Upload(ctx, client, tgp, buf, gcs.Default); err != nil {
+		log.Debug("Writing")
+		// TODO(fejta): configurable cache value
+		if err := gcs.Upload(ctx, client, tgp, buf, gcs.DefaultAcl, "no-cache"); err != nil {
 			return fmt.Errorf("upload %s to %s failed: %v", o, tgp, err)
 		}
 	}

--- a/util/gcs/gcs.go
+++ b/util/gcs/gcs.go
@@ -120,17 +120,20 @@ func calcCRC(buf []byte) uint32 {
 
 const (
 	// Default ACLs for this upload
-	Default = false
+	DefaultAcl = false
 	// PublicRead ACL for this upload.
 	PublicRead = true
 )
 
 // Upload writes bytes to the specified Path
-func Upload(ctx context.Context, client *storage.Client, path Path, buf []byte, worldReadable bool) error {
+func Upload(ctx context.Context, client *storage.Client, path Path, buf []byte, worldReadable bool, cacheControl string) error {
 	crc := calcCRC(buf)
 	w := client.Bucket(path.Bucket()).Object(path.Object()).NewWriter(ctx)
 	if worldReadable {
 		w.ACL = []storage.ACLRule{{Entity: storage.AllUsers, Role: storage.RoleReader}}
+	}
+	if cacheControl != "" {
+		w.ObjectAttrs.CacheControl = cacheControl
 	}
 	w.SendCRC32C = true
 	// Send our CRC32 to ensure google received the same data we sent.


### PR DESCRIPTION
Otherwise values may be stale for an hour (causing the summary to be stale for up to two hours).

Fixes #64 