### PR TITLE
Encapsulate how to get/set version in metadata package.

### DIFF
--- a/cmd/updater/BUILD.bazel
+++ b/cmd/updater/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     deps = [
         "//config:go_default_library",
         "//internal/result:go_default_library",
+        "//metadata:go_default_library",
         "//metadata/junit:go_default_library",
         "//pb/config:go_default_library",
         "//pb/state:go_default_library",


### PR DESCRIPTION
Match the way python currently finds these values.
Support more deprecated fields.
Set both the current way we read them and the way we want to read them.
Unit test this behavior

Fixes #63 
ref https://github.com/kubernetes/test-infra/issues/15434