### PR TITLE
Read from correct metadata link

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -976,7 +976,7 @@ func updateGroup(ctx context.Context, client *storage.Client, tg configpb.TestGr
 	tgp := gridPath
 	log = log.WithField("url", tgp).WithField("bytes", len(buf))
 	if !write {
-		log.Info("Skipping write")
+		log.Debug("Skipping write")
 	} else {
 		log.Debug("Writing")
 		// TODO(fejta): configurable cache value

--- a/util/gcs/read.go
+++ b/util/gcs/read.go
@@ -75,7 +75,9 @@ func (b Builds) Less(i, j int) bool {
 }
 
 // ListBuilds returns the array of builds under path, sorted in monotonically decreasing order.
-func ListBuilds(ctx context.Context, client *storage.Client, path Path) (Builds, error) {
+func ListBuilds(parent context.Context, client *storage.Client, path Path) (Builds, error) {
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
 	p := path.Object()
 	if !strings.HasSuffix(p, "/") {
 		p += "/"
@@ -96,7 +98,7 @@ func ListBuilds(ctx context.Context, client *storage.Client, path Path) (Builds,
 		}
 
 		// if this is a link under directory, resolve the build value
-		if link := objAttrs.Metadata["link"]; len(link) > 0 {
+		if link := objAttrs.Metadata["x-goog-meta-link"]; len(link) > 0 {
 			// links created by bootstrap.py have a space
 			link = strings.TrimSpace(link)
 			u, err := url.Parse(link)


### PR DESCRIPTION
GCS no longer returns `link` in addition to `x-goog-meta-link`, so use the latter.