### PR TITLE
Always configure docker

### DIFF
--- a/images/push.sh
+++ b/images/push.sh
@@ -41,8 +41,9 @@ color-target() { # Bold cyan
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   echo "Detected GOOGLE_APPLICATION_CREDENTIALS, activating..." >&2
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-  gcloud auth configure-docker
 fi
+
+gcloud auth configure-docker
 
 # Build and push the current commit, failing on any uncommitted changes.
 new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"


### PR DESCRIPTION
ref https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202

`GOOGLE_APPLICATION_CREDENTIALS` is no longer set when using workload identity, it happens automatically.

So always run `gcloud auth configure-docker` which is a noop if its already done.

ref https://github.com/GoogleCloudPlatform/oss-test-infra/pull/219