### PR TITLE
Create canary testgrid deployment.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,7 +16,8 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
-        "//cluster:all-srcs",
+        "//cluster/canary:all-srcs",
+        "//cluster/prod:all-srcs",
         "//cmd/summarizer:all-srcs",
         "//cmd/updater:all-srcs",
         "//config:all-srcs",

--- a/cluster/canary/BUILD.bazel
+++ b/cluster/canary/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2018 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,27 +16,37 @@ load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 
 k8s_objects(
-    name = "prod",
+    name = "canary",
     objects = [
         ":updater",
         ":summarizer",
+        ":namespace",
     ],
 )
 
 CLUSTER = "{STABLE_TESTGRID_CLUSTER}"
 
+MULTI_KIND = None
+
 k8s_object(
     name = "updater",
     cluster = CLUSTER,
-    kind = "Deployment",
-    template = "updater_deployment.yaml",
+    kind = MULTI_KIND,
+    template = "updater.yaml",
 )
 
 k8s_object(
     name = "summarizer",
     cluster = CLUSTER,
-    kind = "Deployment",
-    template = "summarizer_deployment.yaml",
+    kind = MULTI_KIND,
+    template = "summarizer.yaml",
+)
+
+k8s_object(
+    name = "namespace",
+    cluster = CLUSTER,
+    kind = "Namespace",
+    template = "namespace.yaml",
 )
 
 filegroup(

--- a/cluster/canary/namespace.yaml
+++ b/cluster/canary/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: testgrid-canary

--- a/cluster/canary/summarizer.yaml
+++ b/cluster/canary/summarizer.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testgrid-summarizer
+  namespace: testgrid-canary
+  labels:
+    component: summarizer
+    app: testgrid
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      component: summarizer
+  template:
+    metadata:
+      labels:
+        component: summarizer
+        app: testgrid
+    spec:
+      serviceAccountName: summarizer
+      containers:
+      - name: summarizer
+        image: gcr.io/k8s-testgrid/summarizer:v20200106-v0.0.1-alpha.4
+        args:
+        - --config=gs://k8s-testgrid-canary/config
+        - --confirm
+        - --wait=5m
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    # Uses same as updater
+    iam.gke.io/gcp-service-account: updater@k8s-testgrid.iam.gserviceaccount.com
+  name: summarizer
+  namespace: testgrid-canary

--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testgrid-updater
+  namespace: testgrid-canary
+  labels:
+    component: updater
+    app: testgrid
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      component: updater
+  template:
+    metadata:
+      labels:
+        component: updater
+        app: testgrid
+    spec:
+      serviceAccountName: updater
+      containers:
+      - name: updater
+        image: gcr.io/k8s-testgrid/updater:v20200106-v0.0.1-alpha.4
+        args:
+        - --config=gs://fejternetes/config
+        - --confirm
+        - --wait=30m
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: updater@k8s-testgrid.iam.gserviceaccount.com
+  name: updater
+  namespace: testgrid-canary

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -29,7 +29,8 @@ fi
 
 case "${1:-}" in
 "--confirm")
-    ;;
+  shift
+  ;;
 "")
   read -p "Deploy testgrid to prod [no]: " confirm
   if [[ "${confirm}" != y* ]]; then
@@ -38,7 +39,7 @@ case "${1:-}" in
   fi
   ;;
 *)
-  echo "Usage: $(basename "$0") [--confirm]"
+  echo "Usage: $(basename "$0") [--confirm [target]]"
   exit 1
 esac
 
@@ -83,5 +84,10 @@ for s in {5..1}; do
     echo -n $'\r'"in $s..."
     sleep 1s
 done
-bazel run //cluster:prod.apply --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+if [[ "$#" == 0 ]]; then
+  WHAT=("//cluster/prod:prod.apply")
+else
+  WHAT=("$@")
+fi
+bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 "${WHAT[@]}"
 echo "$(color-green SUCCESS)"

--- a/cluster/prod/BUILD.bazel
+++ b/cluster/prod/BUILD.bazel
@@ -1,0 +1,64 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
+load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+
+k8s_objects(
+    name = "prod",
+    objects = [
+        ":updater",
+        ":summarizer",
+        ":namespace",
+    ],
+)
+
+CLUSTER = "{STABLE_TESTGRID_CLUSTER}"
+
+MULTI_KIND = None
+
+k8s_object(
+    name = "updater",
+    cluster = CLUSTER,
+    kind = MULTI_KIND,
+    template = "updater.yaml",
+)
+
+k8s_object(
+    name = "summarizer",
+    cluster = CLUSTER,
+    kind = MULTI_KIND,
+    template = "summarizer.yaml",
+)
+
+k8s_object(
+    name = "namespace",
+    cluster = CLUSTER,
+    kind = "Namespace",
+    template = "namespace.yaml",
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cluster/prod/namespace.yaml
+++ b/cluster/prod/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: testgrid

--- a/cluster/prod/summarizer.yaml
+++ b/cluster/prod/summarizer.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,3 +27,12 @@ spec:
         - --config=gs://k8s-testgrid/config
         - --confirm
         - --wait=5m
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    # Uses same as updater
+    iam.gke.io/gcp-service-account: updater@k8s-testgrid.iam.gserviceaccount.com
+  name: summarizer
+  namespace: testgrid

--- a/cluster/prod/updater.yaml
+++ b/cluster/prod/updater.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,3 +27,11 @@ spec:
         - --config=gs://fejternetes/config
         - --confirm
         - --wait=30m
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: updater@k8s-testgrid.iam.gserviceaccount.com
+  name: updater
+  namespace: testgrid

--- a/cluster/summarizer_serviceaccount.yaml
+++ b/cluster/summarizer_serviceaccount.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    # Uses same as updater
-    iam.gke.io/gcp-service-account: updater@k8s-testgrid.iam.gserviceaccount.com
-  name: summarizer
-  namespace: testgrid

--- a/cluster/updater_serviceaccount.yaml
+++ b/cluster/updater_serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: updater@k8s-testgrid.iam.gserviceaccount.com
-  name: updater
-  namespace: testgrid


### PR DESCRIPTION
Deploy to testgrid-canary namespace.
Create summarizier.yaml, updater.yaml, namespace.yaml to manage resources for those apps.
Separte into cluster/prod and cluster/canary dirs
Update deploy script to allow running whichever target

/assign @michelle192837 @chases2 