### PR TITLE
Handle scenario where grid is not found

### DIFF
--- a/pkg/summarizer/BUILD.bazel
+++ b/pkg/summarizer/BUILD.bazel
@@ -42,5 +42,6 @@ go_test(
         "//pb/state:go_default_library",
         "//pb/summary:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_google_cloud_go//storage:go_default_library",
     ],
 )

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -21,6 +21,7 @@ import (
 	"compress/zlib"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -28,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/GoogleCloudPlatform/testgrid/internal/result"
@@ -268,6 +270,21 @@ func TestUpdateTab(t *testing.T) {
 				LatestGreen:         noGreens,
 				OverallStatus:       summarypb.DashboardTabSummary_STALE,
 				Status:              noRuns,
+			},
+		},
+		{
+			name: "missing grid returns a blank summary",
+			tab: &configpb.DashboardTab{
+				Name: "you know",
+			},
+			group:     &configpb.TestGroup{},
+			gridError: fmt.Errorf("oh yeah: %w", storage.ErrObjectNotExist),
+			expected: &summarypb.DashboardTabSummary{
+				DashboardTabName: "you know",
+				Alert:            noRuns,
+				OverallStatus:    summarypb.DashboardTabSummary_STALE,
+				Status:           noRuns,
+				LatestGreen:      noGreens,
 			},
 		},
 	}


### PR DESCRIPTION
/assign @michelle192837 @chases2 

Use [error wrapping](https://blog.golang.org/go1.13-errors) to detect when the grid does not exist. Return a skeleton summary in this scenario.

Cover with unit tests