### PR TITLE
Testgrid does not accept gs:// prefix on gcs_prefix field

### DIFF
--- a/pb/config/config.pb.go
+++ b/pb/config/config.pb.go
@@ -420,7 +420,7 @@ func (m *Notification) GetContextLink() string {
 type TestGroup struct {
 	// Name of this TestGroup, for mapping dashboard tabs to tests.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Path to the test result stored in gcs (gs://some/path)
+	// Path to the test result stored in gcs (some-bucket/some/optional/path).
 	GcsPrefix string `protobuf:"bytes,2,opt,name=gcs_prefix,json=gcsPrefix,proto3" json:"gcs_prefix,omitempty"`
 	// Number of days of test results to gather and serve.
 	DaysOfResults int32 `protobuf:"varint,3,opt,name=days_of_results,json=daysOfResults,proto3" json:"days_of_results,omitempty"`

--- a/pb/config/config.proto
+++ b/pb/config/config.proto
@@ -58,7 +58,7 @@ message TestGroup {
   // Name of this TestGroup, for mapping dashboard tabs to tests.
   string name = 1;
 
-  // Path to the test result stored in gcs (gs://some/path)
+  // Path to the test result stored in gcs (some-bucket/some/optional/path).
   string gcs_prefix = 2;
 
   // Number of days of test results to gather and serve.


### PR DESCRIPTION
Current usage suggests that these protos do not have the gcs_prefix, and I am pretty sure not including the prefix is currently required. So documenting this as such.