### PR TITLE
Populates Dashboard Name in generated summaries

### DIFF
--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -183,9 +183,10 @@ func updateDashboard(ctx context.Context, dash *configpb.Dashboard, finder group
 		if err != nil {
 			log.WithError(err).Error("Cannot summarize tab")
 			badTabs = append(badTabs, tab.Name)
-			sum.TabSummaries = append(sum.TabSummaries, problemTab(tab.Name))
+			sum.TabSummaries = append(sum.TabSummaries, problemTab(dash.Name, tab.Name))
 			continue
 		}
+		s.DashboardName = dash.Name
 		sum.TabSummaries = append(sum.TabSummaries, s)
 	}
 	var err error
@@ -196,9 +197,10 @@ func updateDashboard(ctx context.Context, dash *configpb.Dashboard, finder group
 }
 
 // problemTab summarizes a tab that cannot summarize
-func problemTab(name string) *summarypb.DashboardTabSummary {
+func problemTab(dashboardName, tabName string) *summarypb.DashboardTabSummary {
 	return &summarypb.DashboardTabSummary{
-		DashboardTabName: name,
+		DashboardName:    dashboardName,
+		DashboardTabName: tabName,
 		Alert:            "failed to summarize tab",
 	}
 }

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -57,6 +57,7 @@ func TestUpdateDashboard(t *testing.T) {
 		{
 			name: "basically works",
 			dash: &configpb.Dashboard{
+				Name: "stale-dashboard",
 				DashboardTab: []*configpb.DashboardTab{
 					{
 						Name:          "stale-tab",
@@ -72,6 +73,7 @@ func TestUpdateDashboard(t *testing.T) {
 			expected: &summarypb.DashboardSummary{
 				TabSummaries: []*summarypb.DashboardTabSummary{
 					{
+						DashboardName:       "stale-dashboard",
 						DashboardTabName:    "stale-tab",
 						LastUpdateTimestamp: 1000,
 						Alert:               noRuns,
@@ -85,6 +87,7 @@ func TestUpdateDashboard(t *testing.T) {
 		{
 			name: "still update working tabs when some tabs fail",
 			dash: &configpb.Dashboard{
+				Name: "a-dashboard",
 				DashboardTab: []*configpb.DashboardTab{
 					{
 						Name:          "working",
@@ -115,6 +118,7 @@ func TestUpdateDashboard(t *testing.T) {
 			expected: &summarypb.DashboardSummary{
 				TabSummaries: []*summarypb.DashboardTabSummary{
 					{
+						DashboardName:       "a-dashboard",
 						DashboardTabName:    "working",
 						LastUpdateTimestamp: 1000,
 						Alert:               noRuns,
@@ -122,9 +126,10 @@ func TestUpdateDashboard(t *testing.T) {
 						OverallStatus:       summarypb.DashboardTabSummary_STALE,
 						LatestGreen:         noGreens,
 					},
-					problemTab("missing-tab"),
-					problemTab("error-tab"),
+					problemTab("a-dashboard", "missing-tab"),
+					problemTab("a-dashboard", "error-tab"),
 					{
+						DashboardName:       "a-dashboard",
 						DashboardTabName:    "still-working",
 						LastUpdateTimestamp: 1000,
 						Alert:               noRuns,


### PR DESCRIPTION
Allows other services to determine the dashboard & tab name from only the DashboardTabSummary proto.

Arguably, this field should be a member of the [DashboardSummary](https://github.com/GoogleCloudPlatform/testgrid/blob/master/pb/summary/summary.proto#L91), not the DashboardTabSummary, but I think the advantage of deduplication doesn't outweigh having to restructure a proto definition.