### PR TITLE
Add Column failure collection for use in 2nd stage processing (Part 1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.5.1
 	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 // indirect
 	go.opencensus.io v0.22.1 // indirect
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 h1:j2hhcujLRHAg872RWAV5yaUrEjHEObwDv3aImCaNLek=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/pkg/summarizer/BUILD.bazel
+++ b/pkg/summarizer/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "//pb/state:go_default_library",
         "//pb/summary:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",
     ],
 )

--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -246,7 +246,7 @@ func updateTab(ctx context.Context, tab *configpb.DashboardTab, findGroup groupF
 	latest, latestSeconds := latestRun(grid.Columns)
 	alert := staleAlert(mod, latest, staleHours(tab))
 	failures := failingTestSummaries(grid.Rows)
-	//TODO(gmccloskey): update DashboardTabSummary to inclused failure ratio in PB
+	//TODO(gmccloskey): update DashboardTabSummary to include failure ratio in PB
 	passingCols, completedCols, passingCells, filledCells, _ := gridMetrics(len(grid.Columns), grid.Rows, recent)
 	return &summarypb.DashboardTabSummary{
 		DashboardTabName:     tab.Name,
@@ -488,7 +488,7 @@ func overallStatus(grid *statepb.Grid, recent int, stale string, alerts []*summa
 	return summarypb.DashboardTabSummary_UNKNOWN
 }
 
-// Culminate set of metrics related to a section of the Grid that can be consumed by
+// Culminate set of metrics related to a section of the Grid
 func gridMetrics(cols int, rows []*statepb.Row, recent int) (int, int, int, int, []float32) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -500,12 +500,16 @@ func gridMetrics(cols int, rows []*statepb.Row, recent int) (int, int, int, int,
 	var passingCols int
 	var completedCols int
 
-	for idx := 0; idx < cols && idx < recent; idx++ {
+	for idx := 0; idx < cols; idx++ {
+		if idx >= recent {
+			break
+		}
 		var passes int
 		var failures int
 		for _, ch := range results {
 			// TODO(fejta): fail old running cols
 			switch coalesceResult(<-ch, result.IgnoreRunning) {
+			//TODO(michelle192837): Create utility to standardize pass/fail boundaries
 			case statepb.Row_PASS, statepb.Row_PASS_WITH_ERRORS, statepb.Row_PASS_WITH_SKIPS:
 				passes++
 				passingCells++

--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -246,6 +246,7 @@ func updateTab(ctx context.Context, tab *configpb.DashboardTab, findGroup groupF
 	latest, latestSeconds := latestRun(grid.Columns)
 	alert := staleAlert(mod, latest, staleHours(tab))
 	failures := failingTestSummaries(grid.Rows)
+	passingCols, completedCols, passingCells, filledCells, _ := gridMetrics(len(grid.Columns), grid.Rows, recent)
 	return &summarypb.DashboardTabSummary{
 		DashboardTabName:     tab.Name,
 		LastUpdateTimestamp:  float64(mod.Unix()),
@@ -253,7 +254,7 @@ func updateTab(ctx context.Context, tab *configpb.DashboardTab, findGroup groupF
 		Alert:                alert,
 		FailingTestSummaries: failures,
 		OverallStatus:        overallStatus(grid, recent, alert, failures),
-		Status:               statusMessage(len(grid.Columns), grid.Rows, recent),
+		Status:               statusMessage(passingCols, completedCols, passingCells, filledCells),
 		LatestGreen:          latestGreen(grid, group.UseKubernetesClient),
 		// TODO(fejta): BugUrl
 	}, nil
@@ -486,55 +487,58 @@ func overallStatus(grid *statepb.Grid, recent int, stale string, alerts []*summa
 	return summarypb.DashboardTabSummary_UNKNOWN
 }
 
-func fmtStatus(passCols, cols, passCells, cells int) string {
-	colCent := 100 * float64(passCols) / float64(cols)
-	cellCent := 100 * float64(passCells) / float64(cells)
-	return fmt.Sprintf("%d of %d (%.1f%%) recent columns passed (%d of %d or %.1f%% cells)", passCols, cols, colCent, passCells, cells, cellCent)
-}
-
-func statusMessage(cols int, rows []*statepb.Row, recent int) string {
-	//  2483 of 115784 tests (2.1%) and 163 of 164 runs (99.4%) failed in the past 7 days
+// Culminate set of metrics related to a section of the Grid that can be consumed by
+func gridMetrics(cols int, rows []*statepb.Row, recent int) (int, int, int, int, []float32) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	results := results(ctx, rows)
+	var columnFailureRatios []float32
 	var passingCells int
 	var filledCells int
 	var passingCols int
 	var completedCols int
-	for idx := 0; idx < cols; idx++ {
-		if idx >= recent {
-			break
-		}
-		var passes bool
-		var failures bool
+
+	for idx := 0; idx < cols && idx <= recent; idx++ {
+		var passes int
+		var failures int
 		for _, ch := range results {
 			// TODO(fejta): fail old running cols
 			switch coalesceResult(<-ch, result.IgnoreRunning) {
-			case statepb.Row_PASS:
-				if !failures {
-					passes = true
-				}
+			case statepb.Row_PASS, statepb.Row_PASS_WITH_ERRORS, statepb.Row_PASS_WITH_SKIPS:
+				passes++
 				passingCells++
 				filledCells++
 			case statepb.Row_NO_RESULT:
 				// noop
 			default:
-				passes = false
-				failures = true
+				failures++
 				filledCells++
 			}
 		}
 
-		if failures || passes {
+		if failures > 0 || passes > 0 {
 			completedCols++
 		}
-		if passes {
+		if failures == 0 && passes > 0 {
 			passingCols++
 		}
+
+		columnFailureRatios = append(columnFailureRatios, float32(failures/(passes+failures)))
 	}
+
+	return passingCols, completedCols, passingCells, filledCells, columnFailureRatios
+}
+
+//  2483 of 115784 tests (2.1%) and 163 of 164 runs (99.4%) failed in the past 7 days
+func statusMessage(passingCols, completedCols, passingCells, filledCells int) string {
 	if filledCells == 0 {
 		return noRuns
+	}
+	fmtStatus := func(passCols, cols, passCells, cells int) string {
+		colCent := 100 * float64(passCols) / float64(cols)
+		cellCent := 100 * float64(passCells) / float64(cells)
+		return fmt.Sprintf("%d of %d (%.1f%%) recent columns passed (%d of %d or %.1f%% cells)", passCols, cols, colCent, passCells, cells, cellCent)
 	}
 	return fmtStatus(passingCols, completedCols, passingCells, filledCells)
 }

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -1284,18 +1284,36 @@ func TestGridMetrics(t *testing.T) {
 			expectedFailRatio: []float32{0, 0.33333334, 0},
 		},
 		{
-			name:   "half and half",
+			name:   "not enough columns yet works just fine",
 			cols:   4,
 			recent: 50,
 			rows: []*statepb.Row{
 				{
-					Name: "four pass",
+					Name: "four passes",
+					Results: []int32{
+						int32(statepb.Row_PASS), 4,
+					},
+				},
+			},
+			passingCols:       4,
+			filledCols:        4,
+			passingCells:      4,
+			filledCells:       4,
+			expectedFailRatio: []float32{0, 0, 0, 0},
+		},
+		{
+			name:   "half passes and half fails",
+			cols:   4,
+			recent: 4,
+			rows: []*statepb.Row{
+				{
+					Name: "four passes",
 					Results: []int32{
 						int32(statepb.Row_PASS), 4,
 					},
 				},
 				{
-					Name: "four fail",
+					Name: "four fails",
 					Results: []int32{
 						int32(statepb.Row_FAIL), 4,
 					},
@@ -1434,14 +1452,6 @@ func TestStatusMessage(t *testing.T) {
 			completedCols: 2,
 			passingCells:  2,
 			filledCells:   2,
-		},
-		{
-			name:             "all no result",
-			passingCols:      0,
-			completedCols:    0,
-			passingCells:     0,
-			filledCells:      0,
-			expectedOverride: noRuns,
 		},
 	}
 

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -31,6 +31,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/GoogleCloudPlatform/testgrid/internal/result"
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
@@ -1105,21 +1106,23 @@ func TestOverallStatus(t *testing.T) {
 	}
 }
 
-func TestStatusMessage(t *testing.T) {
+func makeShim(v ...interface{}) []interface{} {
+	return v
+}
+
+func TestGridMetrics(t *testing.T) {
 	cases := []struct {
-		name             string
-		cols             int
-		rows             []*statepb.Row
-		recent           int
-		passingCols      int
-		filledCols       int
-		passingCells     int
-		filledCells      int
-		expectedOverride string
+		name         string
+		cols         int
+		rows         []*statepb.Row
+		recent       int
+		passingCols  int
+		filledCols   int
+		passingCells int
+		filledCells  int
 	}{
 		{
-			name:             "no runs",
-			expectedOverride: noRuns,
+			name: "no runs",
 		},
 		{
 			name: "what people want (greens)",
@@ -1291,13 +1294,9 @@ func TestStatusMessage(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			expected := tc.expectedOverride
-			if expected == "" {
-				expected = fmtStatus(tc.passingCols, tc.filledCols, tc.passingCells, tc.filledCells)
-			}
-			if actual := statusMessage(tc.cols, tc.rows, tc.recent); actual != expected {
-				t.Errorf("%s != expected %s", actual, expected)
-			}
+			expected := makeShim(tc.passingCols, tc.filledCols, tc.passingCells, tc.filledCells)
+			actual := makeShim(gridMetrics(tc.cols, tc.rows, tc.recent))
+			assert.Equal(t, expected, actual, fmt.Sprintf("%s != expected %s", actual, expected))
 		})
 	}
 }

--- a/repos.bzl
+++ b/repos.bzl
@@ -200,8 +200,8 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "github.com/stretchr/testify",
-        sum = "h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=",
-        version = "v1.4.0",
+        sum = "h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=",
+        version = "v1.5.1",
     )
 
     go_repository(


### PR DESCRIPTION
This is part of an effort involving adding some new metrics for the failure ratios of columns. I changed the standard bool tracking of row pass rates to track the number of passes and fails. Then calculate the ratio of failing cells to total cells. 

* I also treated PASS_WTH_SKIPS and PASS_WITH_ERRORS as passing and added them into the unit tests. 

Q: Do we want running to be treated as failure still?

I also pulled the status string generation out and gave it it's own test.

Talking with fejta it seem there was a push to avoid adding any new deps and modules. Being able to use assert was nice because it allowed me to create a variadic shim to easily test functions with multiple different return types. If there is a way to do this easily without assert + shim I am all ears. 

Only about 2 months into playing with Golang and not aware of the design patterns so feel free to bring this PR to Gulag.