### PR TITLE
Add placeholder method for building FailingTestLinks

### DIFF
--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -434,6 +434,7 @@ func failingTestSummaries(rows []*statepb.Row) []*summarypb.FailingTestSummary {
 			BuildLinkText: alert.BuildLinkText,
 			BuildUrlText:  alert.BuildUrlText,
 			// TODO(fejta): LinkedBugs
+			FailTestLink: buildFailLink(alert.FailTestId, row.Id),
 			// TODO(fejta): FailTestLink
 		}
 		if alert.PassTime != nil {
@@ -446,6 +447,12 @@ func failingTestSummaries(rows []*statepb.Row) []*summarypb.FailingTestSummary {
 		failures = append(failures, &sum)
 	}
 	return failures
+}
+
+// buildFailLink creates a search link
+// TODO(#134): Build proper url for both internal and external jobs
+func buildFailLink(testID, target string) string {
+	return fmt.Sprintf("%s %s", testID, target)
 }
 
 // overallStatus determines whether the tab is stale, failing, flaky or healthy.

--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -435,7 +435,6 @@ func failingTestSummaries(rows []*statepb.Row) []*summarypb.FailingTestSummary {
 			BuildUrlText:  alert.BuildUrlText,
 			// TODO(fejta): LinkedBugs
 			FailTestLink: buildFailLink(alert.FailTestId, row.Id),
-			// TODO(fejta): FailTestLink
 		}
 		if alert.PassTime != nil {
 			sum.PassTimestamp = float64(alert.PassTime.Seconds)

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -944,6 +944,7 @@ func TestFailingTestSummaries(t *testing.T) {
 					AlertInfo: &statepb.AlertInfo{
 						FailBuildId:    "fbi",
 						PassBuildId:    "pbi",
+						FailTestId:     "819283y823-1232813",
 						FailCount:      1,
 						BuildLink:      "bl",
 						BuildLinkText:  "blt",
@@ -964,6 +965,7 @@ func TestFailingTestSummaries(t *testing.T) {
 					BuildLinkText:  "hyrule",
 					BuildUrlText:   "of sandwich",
 					FailureMessage: "pop tart",
+					FailTestLink:   " foo-target",
 				},
 				{
 					DisplayName:    "bar-name",
@@ -975,6 +977,7 @@ func TestFailingTestSummaries(t *testing.T) {
 					BuildLinkText:  "blt",
 					BuildUrlText:   "but",
 					FailureMessage: "fm",
+					FailTestLink:   "819283y823-1232813 bar-target",
 				},
 			},
 		},


### PR DESCRIPTION
For now it will just report the testID and target which can be used to build the url

TODO: Improve bug gathering and link building (different PR)

#134 