### PR TITLE
Change channel usage logic to drain channels

### DIFF
--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -84,6 +84,7 @@ func main() {
 		defer cancel()
 		return summarizer.Update(ctx, client, opt.config, opt.concurrency, opt.dashboard, opt.confirm)
 	}
+
 	if err := updateOnce(ctx); err != nil {
 		logrus.WithError(err).Error("Failed update")
 	}

--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -84,11 +84,9 @@ func main() {
 		defer cancel()
 		return summarizer.Update(ctx, client, opt.config, opt.concurrency, opt.dashboard, opt.confirm)
 	}
-	start := time.Now()
 	if err := updateOnce(ctx); err != nil {
 		logrus.WithError(err).Error("Failed update")
 	}
-	logrus.Infof("updateOnce took %d ms to complete\n", int64(time.Since(start)))
 	if opt.wait == 0 {
 		return
 	}

--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -84,10 +84,11 @@ func main() {
 		defer cancel()
 		return summarizer.Update(ctx, client, opt.config, opt.concurrency, opt.dashboard, opt.confirm)
 	}
-
+	start := time.Now()
 	if err := updateOnce(ctx); err != nil {
 		logrus.WithError(err).Error("Failed update")
 	}
+	logrus.Infof("updateOnce took %d ms to complete\n", int64(time.Since(start)))
 	if opt.wait == 0 {
 		return
 	}


### PR DESCRIPTION
The current implementation, where it iterates through each column and grabs one output from each channel, causes summarizer to run much more slowly than if it were to consume the all of the output from one channel at a time. This change aims to fix that. 

It also adds logging of the timing for updateOnce and a way to track per row indices of messages (if a Row_Result is NO_RESULT then we don't increment the index, however for all other Row_Result's we do) for accuracy.