### PR TITLE
Use different service account for canary

### DIFF
--- a/cluster/canary/summarizer.yaml
+++ b/cluster/canary/summarizer.yaml
@@ -33,6 +33,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     # Uses same as updater
-    iam.gke.io/gcp-service-account: updater@k8s-testgrid.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: testgrid-canary@k8s-testgrid.iam.gserviceaccount.com
   name: summarizer
   namespace: testgrid-canary

--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -32,6 +32,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: updater@k8s-testgrid.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: testgrid-canary@k8s-testgrid.iam.gserviceaccount.com
   name: updater
   namespace: testgrid-canary


### PR DESCRIPTION
Canary is actually not doing anything right now because it is not authorized to act as updater@k8s-testgrid.iam.gserviceaccount.com and it probably shouldn't have this auth.