### PR TITLE
Rollout v20200714 summarizer and updater to prod.

### DIFF
--- a/cluster/prod/summarizer.yaml
+++ b/cluster/prod/summarizer.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: summarizer
       containers:
       - name: summarizer
-        image: gcr.io/k8s-testgrid/summarizer:v20200106-v0.0.1-alpha.4
+        image: gcr.io/k8s-testgrid/summarizer:v20200714-v0.0.13-4-g708c3dd
         args:
         - --config=gs://k8s-testgrid/config
         - --confirm

--- a/cluster/prod/updater.yaml
+++ b/cluster/prod/updater.yaml
@@ -25,6 +25,7 @@ spec:
         image: gcr.io/k8s-testgrid/updater:v20200714-v0.0.13-4-g708c3dd
         args:
         - --config=gs://k8s-testgrid
+        - --confirm
         - --wait=30m
 ---
 apiVersion: v1


### PR DESCRIPTION
Turn back on updater writing (confirmed this goes to the PREFIX/grid/testgroup-name path
(meaning it has the grid/ prefix and thus can run concurrently)

Once the updater completes a loop, we'll be able to view golang updater results by appending `&grid=beta` to a tab's fragment.

https://testgrid.k8s.io/sig-node-kubelet#node-kubelet-master&grid=beta