### PR TITLE
Functions to reinflate compressed grid messages.

### DIFF
--- a/pb/state/state.pb.go
+++ b/pb/state/state.pb.go
@@ -86,7 +86,7 @@ type Metric struct {
 	//   Indices: [0, 2, 6, 4]
 	//   Values: [0.1,0.2,6.1,6.2,6.3,6.4]
 	// Decoded 12-value equivalent is:
-	// [0.1, 0.2, nil, nil, nil, nil, nil, 6.1, 6.2, 6.3, 6.4, nil, nil, ...]
+	// [0.1, 0.2, nil, nil, nil, nil, 6.1, 6.2, 6.3, 6.4, nil, nil, ...]
 	Indices              []int32   `protobuf:"varint,2,rep,packed,name=indices,proto3" json:"indices,omitempty"`
 	Values               []float64 `protobuf:"fixed64,3,rep,packed,name=values,proto3" json:"values,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`

--- a/pb/state/state.proto
+++ b/pb/state/state.proto
@@ -17,7 +17,7 @@ message Metric {
   //   Indices: [0, 2, 6, 4]
   //   Values: [0.1,0.2,6.1,6.2,6.3,6.4]
   // Decoded 12-value equivalent is:
-  // [0.1, 0.2, nil, nil, nil, nil, nil, 6.1, 6.2, 6.3, 6.4, nil, nil, ...]
+  // [0.1, 0.2, nil, nil, nil, nil, 6.1, 6.2, 6.3, 6.4, nil, nil, ...]
   repeated int32 indices = 2; // n=index of first value, n+1=count of filled values
   repeated double values = 3; // only present for columns with a metric value
 }

--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["updater.go"],
+    srcs = [
+        "inflate.go",
+        "updater.go",
+    ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/pkg/updater",
     visibility = ["//visibility:public"],
     deps = [
@@ -23,7 +26,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["updater_test.go"],
+    srcs = [
+        "inflate_test.go",
+        "updater_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//metadata/junit:go_default_library",

--- a/pkg/updater/inflate.go
+++ b/pkg/updater/inflate.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2020 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package updater
+
+import (
+	"context"
+	"time"
+
+	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+)
+
+// inflatedColumn holds all the entries for a given column.
+//
+// This includes both:
+// * Column state metadata and
+// * cell values for every row in this column
+type inflatedColumn struct {
+	column *state.Column
+	cells  map[string]cell
+}
+
+// cell holds a row's values for a given column
+type cell struct {
+	result state.Row_Result
+
+	cellID string
+
+	icon    string
+	message string
+
+	metrics map[string]float64
+}
+
+// inflateGrid inflates the grid's rows into an inflatedColumn channel.
+func inflateGrid(grid *state.Grid, earliest, latest time.Time) []inflatedColumn {
+	var cols []inflatedColumn
+
+	// nothing is blocking, so no need for a parent context.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rows := make(map[string]<-chan cell, len(grid.Rows))
+	for _, row := range grid.Rows {
+		rows[row.Name] = inflateRow(ctx, row)
+	}
+
+	for _, col := range grid.Columns {
+		// Even if we wind up skipping the column
+		// we still need to inflate the cells.
+		item := inflatedColumn{
+			column: col,
+			cells:  make(map[string]cell, len(rows)),
+		}
+		for rowName, rowCells := range rows {
+			item.cells[rowName] = <-rowCells
+		}
+		when := int64(col.Started / 1000)
+		if when < earliest.Unix() || when > latest.Unix() {
+			continue
+		}
+		cols = append(cols, item)
+
+	}
+	return cols
+}
+
+// inflateRow inflates the values for each column into a cell channel.
+func inflateRow(parent context.Context, row *state.Row) <-chan cell {
+	out := make(chan cell)
+
+	go func() {
+		ctx, cancel := context.WithCancel(parent)
+		defer close(out)
+		defer cancel()
+		var filledIdx int
+		var cellIdx int
+		metrics := map[string]<-chan *float64{}
+		for i, m := range row.Metrics {
+			if m.Name == "" && len(row.Metrics) > i {
+				m.Name = row.Metric[i]
+			}
+			metrics[m.Name] = inflateMetric(ctx, m)
+		}
+		var val *float64
+		for result := range inflateResults(ctx, row.Results) {
+			c := cell{
+				cellID: row.CellIds[cellIdx],
+				result: result,
+			}
+			cellIdx++
+			for name, ch := range metrics {
+				select {
+				case <-ctx.Done():
+					return
+				case val = <-ch:
+				}
+				if val == nil {
+					continue
+				}
+				if c.metrics == nil {
+					c.metrics = map[string]float64{}
+				}
+				c.metrics[name] = *val
+			}
+			if result != state.Row_NO_RESULT {
+				c.icon = row.Icons[filledIdx]
+				c.message = row.Messages[filledIdx]
+				filledIdx++
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case out <- c:
+			}
+		}
+
+	}()
+	return out
+}
+
+// inflateMetric inflates the sparse-encoded metric values into a channel
+func inflateMetric(ctx context.Context, metric *state.Metric) <-chan *float64 {
+	out := make(chan *float64)
+	go func() {
+		defer close(out)
+		var current int32
+		var valueIdx int
+		// TODO(fejta): ugh? this might be wrong
+		// I believe we may need to ignore NO_RESULT columns.
+		for i := 0; i < len(metric.Indices); i++ {
+			start := metric.Indices[i]
+			i++
+			remain := metric.Indices[i]
+			for ; remain > 0; current++ {
+				if current < start {
+					select {
+					case <-ctx.Done():
+						return
+					case out <- nil:
+					}
+					continue
+				}
+				remain--
+				value := metric.Values[valueIdx]
+				valueIdx++
+				select {
+				case <-ctx.Done():
+					return
+				case out <- &value:
+				}
+			}
+		}
+	}()
+	return out
+}
+
+// inflateResults inflates the run-length encoded row results into a channel.
+func inflateResults(ctx context.Context, results []int32) <-chan state.Row_Result {
+	out := make(chan state.Row_Result)
+	go func() {
+		defer close(out)
+		for idx := 0; idx < len(results); idx++ {
+			val := results[idx]
+			idx++
+			for n := results[idx]; n > 0; n-- {
+				select {
+				case <-ctx.Done():
+					return
+				case out <- state.Row_Result(val):
+				}
+			}
+		}
+	}()
+	return out
+}

--- a/pkg/updater/inflate_test.go
+++ b/pkg/updater/inflate_test.go
@@ -1,0 +1,601 @@
+/*
+Copyright 2020 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package updater
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+)
+
+func blank(n int) []string {
+	var out []string
+	for i := 0; i < n; i++ {
+		out = append(out, "")
+	}
+	return out
+}
+
+func TestInflateGrid(t *testing.T) {
+	var hours []time.Time
+	when := time.Now().Round(time.Hour)
+	for i := 0; i < 24; i++ {
+		hours = append(hours, when)
+		when = when.Add(time.Hour)
+	}
+
+	millis := func(t time.Time) float64 {
+		return float64(t.Unix() * 1000)
+	}
+
+	cases := []struct {
+		name     string
+		grid     state.Grid
+		earliest time.Time
+		latest   time.Time
+		expected []inflatedColumn
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name: "preserve column data",
+			grid: state.Grid{
+				Columns: []*state.Column{
+					{
+						Build:      "build",
+						Name:       "name",
+						Started:    5,
+						Extra:      []string{"extra", "fun"},
+						HotlistIds: "hot topic",
+					},
+					{
+						Build:      "second build",
+						Name:       "second name",
+						Started:    10,
+						Extra:      []string{"more", "gooder"},
+						HotlistIds: "hot pocket",
+					},
+				},
+			},
+			latest: hours[23],
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:      "build",
+						Name:       "name",
+						Started:    5,
+						Extra:      []string{"extra", "fun"},
+						HotlistIds: "hot topic",
+					},
+					cells: map[string]cell{},
+				},
+				{
+					column: &state.Column{
+						Build:      "second build",
+						Name:       "second name",
+						Started:    10,
+						Extra:      []string{"more", "gooder"},
+						HotlistIds: "hot pocket",
+					},
+					cells: map[string]cell{},
+				},
+			},
+		},
+		{
+			name: "preserve row data",
+			grid: state.Grid{
+				Columns: []*state.Column{
+					{
+						Build:   "b1",
+						Name:    "n1",
+						Started: 1,
+					},
+					{
+						Build:   "b2",
+						Name:    "n2",
+						Started: 2,
+					},
+				},
+				Rows: []*state.Row{
+					{
+						Name: "name",
+						Results: []int32{
+							int32(state.Row_FAIL), 2,
+						},
+						CellIds:  []string{"this", "that"},
+						Messages: []string{"important", "notice"},
+						Icons:    []string{"I1", "I2"},
+						Metric:   []string{"this", "that"},
+						Metrics: []*state.Metric{
+							{
+								Indices: []int32{0, 2},
+								Values:  []float64{0.1, 0.2},
+							},
+							{
+								Name:    "override",
+								Indices: []int32{1, 1},
+								Values:  []float64{1.1},
+							},
+						},
+					},
+					{
+						Name: "second",
+						Results: []int32{
+							int32(state.Row_PASS), 2,
+						},
+						CellIds:  blank(2),
+						Messages: blank(2),
+						Icons:    blank(2),
+						Metric:   blank(2),
+					},
+				},
+			},
+			latest: hours[23],
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:   "b1",
+						Name:    "n1",
+						Started: 1,
+					},
+					cells: map[string]cell{
+						"name": {
+							result:  state.Row_FAIL,
+							cellID:  "this",
+							message: "important",
+							icon:    "I1",
+							metrics: map[string]float64{
+								"this": 0.1,
+							},
+						},
+						"second": {
+							result: state.Row_PASS,
+						},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "b2",
+						Name:    "n2",
+						Started: 2,
+					},
+					cells: map[string]cell{
+						"name": {
+							result:  state.Row_FAIL,
+							cellID:  "that",
+							message: "notice",
+							icon:    "I2",
+							metrics: map[string]float64{
+								"this":     0.2,
+								"override": 1.1,
+							},
+						},
+						"second": {
+							result: state.Row_PASS,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "drop latest columns",
+			grid: state.Grid{
+				Columns: []*state.Column{
+					{
+						Build:   "latest1",
+						Started: millis(hours[23]),
+					},
+					{
+						Build:   "latest2",
+						Started: millis(hours[20]) + 1000,
+					},
+					{
+						Build:   "keep1",
+						Started: millis(hours[20]) + 999,
+					},
+					{
+						Build:   "keep2",
+						Started: millis(hours[10]),
+					},
+				},
+				Rows: []*state.Row{
+					{
+						Name:     "hello",
+						CellIds:  blank(4),
+						Messages: blank(4),
+						Icons:    blank(4),
+						Results: []int32{
+							int32(state.Row_RUNNING), 1,
+							int32(state.Row_PASS), 1,
+							int32(state.Row_FAIL), 1,
+							int32(state.Row_FLAKY), 1,
+						},
+					},
+					{
+						Name:     "world",
+						CellIds:  blank(4),
+						Messages: blank(4),
+						Icons:    blank(4),
+						Results: []int32{
+							int32(state.Row_PASS_WITH_SKIPS), 4,
+						},
+					},
+				},
+			},
+			latest: hours[20],
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:   "keep1",
+						Started: millis(hours[20]) + 999,
+					},
+					cells: map[string]cell{
+						"hello": {result: state.Row_FAIL},
+						"world": {result: state.Row_PASS_WITH_SKIPS},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "keep2",
+						Started: millis(hours[10]),
+					},
+					cells: map[string]cell{
+						"hello": {result: state.Row_FLAKY},
+						"world": {result: state.Row_PASS_WITH_SKIPS},
+					},
+				},
+			},
+		},
+		{
+			name: "drop old columns",
+			grid: state.Grid{
+				Columns: []*state.Column{
+					{
+						Build:   "current1",
+						Started: millis(hours[20]),
+					},
+					{
+						Build:   "current2",
+						Started: millis(hours[10]),
+					},
+					{
+						Build:   "old1",
+						Started: millis(hours[10]) - 1,
+					},
+					{
+						Build:   "old2",
+						Started: millis(hours[0]),
+					},
+				},
+				Rows: []*state.Row{
+					{
+						Name:     "hello",
+						CellIds:  blank(4),
+						Messages: blank(4),
+						Icons:    blank(4),
+						Results: []int32{
+							int32(state.Row_RUNNING), 1,
+							int32(state.Row_PASS), 1,
+							int32(state.Row_FAIL), 1,
+							int32(state.Row_FLAKY), 1,
+						},
+					},
+					{
+						Name:     "world",
+						CellIds:  blank(4),
+						Messages: blank(4),
+						Icons:    blank(4),
+						Results: []int32{
+							int32(state.Row_PASS_WITH_SKIPS), 4,
+						},
+					},
+				},
+			},
+			latest:   hours[23],
+			earliest: hours[10],
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:   "current1",
+						Started: millis(hours[20]),
+					},
+					cells: map[string]cell{
+						"hello": {result: state.Row_RUNNING},
+						"world": {result: state.Row_PASS_WITH_SKIPS},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "current2",
+						Started: millis(hours[10]),
+					},
+					cells: map[string]cell{
+						"hello": {result: state.Row_PASS},
+						"world": {result: state.Row_PASS_WITH_SKIPS},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := inflateGrid(&tc.grid, tc.earliest, tc.latest)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("inflateGrid(%v) got %s, want %s", tc.grid, actual, tc.expected)
+			}
+		})
+
+	}
+}
+
+func TestInflateRow(t *testing.T) {
+	cases := []struct {
+		name     string
+		row      state.Row
+		expected []cell
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name: "preserve cell ids",
+			row: state.Row{
+				CellIds:  []string{"cell-a", "cell-b"},
+				Icons:    blank(2),
+				Messages: blank(2),
+				Results: []int32{
+					int32(state.Row_PASS), 2,
+				},
+			},
+			expected: []cell{
+				{
+					result: state.Row_PASS,
+					cellID: "cell-a",
+				},
+				{
+					result: state.Row_PASS,
+					cellID: "cell-b",
+				},
+			},
+		},
+		{
+			name: "only finished columns contain icons and messages",
+			row: state.Row{
+				CellIds: blank(8),
+				Icons: []string{
+					"F1", "~1", "~2",
+				},
+				Messages: []string{
+					"fail", "flake-first", "flake-second",
+				},
+				Results: []int32{
+					int32(state.Row_NO_RESULT), 2,
+					int32(state.Row_FAIL), 1,
+					int32(state.Row_NO_RESULT), 2,
+					int32(state.Row_FLAKY), 2,
+					int32(state.Row_NO_RESULT), 1,
+				},
+			},
+			expected: []cell{
+				{},
+				{},
+				{
+					result:  state.Row_FAIL,
+					icon:    "F1",
+					message: "fail",
+				},
+				{},
+				{},
+				{
+					result:  state.Row_FLAKY,
+					icon:    "~1",
+					message: "flake-first",
+				},
+				{
+					result:  state.Row_FLAKY,
+					icon:    "~2",
+					message: "flake-second",
+				},
+				{},
+			},
+		},
+		{
+			name: "find metric name from row when missing",
+			row: state.Row{
+				CellIds:  blank(1),
+				Icons:    blank(1),
+				Messages: blank(1),
+				Results: []int32{
+					int32(state.Row_PASS), 1,
+				},
+				Metric: []string{"found-it"},
+				Metrics: []*state.Metric{
+					{
+						Indices: []int32{0, 1},
+						Values:  []float64{7},
+					},
+				},
+			},
+			expected: []cell{
+				{
+					result: state.Row_PASS,
+					metrics: map[string]float64{
+						"found-it": 7,
+					},
+				},
+			},
+		},
+		{
+			name: "prioritize local metric name",
+			row: state.Row{
+				CellIds:  blank(1),
+				Icons:    blank(1),
+				Messages: blank(1),
+				Results: []int32{
+					int32(state.Row_PASS), 1,
+				},
+				Metric: []string{"ignore-this"},
+				Metrics: []*state.Metric{
+					{
+						Name:    "oh yeah",
+						Indices: []int32{0, 1},
+						Values:  []float64{7},
+					},
+				},
+			},
+			expected: []cell{
+				{
+					result: state.Row_PASS,
+					metrics: map[string]float64{
+						"oh yeah": 7,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual []cell
+			for r := range inflateRow(context.Background(), &tc.row) {
+				actual = append(actual, r)
+			}
+
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("inflateRow(%v) got %v, want %v", tc.row, actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestInflateMetic(t *testing.T) {
+	point := func(v float64) *float64 {
+		return &v
+	}
+	cases := []struct {
+		name     string
+		indices  []int32
+		values   []float64
+		expected []*float64
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:    "documented example with both values and holes works",
+			indices: []int32{0, 2, 6, 4},
+			values:  []float64{0.1, 0.2, 6.1, 6.2, 6.3, 6.4},
+			expected: []*float64{
+				point(0.1),
+				point(0.2),
+				nil,
+				nil,
+				nil,
+				nil,
+				point(6.1),
+				point(6.2),
+				point(6.3),
+				point(6.4),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual []*float64
+			metric := state.Metric{
+				Name:    tc.name,
+				Indices: tc.indices,
+				Values:  tc.values,
+			}
+			for v := range inflateMetric(context.Background(), &metric) {
+				actual = append(actual, v)
+			}
+
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("inflateMetric(%v) got %v want %v", metric, actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestInflateResults(t *testing.T) {
+	cases := []struct {
+		name     string
+		results  []int32
+		expected []state.Row_Result
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name: "first documented example with multiple values works",
+			results: []int32{
+				int32(state.Row_NO_RESULT), 3,
+				int32(state.Row_PASS), 4,
+			},
+			expected: []state.Row_Result{
+				state.Row_NO_RESULT,
+				state.Row_NO_RESULT,
+				state.Row_NO_RESULT,
+				state.Row_PASS,
+				state.Row_PASS,
+				state.Row_PASS,
+				state.Row_PASS,
+			},
+		},
+		{
+			name: "first item is the type",
+			results: []int32{
+				int32(state.Row_RUNNING), 1, // RUNNING == 4
+			},
+			expected: []state.Row_Result{
+				state.Row_RUNNING,
+			},
+		},
+		{
+			name: "second item is the number of repetitions",
+			results: []int32{
+				int32(state.Row_PASS), 4, // Running == 1
+			},
+			expected: []state.Row_Result{
+				state.Row_PASS,
+				state.Row_PASS,
+				state.Row_PASS,
+				state.Row_PASS,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ch := inflateResults(context.Background(), tc.results)
+			var actual []state.Row_Result
+			for r := range ch {
+				actual = append(actual, r)
+			}
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("inflateResults(%v) got %v, want %v", tc.results, actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Correct a documentation error on metric encoding.

This will soon be used to refactor the updater to only download the
latest results, rather than everything.

Sending just this as a way to break things up.