### PR TITLE
Refactor how we read test suites.

### DIFF
--- a/util/gcs/BUILD.bazel
+++ b/util/gcs/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "read_test.go",
     ],
     embed = [":go_default_library"],
+    deps = ["@com_google_cloud_go_storage//:go_default_library"],
 )
 
 filegroup(


### PR DESCRIPTION
We do not need a special function to parse the json.
We do not need a WaitGroup and/or a thread that waits for this group.

Add readJSON test coverage