### PR TITLE
Add ReadColumns coverage.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	cloud.google.com/go/storage v1.10.0
 	github.com/client9/misspell v0.3.4
 	github.com/golang/protobuf v1.4.2
+	github.com/google/go-cmp v0.4.1
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/sirupsen/logrus v1.6.0
@@ -12,6 +13,7 @@ require (
 	google.golang.org/api v0.28.0
 	google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790
 	google.golang.org/grpc v1.29.1
+	google.golang.org/protobuf v1.24.0
 	gopkg.in/yaml.v2 v2.2.4 // indirect
 	sigs.k8s.io/yaml v1.1.0
 	vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787

--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -38,12 +38,15 @@ go_test(
     deps = [
         "//metadata:go_default_library",
         "//metadata/junit:go_default_library",
+        "//pb/config:go_default_library",
         "//pb/state:go_default_library",
         "//util/gcs:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
         "@org_golang_google_api//iterator:go_default_library",
+        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
     ],
 )
 

--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -19,21 +19,27 @@ package updater
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	"github.com/GoogleCloudPlatform/testgrid/metadata/junit"
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/GoogleCloudPlatform/testgrid/pb/state"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestDownloadGrid(t *testing.T) {
@@ -49,21 +55,673 @@ func TestDownloadGrid(t *testing.T) {
 	}
 }
 
+func resolveOrDie(path *gcs.Path, s string) *gcs.Path {
+	p, err := path.ResolveReference(&url.URL{Path: s})
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func jsonData(i interface{}) string {
+	buf, err := json.Marshal(i)
+	if err != nil {
+		panic(err)
+	}
+	return string(buf)
+}
+
+func xmlData(i interface{}) string {
+	buf, err := xml.Marshal(i)
+	if err != nil {
+		panic(err)
+	}
+	return string(buf)
+}
+
+func makeJunit(passed, failed []string) string {
+	var suite junit.Suite
+	for _, name := range passed {
+		suite.Results = append(suite.Results, junit.Result{Name: name})
+	}
+
+	for _, name := range failed {
+		f := name
+		suite.Results = append(suite.Results, junit.Result{
+			Name:    name,
+			Failure: &f,
+		})
+	}
+	return xmlData(suite)
+}
+
+type fakeBuild struct {
+	id           string
+	started      *fakeObject
+	finished     *fakeObject
+	artifacts    map[string]fakeObject
+	rawJunit     *fakeObject
+	passed       []string
+	failed       []string
+	junitName    string
+	rawJUnitName string
+}
+
+func pint64(n int64) *int64 {
+	return &n
+}
+
 func TestReadColumns(t *testing.T) {
+	now := time.Now().Unix()
+	yes := true
+	var no bool
 	cases := []struct {
-		name string
+		name        string
+		ctx         context.Context
+		builds      []fakeBuild
+		group       configpb.TestGroup
+		max         int
+		stop        time.Time
+		dur         time.Duration
+		concurrency int
+
+		expected []inflatedColumn
+		err      bool
 	}{
-		{},
+		{
+			name:     "basically works",
+			expected: []inflatedColumn{},
+		},
+		{
+			name: "convert results correctly",
+			builds: []fakeBuild{
+				{
+					id: "11",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 11}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 22),
+							Passed:    &no,
+						}),
+					},
+				},
+				{
+					id: "10",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 10}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 20),
+							Passed:    &yes,
+						}),
+					},
+				},
+			},
+			group: configpb.TestGroup{
+				GcsPrefix: "bucket/path/to/build/",
+			},
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:   "11",
+						Started: float64(now+11) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result:  state.Row_FAIL,
+							icon:    "F",
+							message: "Build failed outside of test results",
+							metrics: map[string]float64{
+								"seconds-elapsed": 11,
+							},
+						},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "10",
+						Started: float64(now+10) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 10,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "column headers processed correctly",
+			builds: []fakeBuild{
+				{
+					id: "11",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 11}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 22),
+							Passed:    &no,
+							Metadata: metadata.Metadata{
+								metadata.JobVersion: "v0.0.0-alpha.0+build11",
+								"random":            "new information",
+							},
+						}),
+					},
+				},
+				{
+					id: "10",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 10}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 20),
+							Passed:    &yes,
+							Metadata: metadata.Metadata{
+								metadata.JobVersion: "v0.0.0-alpha.0+build10",
+								"random":            "old information",
+							},
+						}),
+					},
+				},
+			},
+			group: configpb.TestGroup{
+				GcsPrefix: "bucket/path/to/build/",
+				ColumnHeader: []*configpb.TestGroup_ColumnHeader{
+					{
+						ConfigurationValue: "Commit",
+					},
+					{
+						ConfigurationValue: "random",
+					},
+				},
+			},
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:   "11",
+						Started: float64(now+11) * 1000,
+						Extra: []string{
+							"build11",
+							"new information",
+						},
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result:  state.Row_FAIL,
+							icon:    "F",
+							message: "Build failed outside of test results",
+							metrics: map[string]float64{
+								"seconds-elapsed": 11,
+							},
+						},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "10",
+						Started: float64(now+10) * 1000,
+						Extra: []string{
+							"build10",
+							"old information",
+						},
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 10,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "name config works correctly",
+			builds: []fakeBuild{
+				{
+					id: "10",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 10}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 20),
+							Passed:    &yes,
+						}),
+					},
+					artifacts: map[string]fakeObject{
+						"junit_context-a_33.xml": {
+							data: makeJunit([]string{"good"}, []string{"bad"}),
+						},
+						"junit_context-b_44.xml": {
+							data: makeJunit([]string{"good"}, []string{"bad"}),
+						},
+					},
+				},
+			},
+			group: configpb.TestGroup{
+				GcsPrefix: "bucket/path/to/build/",
+				TestNameConfig: &configpb.TestNameConfig{
+					NameFormat: "name %s - context %s - thread %s",
+					NameElements: []*configpb.TestNameConfig_NameElement{
+						{
+							TargetConfig: "Tests name",
+						},
+						{
+							TargetConfig: "Context",
+						},
+						{
+							TargetConfig: "Thread",
+						},
+					},
+				},
+			},
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:   "10",
+						Started: float64(now+10) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 10,
+							},
+						},
+						"name good - context context-a - thread 33": {
+							result: state.Row_PASS,
+						},
+						"name bad - context context-a - thread 33": {
+							result:  state.Row_FAIL,
+							icon:    "F",
+							message: "bad",
+						},
+						"name good - context context-b - thread 44": {
+							result: state.Row_PASS,
+						},
+						"name bad - context context-b - thread 44": {
+							result:  state.Row_FAIL,
+							icon:    "F",
+							message: "bad",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "stop columns at max",
+			max:  2,
+			builds: []fakeBuild{
+				{
+					id: "12",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 12}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 24),
+							Passed:    &yes,
+						}),
+					},
+				},
+				{
+					id: "11",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 11}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 22),
+							Passed:    &yes,
+						}),
+					},
+				},
+				{
+					id: "10",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 10}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 20),
+							Passed:    &yes,
+						}),
+					},
+				},
+			},
+			group: configpb.TestGroup{
+				GcsPrefix: "bucket/path/to/build/",
+			},
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:   "12",
+						Started: float64(now+12) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 12,
+							},
+						},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "11",
+						Started: float64(now+11) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 11,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "truncate columns after the newest old result",
+			stop: time.Unix(now+13, 0), // should capture 13 and 12
+			builds: []fakeBuild{
+				{
+					id: "13",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 13}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 26),
+							Passed:    &yes,
+						}),
+					},
+				},
+				{
+					id: "12",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 12}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 24),
+							Passed:    &yes,
+						}),
+					},
+				},
+				{
+					id: "11",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 11}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 22),
+							Passed:    &yes,
+						}),
+					},
+				},
+				{
+					id: "10",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 10}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 20),
+							Passed:    &yes,
+						}),
+					},
+				},
+			},
+			group: configpb.TestGroup{
+				GcsPrefix: "bucket/path/to/build/",
+			},
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:   "13",
+						Started: float64(now+13) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 13,
+							},
+						},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "12",
+						Started: float64(now+12) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 12,
+							},
+						},
+					},
+				},
+				// drop 11 and 10
+			},
+		},
+		{
+			name:        "high concurrency works",
+			concurrency: 4,
+			builds: []fakeBuild{
+				{
+					id: "13",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 13}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 26),
+							Passed:    &yes,
+						}),
+					},
+				},
+				{
+					id: "12",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 12}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 24),
+							Passed:    &yes,
+						}),
+					},
+				},
+				{
+					id: "11",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 11}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 22),
+							Passed:    &yes,
+						}),
+					},
+				},
+				{
+					id: "10",
+					started: &fakeObject{
+						data: jsonData(metadata.Started{Timestamp: now + 10}),
+					},
+					finished: &fakeObject{
+						data: jsonData(metadata.Finished{
+							Timestamp: pint64(now + 20),
+							Passed:    &yes,
+						}),
+					},
+				},
+			},
+			group: configpb.TestGroup{
+				GcsPrefix: "bucket/path/to/build/",
+			},
+			expected: []inflatedColumn{
+				{
+					column: &state.Column{
+						Build:   "13",
+						Started: float64(now+13) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 13,
+							},
+						},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "12",
+						Started: float64(now+12) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 12,
+							},
+						},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "11",
+						Started: float64(now+11) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 11,
+							},
+						},
+					},
+				},
+				{
+					column: &state.Column{
+						Build:   "10",
+						Started: float64(now+10) * 1000,
+					},
+					cells: map[string]cell{
+						"Overall": {
+							result: state.Row_PASS,
+							metrics: map[string]float64{
+								"seconds-elapsed": 10,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "cancelled context returns error",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			err: true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			path := newPathOrDie("gs://" + tc.group.GcsPrefix)
+			if tc.ctx == nil {
+				tc.ctx = context.Background()
+			}
+			ctx, cancel := context.WithCancel(tc.ctx)
+			defer cancel()
+			client := fakeClient{
+				fakeLister: fakeLister{},
+				fakeOpener: fakeOpener{},
+			}
+
+			var builds []gcs.Build
+			for _, build := range tc.builds {
+				buildPath := resolveOrDie(&path, build.id+"/")
+				builds = append(builds, gcs.Build{Path: *buildPath})
+				fi := fakeIterator{}
+
+				if build.started != nil {
+					p := resolveOrDie(buildPath, "started.json")
+					fi.objects = append(fi.objects, storage.ObjectAttrs{
+						Name: p.Object(),
+					})
+					client.fakeOpener[*p] = *build.started
+				}
+				if build.finished != nil {
+					p := resolveOrDie(buildPath, "finished.json")
+					fi.objects = append(fi.objects, storage.ObjectAttrs{
+						Name: p.Object(),
+					})
+					client.fakeOpener[*p] = *build.finished
+				}
+				for n, fo := range build.artifacts {
+					p := resolveOrDie(buildPath, n)
+					fi.objects = append(fi.objects, storage.ObjectAttrs{
+						Name: p.Object(),
+					})
+					client.fakeOpener[*p] = fo
+				}
+				client.fakeLister[*buildPath] = fi
+			}
+
+			if tc.concurrency == 0 {
+				tc.concurrency = 1
+			}
+
+			if tc.max == 0 {
+				tc.max = len(builds)
+			}
+
+			if tc.dur == 0 {
+				tc.dur = 5 * time.Minute
+			}
+
+			actual, err := readColumns(ctx, client, tc.group, builds, tc.stop, tc.max, tc.dur, tc.concurrency)
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("readColumns(): unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Error("readColumns(): failed to receive an error")
+			default:
+				if diff := cmp.Diff(actual, tc.expected, cmp.AllowUnexported(inflatedColumn{}, cell{}), protocmp.Transform()); diff != "" {
+					t.Errorf("readColumns() got unexpected diff (-got +want):\n%s", diff)
+				}
+			}
 		})
 	}
 }
 
 func TestReadResult(t *testing.T) {
 	path := newPathOrDie("gs://bucket/path/to/some/build/")
+	yes := true
 	cases := []struct {
 		name     string
 		ctx      context.Context
@@ -79,6 +737,162 @@ func TestReadResult(t *testing.T) {
 				finished: gcs.Finished{
 					Running: true,
 				},
+			},
+		},
+		{
+			name: "cancelled context returns error",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+		},
+		{
+			name: "all info present",
+			data: map[string]fakeObject{
+				"started.json":       {data: `{"node": "fun"}`},
+				"finished.json":      {data: `{"passed": true}`},
+				"junit_super_88.xml": {data: `<testsuite><testcase name="foo"/></testsuite>`},
+			},
+			expected: &gcsResult{
+				started: gcs.Started{
+					Started: metadata.Started{Node: "fun"},
+				},
+				finished: gcs.Finished{
+					Finished: metadata.Finished{Passed: &yes},
+				},
+				suites: []gcs.SuitesMeta{
+					{
+						Suites: junit.Suites{
+							Suites: []junit.Suite{
+								{
+									XMLName: xml.Name{Local: "testsuite"},
+									Results: []junit.Result{
+										{Name: "foo"},
+									},
+								},
+							},
+						},
+						Metadata: map[string]string{
+							"Context":   "super",
+							"Thread":    "88",
+							"Timestamp": "",
+						},
+						Path: "gs://bucket/path/to/some/build/junit_super_88.xml",
+					},
+				},
+			},
+		},
+		{
+			name: "missing started.json reports pending",
+			data: map[string]fakeObject{
+				"finished.json":      {data: `{"passed": true}`},
+				"junit_super_88.xml": {data: `<testsuite><testcase name="foo"/></testsuite>`},
+			},
+			expected: &gcsResult{
+				started: gcs.Started{
+					Pending: true,
+				},
+				finished: gcs.Finished{
+					Finished: metadata.Finished{Passed: &yes},
+				},
+				suites: []gcs.SuitesMeta{
+					{
+						Suites: junit.Suites{
+							Suites: []junit.Suite{
+								{
+									XMLName: xml.Name{Local: "testsuite"},
+									Results: []junit.Result{
+										{Name: "foo"},
+									},
+								},
+							},
+						},
+						Metadata: map[string]string{
+							"Context":   "super",
+							"Thread":    "88",
+							"Timestamp": "",
+						},
+						Path: "gs://bucket/path/to/some/build/junit_super_88.xml",
+					},
+				},
+			},
+		},
+		{
+			name: "no finished reports running",
+			data: map[string]fakeObject{
+				"started.json":       {data: `{"node": "fun"}`},
+				"junit_super_88.xml": {data: `<testsuite><testcase name="foo"/></testsuite>`},
+			},
+			expected: &gcsResult{
+				started: gcs.Started{
+					Started: metadata.Started{Node: "fun"},
+				},
+				finished: gcs.Finished{
+					Running: true,
+				},
+				suites: []gcs.SuitesMeta{
+					{
+						Suites: junit.Suites{
+							Suites: []junit.Suite{
+								{
+									XMLName: xml.Name{Local: "testsuite"},
+									Results: []junit.Result{
+										{Name: "foo"},
+									},
+								},
+							},
+						},
+						Metadata: map[string]string{
+							"Context":   "super",
+							"Thread":    "88",
+							"Timestamp": "",
+						},
+						Path: "gs://bucket/path/to/some/build/junit_super_88.xml",
+					},
+				},
+			},
+		},
+		{
+			name: "no artifacts report no suites",
+			data: map[string]fakeObject{
+				"started.json":  {data: `{"node": "fun"}`},
+				"finished.json": {data: `{"passed": true}`},
+			},
+			expected: &gcsResult{
+				started: gcs.Started{
+					Started: metadata.Started{Node: "fun"},
+				},
+				finished: gcs.Finished{
+					Finished: metadata.Finished{Passed: &yes},
+				},
+			},
+		},
+		{
+			name: "started error returns error",
+			data: map[string]fakeObject{
+				"started.json": {
+					data:     "{}",
+					closeErr: errors.New("injected closer error"),
+				},
+				"finished.json":      {data: `{"passed": true}`},
+				"junit_super_88.xml": {data: `<testsuite><testcase name="foo"/></testsuite>`},
+			},
+		},
+		{
+			name: "finished error returns error",
+			data: map[string]fakeObject{
+				"started.json":       {data: `{"node": "fun"}`},
+				"finished.json":      {readErr: errors.New("injected read error")},
+				"junit_super_88.xml": {data: `<testsuite><testcase name="foo"/></testsuite>`},
+			},
+		},
+		{
+			name: "artifact error returns error",
+			data: map[string]fakeObject{
+				"started.json":       {data: `{"node": "fun"}`},
+				"finished.json":      {data: `{"passed": true}`},
+				"junit_super_88.xml": {openErr: errors.New("injected open error")},
 			},
 		},
 	}
@@ -313,11 +1127,11 @@ func (fo fakeOpener) Open(ctx context.Context, path gcs.Path) (io.ReadCloser, er
 	if o.openErr != nil {
 		return nil, o.openErr
 	}
-	return ioutil.NopCloser(&fakeReader{
+	return &fakeReader{
 		buf:      bytes.NewBufferString(o.data),
 		readErr:  o.readErr,
 		closeErr: o.closeErr,
-	}), nil
+	}, nil
 }
 
 type fakeObject struct {


### PR DESCRIPTION
Also catch and resolve some bugs in the process:
* Need to get column header's configuration value.
* Distinguish between stop time and build download duration
* Truncate excessive results correctly
* Include the newest result that is too old.
* Fix a NPE when started/finished error.
* Avoid hang when multiple builds find a too old build concurrently