### PR TITLE
Add coverage for linked builds

### DIFF
--- a/util/gcs/BUILD.bazel
+++ b/util/gcs/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     deps = [
         "//metadata:go_default_library",
         "//metadata/junit:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@org_golang_google_api//iterator:go_default_library",
     ],


### PR DESCRIPTION
Also refactor to use `cmp.Diff()` instead of `reflect.DeepEqual()`