### PR TITLE
Fix lint errors across files

### DIFF
--- a/pb/state/state.pb.go
+++ b/pb/state/state.pb.go
@@ -38,6 +38,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
+// TODO(michelle192837): Update uses of this to use test_status instead.
 type Row_Result int32
 
 const (

--- a/pb/state/state.proto
+++ b/pb/state/state.proto
@@ -113,6 +113,7 @@ message Row {
   string name = 1; // Display name, which might process id to append/filter info.
   string id = 2;  // raw id for the row, such as the bazel target or golang package.
 
+  // TODO(michelle192837): Update uses of this to use test_status instead.
   enum Result {
     NO_RESULT = 0;
     PASS = 1;
@@ -140,7 +141,7 @@ message Row {
   // The decoded values are Result enums
   repeated int32 results = 3;
 
-  // Test IDs for each test result in this test case. 
+  // Test IDs for each test result in this test case.
   // Must be present on every column, regardless of status.
   repeated string cell_ids = 4;
 

--- a/pkg/summarizer/flakiness_test.go
+++ b/pkg/summarizer/flakiness_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
 	summarypb "github.com/GoogleCloudPlatform/testgrid/pb/summary"
 	"github.com/GoogleCloudPlatform/testgrid/pkg/summarizer/common"
 	"github.com/golang/protobuf/proto"
@@ -157,14 +157,14 @@ func TestGetTrend(t *testing.T) {
 func TestIsWithinTimeFrame(t *testing.T) {
 	cases := []struct {
 		name      string
-		column    *state.Column
+		column    *statepb.Column
 		startTime int
 		endTime   int
 		expected  bool
 	}{
 		{
 			name: "column within time frame returns true",
-			column: &state.Column{
+			column: &statepb.Column{
 				Started: 1.0,
 			},
 			startTime: 0,
@@ -173,7 +173,7 @@ func TestIsWithinTimeFrame(t *testing.T) {
 		},
 		{
 			name: "column before time frame returns false",
-			column: &state.Column{
+			column: &statepb.Column{
 				Started: 1.0,
 			},
 			startTime: 3,
@@ -182,7 +182,7 @@ func TestIsWithinTimeFrame(t *testing.T) {
 		},
 		{
 			name: "column after time frame returns false",
-			column: &state.Column{
+			column: &statepb.Column{
 				Started: 4.0,
 			},
 			startTime: 0,
@@ -191,7 +191,7 @@ func TestIsWithinTimeFrame(t *testing.T) {
 		},
 		{
 			name: "function is inclusive with column at start time",
-			column: &state.Column{
+			column: &statepb.Column{
 				Started: 0.0,
 			},
 			startTime: 0,
@@ -200,7 +200,7 @@ func TestIsWithinTimeFrame(t *testing.T) {
 		},
 		{
 			name: "function is inclusive with column at end time",
-			column: &state.Column{
+			column: &statepb.Column{
 				Started: 2.0,
 			},
 			startTime: 0,
@@ -221,28 +221,28 @@ func TestIsWithinTimeFrame(t *testing.T) {
 func TestParseGrid(t *testing.T) {
 	cases := []struct {
 		name      string
-		grid      *state.Grid
+		grid      *statepb.Grid
 		startTime int
 		endTime   int
 		expected  []*common.GridMetrics
 	}{
 		{
 			name: "grid with all analyzed result types produces correct result list",
-			grid: &state.Grid{
-				Columns: []*state.Column{
+			grid: &statepb.Grid{
+				Columns: []*statepb.Column{
 					{Started: 0},
 					{Started: 1000},
 					{Started: 2000},
 					{Started: 2000},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					{
 						Name: "test_1",
 						Results: []int32{
-							state.Row_Result_value["PASS"], 1,
-							state.Row_Result_value["FAIL"], 1,
-							state.Row_Result_value["FLAKY"], 1,
-							state.Row_Result_value["CATEGORIZED_FAIL"], 1,
+							statepb.Row_Result_value["PASS"], 1,
+							statepb.Row_Result_value["FAIL"], 1,
+							statepb.Row_Result_value["FLAKY"], 1,
+							statepb.Row_Result_value["CATEGORIZED_FAIL"], 1,
 						},
 						Messages: []string{
 							"",
@@ -271,18 +271,18 @@ func TestParseGrid(t *testing.T) {
 		},
 		{
 			name: "grid with no analyzed results produces empty result list",
-			grid: &state.Grid{
-				Columns: []*state.Column{
+			grid: &statepb.Grid{
+				Columns: []*statepb.Column{
 					{Started: -1000},
 					{Started: 1000},
 					{Started: 2000},
 					{Started: 2000},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					{
 						Name: "test_1",
 						Results: []int32{
-							state.Row_Result_value["NO_RESULT"], 4,
+							statepb.Row_Result_value["NO_RESULT"], 4,
 						},
 						Messages: []string{
 							"this_message_should_not_show_up_in_results_0",
@@ -299,21 +299,21 @@ func TestParseGrid(t *testing.T) {
 		},
 		{
 			name: "grid with some non-analyzed results properly assigns correct messages",
-			grid: &state.Grid{
-				Columns: []*state.Column{
+			grid: &statepb.Grid{
+				Columns: []*statepb.Column{
 					{Started: 0},
 					{Started: 1000},
 					{Started: 1000},
 					{Started: 2000},
 					{Started: 2000},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					{
 						Name: "test_1",
 						Results: []int32{
-							state.Row_Result_value["PASS"], 1,
-							state.Row_Result_value["NO_RESULT"], 2,
-							state.Row_Result_value["FAIL"], 2,
+							statepb.Row_Result_value["PASS"], 1,
+							statepb.Row_Result_value["NO_RESULT"], 2,
+							statepb.Row_Result_value["FAIL"], 2,
 						},
 						Messages: []string{
 							"this_message_should_not_show_up_in_results",
@@ -341,21 +341,21 @@ func TestParseGrid(t *testing.T) {
 		},
 		{
 			name: "grid with columns outside of time frame correctly assigns messages",
-			grid: &state.Grid{
-				Columns: []*state.Column{
+			grid: &statepb.Grid{
+				Columns: []*statepb.Column{
 					{Started: 0},
 					{Started: 1000},
 					{Started: 1000},
 					{Started: 7000},
 					{Started: 2000},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					{
 						Name: "test_1",
 						Results: []int32{
-							state.Row_Result_value["PASS"], 1,
-							state.Row_Result_value["NO_RESULT"], 2,
-							state.Row_Result_value["FAIL"], 2,
+							statepb.Row_Result_value["PASS"], 1,
+							statepb.Row_Result_value["NO_RESULT"], 2,
+							statepb.Row_Result_value["FAIL"], 2,
 						},
 						Messages: []string{
 							"this_message_should_not_show_up_in_results",

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/testgrid/internal/result"
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	"github.com/GoogleCloudPlatform/testgrid/pb/state"
 	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
 	summarypb "github.com/GoogleCloudPlatform/testgrid/pb/summary"
 )
@@ -1834,22 +1833,22 @@ func TestGetHealthinessForInterval(t *testing.T) {
 	}{
 		{
 			name: "typical inputs returns correct HealthinessInfo",
-			grid: &state.Grid{
-				Columns: []*state.Column{
+			grid: &statepb.Grid{
+				Columns: []*statepb.Column{
 					{Started: withinCurrentInterval},
 					{Started: withinCurrentInterval},
 					{Started: withinPreviousInterval},
 					{Started: withinPreviousInterval},
 					{Started: notWithinAnyInterval},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					{
 						Name: "test_1",
 						Results: []int32{
-							state.Row_Result_value["PASS"], 1,
-							state.Row_Result_value["FAIL"], 1,
-							state.Row_Result_value["FAIL"], 1,
-							state.Row_Result_value["FAIL"], 2,
+							statepb.Row_Result_value["PASS"], 1,
+							statepb.Row_Result_value["FAIL"], 1,
+							statepb.Row_Result_value["FAIL"], 1,
+							statepb.Row_Result_value["FAIL"], 2,
 						},
 						Messages: []string{
 							"",

--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	"github.com/GoogleCloudPlatform/testgrid/metadata/junit"
-	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 )
 
@@ -47,10 +47,10 @@ func TestConvertResult(t *testing.T) {
 		{
 			name: "basically works",
 			expected: inflatedColumn{
-				column: &state.Column{},
+				column: &statepb.Column{},
 				cells: map[string]cell{
 					"Overall": {
-						result:  state.Row_FAIL,
+						result:  statepb.Row_FAIL,
 						icon:    "T",
 						message: "Build did not complete within 24 hours",
 					},
@@ -78,7 +78,7 @@ func TestConvertResult(t *testing.T) {
 				},
 			},
 			expected: inflatedColumn{
-				column: &state.Column{
+				column: &statepb.Column{
 					Build:   "hello",
 					Started: 300 * 1000,
 					Extra: []string{
@@ -90,7 +90,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				cells: map[string]cell{
 					"Overall": {
-						result:  state.Row_FAIL,
+						result:  statepb.Row_FAIL,
 						icon:    "T",
 						message: "Build did not complete within 24 hours",
 					},
@@ -118,7 +118,7 @@ func TestConvertResult(t *testing.T) {
 				},
 			},
 			expected: inflatedColumn{
-				column: &state.Column{
+				column: &statepb.Column{
 					Build:   "hello",
 					Started: float64(now * 1000),
 					Extra: []string{
@@ -130,7 +130,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				cells: map[string]cell{
 					"Overall": {
-						result:  state.Row_RUNNING,
+						result:  statepb.Row_RUNNING,
 						icon:    "R",
 						message: "Build still running...",
 					},
@@ -172,18 +172,18 @@ func TestConvertResult(t *testing.T) {
 				},
 			},
 			expected: inflatedColumn{
-				column: &state.Column{
+				column: &statepb.Column{
 					Started: float64(now * 1000),
 				},
 				cells: map[string]cell{
 					"Overall": {
-						result:  state.Row_FAIL,
+						result:  statepb.Row_FAIL,
 						icon:    "F",
 						message: "Build failed outside of test results",
 						metrics: setElapsed(nil, 1),
 					},
 					"this.that": {
-						result: state.Row_PASS,
+						result: statepb.Row_PASS,
 					},
 				},
 			},
@@ -252,44 +252,44 @@ func TestConvertResult(t *testing.T) {
 				},
 			},
 			expected: inflatedColumn{
-				column: &state.Column{
+				column: &statepb.Column{
 					Started: float64(now * 1000),
 				},
 				cells: map[string]cell{
 					"Overall": {
-						result:  state.Row_FAIL,
+						result:  statepb.Row_FAIL,
 						metrics: setElapsed(nil, 1),
 					},
 					"elapsed": {
-						result:  state.Row_PASS,
+						result:  statepb.Row_PASS,
 						metrics: setElapsed(nil, 5),
 					},
 					"failed no message": {
-						result: state.Row_FAIL,
+						result: statepb.Row_FAIL,
 					},
 					"failed": {
 						message: "boom",
-						result:  state.Row_FAIL,
+						result:  statepb.Row_FAIL,
 						icon:    "F",
 					},
 					"failed other message": {
 						message: "irrelevant message",
-						result:  state.Row_FAIL,
+						result:  statepb.Row_FAIL,
 						icon:    "F",
 					},
 					// no invisible skip
 					"visible skip": {
-						result:  state.Row_PASS_WITH_SKIPS,
+						result:  statepb.Row_PASS_WITH_SKIPS,
 						message: "tl;dr",
 						icon:    "S",
 					},
 					"stderr message": {
 						message: "ouch",
-						result:  state.Row_PASS,
+						result:  statepb.Row_PASS,
 					},
 					"stdout message": {
 						message: "bellybutton",
-						result:  state.Row_PASS,
+						result:  statepb.Row_PASS,
 					},
 				},
 			},
@@ -350,19 +350,19 @@ func TestConvertResult(t *testing.T) {
 				},
 			},
 			expected: inflatedColumn{
-				column: &state.Column{
+				column: &statepb.Column{
 					Started: float64(now * 1000),
 				},
 				cells: map[string]cell{
 					"Overall": {
-						result:  state.Row_PASS,
+						result:  statepb.Row_PASS,
 						metrics: setElapsed(nil, 1),
 					},
 					"elapsed - first [second]": {
-						result: state.Row_PASS,
+						result: statepb.Row_PASS,
 					},
 					"other - hey []": {
-						result: state.Row_PASS,
+						result: statepb.Row_PASS,
 					},
 				},
 			},
@@ -427,24 +427,24 @@ func TestConvertResult(t *testing.T) {
 				},
 			},
 			expected: inflatedColumn{
-				column: &state.Column{
+				column: &statepb.Column{
 					Started: float64(now * 1000),
 				},
 				cells: map[string]cell{
 					"Overall": {
-						result:  state.Row_PASS,
+						result:  statepb.Row_PASS,
 						metrics: setElapsed(nil, 1),
 					},
 					"same - same": {
-						result:  state.Row_PASS,
+						result:  statepb.Row_PASS,
 						metrics: setElapsed(nil, 1),
 					},
 					"same - same [1]": {
-						result:  state.Row_PASS,
+						result:  statepb.Row_PASS,
 						metrics: setElapsed(nil, 2),
 					},
 					"same - same [2]": {
-						result:  state.Row_PASS,
+						result:  statepb.Row_PASS,
 						metrics: setElapsed(nil, 3),
 					},
 				},
@@ -457,7 +457,7 @@ func TestConvertResult(t *testing.T) {
 			actual := convertResult(tc.nameCfg, tc.id, tc.headers, tc.result)
 			if !reflect.DeepEqual(actual, tc.expected) {
 				t.Errorf(
-					"convertResult(%v, %v,%v, %v) got %s, want %s",
+					"convertResult(%v, %v,%v, %v) got %v, want %v",
 					tc.nameCfg,
 					tc.id,
 					tc.headers,
@@ -491,7 +491,7 @@ func TestOverallCell(t *testing.T) {
 				},
 			},
 			expected: cell{
-				result:  state.Row_FAIL,
+				result:  statepb.Row_FAIL,
 				message: "Build did not complete within 24 hours",
 				icon:    "T",
 			},
@@ -512,7 +512,7 @@ func TestOverallCell(t *testing.T) {
 				},
 			},
 			expected: cell{
-				result:  state.Row_PASS,
+				result:  statepb.Row_PASS,
 				metrics: setElapsed(nil, 150),
 			},
 		},
@@ -532,7 +532,7 @@ func TestOverallCell(t *testing.T) {
 				},
 			},
 			expected: cell{
-				result:  state.Row_FAIL,
+				result:  statepb.Row_FAIL,
 				metrics: setElapsed(nil, 150),
 			},
 		},
@@ -551,7 +551,7 @@ func TestOverallCell(t *testing.T) {
 				},
 			},
 			expected: cell{
-				result:  state.Row_FAIL,
+				result:  statepb.Row_FAIL,
 				metrics: setElapsed(nil, 150),
 			},
 		},

--- a/pkg/updater/inflate.go
+++ b/pkg/updater/inflate.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
 )
 
 // inflatedColumn holds all the entries for a given column.
@@ -29,13 +29,13 @@ import (
 // * Column state metadata and
 // * cell values for every row in this column
 type inflatedColumn struct {
-	column *state.Column
+	column *statepb.Column
 	cells  map[string]cell
 }
 
 // cell holds a row's values for a given column
 type cell struct {
-	result state.Row_Result
+	result statepb.Row_Result
 
 	cellID string
 
@@ -46,7 +46,7 @@ type cell struct {
 }
 
 // inflateGrid inflates the grid's rows into an inflatedColumn channel.
-func inflateGrid(grid *state.Grid, earliest, latest time.Time) []inflatedColumn {
+func inflateGrid(grid *statepb.Grid, earliest, latest time.Time) []inflatedColumn {
 	var cols []inflatedColumn
 
 	// nothing is blocking, so no need for a parent context.
@@ -82,7 +82,7 @@ func inflateGrid(grid *state.Grid, earliest, latest time.Time) []inflatedColumn 
 }
 
 // inflateRow inflates the values for each column into a cell channel.
-func inflateRow(parent context.Context, row *state.Row) <-chan cell {
+func inflateRow(parent context.Context, row *statepb.Row) <-chan cell {
 	out := make(chan cell)
 
 	go func() {
@@ -119,7 +119,7 @@ func inflateRow(parent context.Context, row *state.Row) <-chan cell {
 				}
 				c.metrics[name] = *val
 			}
-			if result != state.Row_NO_RESULT {
+			if result != statepb.Row_NO_RESULT {
 				c.icon = row.Icons[filledIdx]
 				c.message = row.Messages[filledIdx]
 				filledIdx++
@@ -136,7 +136,7 @@ func inflateRow(parent context.Context, row *state.Row) <-chan cell {
 }
 
 // inflateMetric inflates the sparse-encoded metric values into a channel
-func inflateMetric(ctx context.Context, metric *state.Metric) <-chan *float64 {
+func inflateMetric(ctx context.Context, metric *statepb.Metric) <-chan *float64 {
 	out := make(chan *float64)
 	go func() {
 		defer close(out)
@@ -172,8 +172,8 @@ func inflateMetric(ctx context.Context, metric *state.Metric) <-chan *float64 {
 }
 
 // inflateResults inflates the run-length encoded row results into a channel.
-func inflateResults(ctx context.Context, results []int32) <-chan state.Row_Result {
-	out := make(chan state.Row_Result)
+func inflateResults(ctx context.Context, results []int32) <-chan statepb.Row_Result {
+	out := make(chan statepb.Row_Result)
 	go func() {
 		defer close(out)
 		for idx := 0; idx < len(results); idx++ {
@@ -183,7 +183,7 @@ func inflateResults(ctx context.Context, results []int32) <-chan state.Row_Resul
 				select {
 				case <-ctx.Done():
 					return
-				case out <- state.Row_Result(val):
+				case out <- statepb.Row_Result(val):
 				}
 			}
 		}

--- a/pkg/updater/inflate_test.go
+++ b/pkg/updater/inflate_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
 )
 
 func blank(n int) []string {
@@ -47,7 +47,7 @@ func TestInflateGrid(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		grid     state.Grid
+		grid     statepb.Grid
 		earliest time.Time
 		latest   time.Time
 		expected []inflatedColumn
@@ -57,8 +57,8 @@ func TestInflateGrid(t *testing.T) {
 		},
 		{
 			name: "preserve column data",
-			grid: state.Grid{
-				Columns: []*state.Column{
+			grid: statepb.Grid{
+				Columns: []*statepb.Column{
 					{
 						Build:      "build",
 						Name:       "name",
@@ -78,7 +78,7 @@ func TestInflateGrid(t *testing.T) {
 			latest: hours[23],
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:      "build",
 						Name:       "name",
 						Started:    5,
@@ -88,7 +88,7 @@ func TestInflateGrid(t *testing.T) {
 					cells: map[string]cell{},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:      "second build",
 						Name:       "second name",
 						Started:    10,
@@ -101,8 +101,8 @@ func TestInflateGrid(t *testing.T) {
 		},
 		{
 			name: "preserve row data",
-			grid: state.Grid{
-				Columns: []*state.Column{
+			grid: statepb.Grid{
+				Columns: []*statepb.Column{
 					{
 						Build:   "b1",
 						Name:    "n1",
@@ -114,17 +114,17 @@ func TestInflateGrid(t *testing.T) {
 						Started: 2,
 					},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					{
 						Name: "name",
 						Results: []int32{
-							int32(state.Row_FAIL), 2,
+							int32(statepb.Row_FAIL), 2,
 						},
 						CellIds:  []string{"this", "that"},
 						Messages: []string{"important", "notice"},
 						Icons:    []string{"I1", "I2"},
 						Metric:   []string{"this", "that"},
-						Metrics: []*state.Metric{
+						Metrics: []*statepb.Metric{
 							{
 								Indices: []int32{0, 2},
 								Values:  []float64{0.1, 0.2},
@@ -139,7 +139,7 @@ func TestInflateGrid(t *testing.T) {
 					{
 						Name: "second",
 						Results: []int32{
-							int32(state.Row_PASS), 2,
+							int32(statepb.Row_PASS), 2,
 						},
 						CellIds:  blank(2),
 						Messages: blank(2),
@@ -151,14 +151,14 @@ func TestInflateGrid(t *testing.T) {
 			latest: hours[23],
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "b1",
 						Name:    "n1",
 						Started: 1,
 					},
 					cells: map[string]cell{
 						"name": {
-							result:  state.Row_FAIL,
+							result:  statepb.Row_FAIL,
 							cellID:  "this",
 							message: "important",
 							icon:    "I1",
@@ -167,19 +167,19 @@ func TestInflateGrid(t *testing.T) {
 							},
 						},
 						"second": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "b2",
 						Name:    "n2",
 						Started: 2,
 					},
 					cells: map[string]cell{
 						"name": {
-							result:  state.Row_FAIL,
+							result:  statepb.Row_FAIL,
 							cellID:  "that",
 							message: "notice",
 							icon:    "I2",
@@ -189,7 +189,7 @@ func TestInflateGrid(t *testing.T) {
 							},
 						},
 						"second": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 					},
 				},
@@ -197,8 +197,8 @@ func TestInflateGrid(t *testing.T) {
 		},
 		{
 			name: "drop latest columns",
-			grid: state.Grid{
-				Columns: []*state.Column{
+			grid: statepb.Grid{
+				Columns: []*statepb.Column{
 					{
 						Build:   "latest1",
 						Started: millis(hours[23]),
@@ -216,17 +216,17 @@ func TestInflateGrid(t *testing.T) {
 						Started: millis(hours[10]),
 					},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					{
 						Name:     "hello",
 						CellIds:  blank(4),
 						Messages: blank(4),
 						Icons:    blank(4),
 						Results: []int32{
-							int32(state.Row_RUNNING), 1,
-							int32(state.Row_PASS), 1,
-							int32(state.Row_FAIL), 1,
-							int32(state.Row_FLAKY), 1,
+							int32(statepb.Row_RUNNING), 1,
+							int32(statepb.Row_PASS), 1,
+							int32(statepb.Row_FAIL), 1,
+							int32(statepb.Row_FLAKY), 1,
 						},
 					},
 					{
@@ -235,7 +235,7 @@ func TestInflateGrid(t *testing.T) {
 						Messages: blank(4),
 						Icons:    blank(4),
 						Results: []int32{
-							int32(state.Row_PASS_WITH_SKIPS), 4,
+							int32(statepb.Row_PASS_WITH_SKIPS), 4,
 						},
 					},
 				},
@@ -243,31 +243,31 @@ func TestInflateGrid(t *testing.T) {
 			latest: hours[20],
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "keep1",
 						Started: millis(hours[20]) + 999,
 					},
 					cells: map[string]cell{
-						"hello": {result: state.Row_FAIL},
-						"world": {result: state.Row_PASS_WITH_SKIPS},
+						"hello": {result: statepb.Row_FAIL},
+						"world": {result: statepb.Row_PASS_WITH_SKIPS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "keep2",
 						Started: millis(hours[10]),
 					},
 					cells: map[string]cell{
-						"hello": {result: state.Row_FLAKY},
-						"world": {result: state.Row_PASS_WITH_SKIPS},
+						"hello": {result: statepb.Row_FLAKY},
+						"world": {result: statepb.Row_PASS_WITH_SKIPS},
 					},
 				},
 			},
 		},
 		{
 			name: "drop old columns",
-			grid: state.Grid{
-				Columns: []*state.Column{
+			grid: statepb.Grid{
+				Columns: []*statepb.Column{
 					{
 						Build:   "current1",
 						Started: millis(hours[20]),
@@ -285,17 +285,17 @@ func TestInflateGrid(t *testing.T) {
 						Started: millis(hours[0]),
 					},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					{
 						Name:     "hello",
 						CellIds:  blank(4),
 						Messages: blank(4),
 						Icons:    blank(4),
 						Results: []int32{
-							int32(state.Row_RUNNING), 1,
-							int32(state.Row_PASS), 1,
-							int32(state.Row_FAIL), 1,
-							int32(state.Row_FLAKY), 1,
+							int32(statepb.Row_RUNNING), 1,
+							int32(statepb.Row_PASS), 1,
+							int32(statepb.Row_FAIL), 1,
+							int32(statepb.Row_FLAKY), 1,
 						},
 					},
 					{
@@ -304,7 +304,7 @@ func TestInflateGrid(t *testing.T) {
 						Messages: blank(4),
 						Icons:    blank(4),
 						Results: []int32{
-							int32(state.Row_PASS_WITH_SKIPS), 4,
+							int32(statepb.Row_PASS_WITH_SKIPS), 4,
 						},
 					},
 				},
@@ -313,23 +313,23 @@ func TestInflateGrid(t *testing.T) {
 			earliest: hours[10],
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "current1",
 						Started: millis(hours[20]),
 					},
 					cells: map[string]cell{
-						"hello": {result: state.Row_RUNNING},
-						"world": {result: state.Row_PASS_WITH_SKIPS},
+						"hello": {result: statepb.Row_RUNNING},
+						"world": {result: statepb.Row_PASS_WITH_SKIPS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "current2",
 						Started: millis(hours[10]),
 					},
 					cells: map[string]cell{
-						"hello": {result: state.Row_PASS},
-						"world": {result: state.Row_PASS_WITH_SKIPS},
+						"hello": {result: statepb.Row_PASS},
+						"world": {result: statepb.Row_PASS_WITH_SKIPS},
 					},
 				},
 			},
@@ -340,7 +340,7 @@ func TestInflateGrid(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := inflateGrid(&tc.grid, tc.earliest, tc.latest)
 			if !reflect.DeepEqual(actual, tc.expected) {
-				t.Errorf("inflateGrid(%v) got %s, want %s", tc.grid, actual, tc.expected)
+				t.Errorf("inflateGrid(%v) got %v, want %v", tc.grid, actual, tc.expected)
 			}
 		})
 
@@ -350,7 +350,7 @@ func TestInflateGrid(t *testing.T) {
 func TestInflateRow(t *testing.T) {
 	cases := []struct {
 		name     string
-		row      state.Row
+		row      statepb.Row
 		expected []cell
 	}{
 		{
@@ -358,28 +358,28 @@ func TestInflateRow(t *testing.T) {
 		},
 		{
 			name: "preserve cell ids",
-			row: state.Row{
+			row: statepb.Row{
 				CellIds:  []string{"cell-a", "cell-b"},
 				Icons:    blank(2),
 				Messages: blank(2),
 				Results: []int32{
-					int32(state.Row_PASS), 2,
+					int32(statepb.Row_PASS), 2,
 				},
 			},
 			expected: []cell{
 				{
-					result: state.Row_PASS,
+					result: statepb.Row_PASS,
 					cellID: "cell-a",
 				},
 				{
-					result: state.Row_PASS,
+					result: statepb.Row_PASS,
 					cellID: "cell-b",
 				},
 			},
 		},
 		{
 			name: "only finished columns contain icons and messages",
-			row: state.Row{
+			row: statepb.Row{
 				CellIds: blank(8),
 				Icons: []string{
 					"F1", "~1", "~2",
@@ -388,30 +388,30 @@ func TestInflateRow(t *testing.T) {
 					"fail", "flake-first", "flake-second",
 				},
 				Results: []int32{
-					int32(state.Row_NO_RESULT), 2,
-					int32(state.Row_FAIL), 1,
-					int32(state.Row_NO_RESULT), 2,
-					int32(state.Row_FLAKY), 2,
-					int32(state.Row_NO_RESULT), 1,
+					int32(statepb.Row_NO_RESULT), 2,
+					int32(statepb.Row_FAIL), 1,
+					int32(statepb.Row_NO_RESULT), 2,
+					int32(statepb.Row_FLAKY), 2,
+					int32(statepb.Row_NO_RESULT), 1,
 				},
 			},
 			expected: []cell{
 				{},
 				{},
 				{
-					result:  state.Row_FAIL,
+					result:  statepb.Row_FAIL,
 					icon:    "F1",
 					message: "fail",
 				},
 				{},
 				{},
 				{
-					result:  state.Row_FLAKY,
+					result:  statepb.Row_FLAKY,
 					icon:    "~1",
 					message: "flake-first",
 				},
 				{
-					result:  state.Row_FLAKY,
+					result:  statepb.Row_FLAKY,
 					icon:    "~2",
 					message: "flake-second",
 				},
@@ -420,15 +420,15 @@ func TestInflateRow(t *testing.T) {
 		},
 		{
 			name: "find metric name from row when missing",
-			row: state.Row{
+			row: statepb.Row{
 				CellIds:  blank(1),
 				Icons:    blank(1),
 				Messages: blank(1),
 				Results: []int32{
-					int32(state.Row_PASS), 1,
+					int32(statepb.Row_PASS), 1,
 				},
 				Metric: []string{"found-it"},
-				Metrics: []*state.Metric{
+				Metrics: []*statepb.Metric{
 					{
 						Indices: []int32{0, 1},
 						Values:  []float64{7},
@@ -437,7 +437,7 @@ func TestInflateRow(t *testing.T) {
 			},
 			expected: []cell{
 				{
-					result: state.Row_PASS,
+					result: statepb.Row_PASS,
 					metrics: map[string]float64{
 						"found-it": 7,
 					},
@@ -446,15 +446,15 @@ func TestInflateRow(t *testing.T) {
 		},
 		{
 			name: "prioritize local metric name",
-			row: state.Row{
+			row: statepb.Row{
 				CellIds:  blank(1),
 				Icons:    blank(1),
 				Messages: blank(1),
 				Results: []int32{
-					int32(state.Row_PASS), 1,
+					int32(statepb.Row_PASS), 1,
 				},
 				Metric: []string{"ignore-this"},
-				Metrics: []*state.Metric{
+				Metrics: []*statepb.Metric{
 					{
 						Name:    "oh yeah",
 						Indices: []int32{0, 1},
@@ -464,7 +464,7 @@ func TestInflateRow(t *testing.T) {
 			},
 			expected: []cell{
 				{
-					result: state.Row_PASS,
+					result: statepb.Row_PASS,
 					metrics: map[string]float64{
 						"oh yeah": 7,
 					},
@@ -522,7 +522,7 @@ func TestInflateMetic(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var actual []*float64
-			metric := state.Metric{
+			metric := statepb.Metric{
 				Name:    tc.name,
 				Indices: tc.indices,
 				Values:  tc.values,
@@ -542,7 +542,7 @@ func TestInflateResults(t *testing.T) {
 	cases := []struct {
 		name     string
 		results  []int32
-		expected []state.Row_Result
+		expected []statepb.Row_Result
 	}{
 		{
 			name: "basically works",
@@ -550,38 +550,38 @@ func TestInflateResults(t *testing.T) {
 		{
 			name: "first documented example with multiple values works",
 			results: []int32{
-				int32(state.Row_NO_RESULT), 3,
-				int32(state.Row_PASS), 4,
+				int32(statepb.Row_NO_RESULT), 3,
+				int32(statepb.Row_PASS), 4,
 			},
-			expected: []state.Row_Result{
-				state.Row_NO_RESULT,
-				state.Row_NO_RESULT,
-				state.Row_NO_RESULT,
-				state.Row_PASS,
-				state.Row_PASS,
-				state.Row_PASS,
-				state.Row_PASS,
+			expected: []statepb.Row_Result{
+				statepb.Row_NO_RESULT,
+				statepb.Row_NO_RESULT,
+				statepb.Row_NO_RESULT,
+				statepb.Row_PASS,
+				statepb.Row_PASS,
+				statepb.Row_PASS,
+				statepb.Row_PASS,
 			},
 		},
 		{
 			name: "first item is the type",
 			results: []int32{
-				int32(state.Row_RUNNING), 1, // RUNNING == 4
+				int32(statepb.Row_RUNNING), 1, // RUNNING == 4
 			},
-			expected: []state.Row_Result{
-				state.Row_RUNNING,
+			expected: []statepb.Row_Result{
+				statepb.Row_RUNNING,
 			},
 		},
 		{
 			name: "second item is the number of repetitions",
 			results: []int32{
-				int32(state.Row_PASS), 4, // Running == 1
+				int32(statepb.Row_PASS), 4, // Running == 1
 			},
-			expected: []state.Row_Result{
-				state.Row_PASS,
-				state.Row_PASS,
-				state.Row_PASS,
-				state.Row_PASS,
+			expected: []statepb.Row_Result{
+				statepb.Row_PASS,
+				statepb.Row_PASS,
+				statepb.Row_PASS,
+				statepb.Row_PASS,
 			},
 		},
 	}
@@ -589,7 +589,7 @@ func TestInflateResults(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ch := inflateResults(context.Background(), tc.results)
-			var actual []state.Row_Result
+			var actual []statepb.Row_Result
 			for r := range ch {
 				actual = append(actual, r)
 			}

--- a/pkg/updater/read.go
+++ b/pkg/updater/read.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 
 	"cloud.google.com/go/storage"
@@ -35,8 +35,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func downloadGrid(ctx context.Context, opener gcs.Opener, path gcs.Path) (*state.Grid, error) {
-	var g state.Grid
+func downloadGrid(ctx context.Context, opener gcs.Opener, path gcs.Path) (*statepb.Grid, error) {
+	var g statepb.Grid
 	r, err := opener.Open(ctx, path)
 	if err != nil && err == storage.ErrObjectNotExist {
 		return &g, nil

--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	"github.com/GoogleCloudPlatform/testgrid/metadata/junit"
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 
 	"cloud.google.com/go/storage"
@@ -153,13 +153,13 @@ func TestReadColumns(t *testing.T) {
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "11",
 						Started: float64(now+11) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result:  state.Row_FAIL,
+							result:  statepb.Row_FAIL,
 							icon:    "F",
 							message: "Build failed outside of test results",
 							metrics: map[string]float64{
@@ -169,13 +169,13 @@ func TestReadColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "10",
 						Started: float64(now+10) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 10,
 							},
@@ -233,7 +233,7 @@ func TestReadColumns(t *testing.T) {
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "11",
 						Started: float64(now+11) * 1000,
 						Extra: []string{
@@ -243,7 +243,7 @@ func TestReadColumns(t *testing.T) {
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result:  state.Row_FAIL,
+							result:  statepb.Row_FAIL,
 							icon:    "F",
 							message: "Build failed outside of test results",
 							metrics: map[string]float64{
@@ -253,7 +253,7 @@ func TestReadColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "10",
 						Started: float64(now+10) * 1000,
 						Extra: []string{
@@ -263,7 +263,7 @@ func TestReadColumns(t *testing.T) {
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 10,
 							},
@@ -315,30 +315,30 @@ func TestReadColumns(t *testing.T) {
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "10",
 						Started: float64(now+10) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 10,
 							},
 						},
 						"name good - context context-a - thread 33": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 						"name bad - context context-a - thread 33": {
-							result:  state.Row_FAIL,
+							result:  statepb.Row_FAIL,
 							icon:    "F",
 							message: "bad",
 						},
 						"name good - context context-b - thread 44": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 						"name bad - context context-b - thread 44": {
-							result:  state.Row_FAIL,
+							result:  statepb.Row_FAIL,
 							icon:    "F",
 							message: "bad",
 						},
@@ -392,13 +392,13 @@ func TestReadColumns(t *testing.T) {
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "12",
 						Started: float64(now+12) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 12,
 							},
@@ -406,13 +406,13 @@ func TestReadColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "11",
 						Started: float64(now+11) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 11,
 							},
@@ -479,13 +479,13 @@ func TestReadColumns(t *testing.T) {
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "13",
 						Started: float64(now+13) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 13,
 							},
@@ -493,13 +493,13 @@ func TestReadColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "12",
 						Started: float64(now+12) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 12,
 							},
@@ -567,13 +567,13 @@ func TestReadColumns(t *testing.T) {
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "13",
 						Started: float64(now+13) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 13,
 							},
@@ -581,13 +581,13 @@ func TestReadColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "12",
 						Started: float64(now+12) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 12,
 							},
@@ -595,13 +595,13 @@ func TestReadColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "11",
 						Started: float64(now+11) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 11,
 							},
@@ -609,13 +609,13 @@ func TestReadColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "10",
 						Started: float64(now+10) * 1000,
 					},
 					cells: map[string]cell{
 						"Overall": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 							metrics: map[string]float64{
 								"seconds-elapsed": 10,
 							},
@@ -873,7 +873,7 @@ func TestReadResult(t *testing.T) {
 			for name, fo := range tc.data {
 				p, err := path.ResolveReference(&url.URL{Path: name})
 				if err != nil {
-					t.Fatal("path.ResolveReference(%q): %w", name, err)
+					t.Fatalf("path.ResolveReference(%q): %w", name, err)
 				}
 				fi.objects = append(fi.objects, storage.ObjectAttrs{
 					Name: p.Object(),
@@ -1042,7 +1042,7 @@ func TestReadSuites(t *testing.T) {
 			for name, fo := range tc.data {
 				p, err := path.ResolveReference(&url.URL{Path: name})
 				if err != nil {
-					t.Fatal("path.ResolveReference(%q): %w", name, err)
+					t.Fatalf("path.ResolveReference(%q): %w", name, err)
 				}
 				fi.objects = append(fi.objects, storage.ObjectAttrs{
 					Name: p.Object(),

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	_ "github.com/GoogleCloudPlatform/testgrid/metadata/junit"
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	"github.com/GoogleCloudPlatform/testgrid/pb/state"
+	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 )
 
@@ -84,7 +84,7 @@ func TestUpdate(t *testing.T) {
 			},
 			expected: fakeUploader{
 				*resolveOrDie(&configPath, "hello"): {
-					buf:          mustGrid(state.Grid{}),
+					buf:          mustGrid(statepb.Grid{}),
 					cacheControl: "no-cache",
 					worldRead:    gcs.DefaultAcl,
 				},
@@ -126,7 +126,7 @@ func TestUpdate(t *testing.T) {
 				data: func() string {
 					b, err := config.MarshalBytes(&tc.config)
 					if err != nil {
-						t.Fatal("config.MarshalBytes() errored: %v", err)
+						t.Fatalf("config.MarshalBytes() errored: %v", err)
 					}
 					return string(b)
 				}(),
@@ -279,7 +279,7 @@ func jsonFinished(stamp int64, passed bool, meta metadata.Metadata) *fakeObject 
 	}
 }
 
-func mustGrid(grid state.Grid) []byte {
+func mustGrid(grid statepb.Grid) []byte {
 	buf, err := marshalGrid(grid)
 	if err != nil {
 		panic(err)
@@ -345,8 +345,8 @@ func TestUpdateGroup(t *testing.T) {
 				},
 			},
 			expected: &fakeUpload{
-				buf: mustGrid(state.Grid{
-					Columns: []*state.Column{
+				buf: mustGrid(statepb.Grid{
+					Columns: []*statepb.Column{
 						{
 							Build:   "99",
 							Started: float64(now+99) * 1000,
@@ -368,63 +368,63 @@ func TestUpdateGroup(t *testing.T) {
 							Extra:   []string{"build10"},
 						},
 					},
-					Rows: []*state.Row{
+					Rows: []*statepb.Row{
 						setupRow(
-							&state.Row{
+							&statepb.Row{
 								Name: "Overall",
 								Id:   "Overall",
 							},
 							cell{
-								result:  state.Row_RUNNING,
+								result:  statepb.Row_RUNNING,
 								message: "Build still running...",
 								icon:    "R",
 							},
 							cell{
-								result:  state.Row_PASS,
+								result:  statepb.Row_PASS,
 								metrics: setElapsed(nil, 1),
 							},
 							cell{
-								result:  state.Row_FAIL,
+								result:  statepb.Row_FAIL,
 								metrics: setElapsed(nil, 1),
 							},
 							cell{
-								result:  state.Row_PASS,
+								result:  statepb.Row_PASS,
 								metrics: setElapsed(nil, 1),
 							},
 						),
 						setupRow(
-							&state.Row{
+							&statepb.Row{
 								Name: "flaky",
 								Id:   "flaky",
 							},
-							cell{result: state.Row_NO_RESULT},
-							cell{result: state.Row_PASS},
+							cell{result: statepb.Row_NO_RESULT},
+							cell{result: statepb.Row_PASS},
 							cell{
-								result:  state.Row_FAIL,
+								result:  statepb.Row_FAIL,
 								message: "flaky",
 								icon:    "F",
 							},
-							cell{result: state.Row_PASS},
+							cell{result: statepb.Row_PASS},
 						),
 						setupRow(
-							&state.Row{
+							&statepb.Row{
 								Name: "good1",
 								Id:   "good1",
 							},
-							cell{result: state.Row_NO_RESULT},
-							cell{result: state.Row_PASS},
-							cell{result: state.Row_PASS},
-							cell{result: state.Row_PASS},
+							cell{result: statepb.Row_NO_RESULT},
+							cell{result: statepb.Row_PASS},
+							cell{result: statepb.Row_PASS},
+							cell{result: statepb.Row_PASS},
 						),
 						setupRow(
-							&state.Row{
+							&statepb.Row{
 								Name: "good2",
 								Id:   "good2",
 							},
-							cell{result: state.Row_NO_RESULT},
-							cell{result: state.Row_PASS},
-							cell{result: state.Row_PASS},
-							cell{result: state.Row_PASS},
+							cell{result: statepb.Row_NO_RESULT},
+							cell{result: statepb.Row_PASS},
+							cell{result: statepb.Row_PASS},
+							cell{result: statepb.Row_PASS},
 						),
 					},
 				}),
@@ -576,37 +576,37 @@ func TestMergeColumns(t *testing.T) {
 			name: "only new cols",
 			newCols: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build: "hello",
 					},
 					cells: map[string]cell{
-						"this": {result: state.Row_PASS},
+						"this": {result: statepb.Row_PASS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build: "world",
 					},
 					cells: map[string]cell{
-						"that": {result: state.Row_FAIL},
+						"that": {result: statepb.Row_FAIL},
 					},
 				},
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build: "hello",
 					},
 					cells: map[string]cell{
-						"this": {result: state.Row_PASS},
+						"this": {result: statepb.Row_PASS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build: "world",
 					},
 					cells: map[string]cell{
-						"that": {result: state.Row_FAIL},
+						"that": {result: statepb.Row_FAIL},
 					},
 				},
 			},
@@ -615,37 +615,37 @@ func TestMergeColumns(t *testing.T) {
 			name: "only old cols",
 			oldCols: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build: "ancient",
 					},
 					cells: map[string]cell{
-						"this": {result: state.Row_PASS},
+						"this": {result: statepb.Row_PASS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build: "graveyard",
 					},
 					cells: map[string]cell{
-						"that": {result: state.Row_FAIL},
+						"that": {result: statepb.Row_FAIL},
 					},
 				},
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build: "ancient",
 					},
 					cells: map[string]cell{
-						"this": {result: state.Row_PASS},
+						"this": {result: statepb.Row_PASS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build: "graveyard",
 					},
 					cells: map[string]cell{
-						"that": {result: state.Row_FAIL},
+						"that": {result: statepb.Row_FAIL},
 					},
 				},
 			},
@@ -654,79 +654,79 @@ func TestMergeColumns(t *testing.T) {
 			name: "accept all when old are all older than new",
 			newCols: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-1000",
 						Started: 1000,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_RUNNING},
+						"test": {result: statepb.Row_RUNNING},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-900",
 						Started: 900,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_PASS},
+						"test": {result: statepb.Row_PASS},
 					},
 				},
 			},
 			oldCols: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-50",
 						Started: 50,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FAIL},
+						"test": {result: statepb.Row_FAIL},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-40",
 						Started: 40,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FLAKY},
+						"test": {result: statepb.Row_FLAKY},
 					},
 				},
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-1000",
 						Started: 1000,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_RUNNING},
+						"test": {result: statepb.Row_RUNNING},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-900",
 						Started: 900,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_PASS},
+						"test": {result: statepb.Row_PASS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-50",
 						Started: 50,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FAIL},
+						"test": {result: statepb.Row_FAIL},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-40",
 						Started: 40,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FLAKY},
+						"test": {result: statepb.Row_FLAKY},
 					},
 				},
 			},
@@ -735,25 +735,25 @@ func TestMergeColumns(t *testing.T) {
 			name: "accept all new and oldest old, reject olds which are >= new",
 			newCols: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-1000",
 						Started: 1000,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_RUNNING},
+						"test": {result: statepb.Row_RUNNING},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-900",
 						Started: 900,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_PASS},
+						"test": {result: statepb.Row_PASS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-200",
 						Started: 200,
 					},
@@ -762,7 +762,7 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-100",
 						Started: 100,
 					},
@@ -773,7 +773,7 @@ func TestMergeColumns(t *testing.T) {
 			},
 			oldCols: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-500",
 						Started: 500,
 					},
@@ -782,7 +782,7 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-150",
 						Started: 150,
 					},
@@ -791,45 +791,45 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-50",
 						Started: 50,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FAIL},
+						"test": {result: statepb.Row_FAIL},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-40",
 						Started: 40,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FLAKY},
+						"test": {result: statepb.Row_FLAKY},
 					},
 				},
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-1000",
 						Started: 1000,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_RUNNING},
+						"test": {result: statepb.Row_RUNNING},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-900",
 						Started: 900,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_PASS},
+						"test": {result: statepb.Row_PASS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-200",
 						Started: 200,
 					},
@@ -838,7 +838,7 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-100",
 						Started: 100,
 					},
@@ -847,21 +847,21 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-50",
 						Started: 50,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FAIL},
+						"test": {result: statepb.Row_FAIL},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-40",
 						Started: 40,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FLAKY},
+						"test": {result: statepb.Row_FLAKY},
 					},
 				},
 			},
@@ -870,25 +870,25 @@ func TestMergeColumns(t *testing.T) {
 			name: "accept all new and oldest old, reject old duplicates",
 			newCols: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-1000",
 						Started: 1000,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_RUNNING},
+						"test": {result: statepb.Row_RUNNING},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-900",
 						Started: 900,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_PASS},
+						"test": {result: statepb.Row_PASS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "shared-110",
 						Started: 110,
 					},
@@ -897,7 +897,7 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "shared-100",
 						Started: 100,
 					},
@@ -906,7 +906,7 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "shared-90",
 						Started: 90,
 					},
@@ -917,75 +917,75 @@ func TestMergeColumns(t *testing.T) {
 			},
 			oldCols: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "shared-110",
 						Started: 110,
 						Extra:   []string{"reject old"},
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FAIL},
+						"test": {result: statepb.Row_FAIL},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "shared-100",
 						Started: 100,
 						Extra:   []string{"reject old"},
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FAIL},
+						"test": {result: statepb.Row_FAIL},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "shared-90",
 						Started: 90,
 						Extra:   []string{"reject old"},
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FAIL},
+						"test": {result: statepb.Row_FAIL},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-50",
 						Started: 50,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FAIL},
+						"test": {result: statepb.Row_FAIL},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-40",
 						Started: 40,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FLAKY},
+						"test": {result: statepb.Row_FLAKY},
 					},
 				},
 			},
 			expected: []inflatedColumn{
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-1000",
 						Started: 1000,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_RUNNING},
+						"test": {result: statepb.Row_RUNNING},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "new-900",
 						Started: 900,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_PASS},
+						"test": {result: statepb.Row_PASS},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "shared-110",
 						Started: 110,
 					},
@@ -994,7 +994,7 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "shared-100",
 						Started: 100,
 					},
@@ -1003,7 +1003,7 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "shared-90",
 						Started: 90,
 					},
@@ -1012,21 +1012,21 @@ func TestMergeColumns(t *testing.T) {
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-50",
 						Started: 50,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FAIL},
+						"test": {result: statepb.Row_FAIL},
 					},
 				},
 				{
-					column: &state.Column{
+					column: &statepb.Column{
 						Build:   "old-40",
 						Started: 40,
 					},
 					cells: map[string]cell{
-						"test": {result: state.Row_FLAKY},
+						"test": {result: statepb.Row_FLAKY},
 					},
 				},
 			},
@@ -1038,7 +1038,7 @@ func TestMergeColumns(t *testing.T) {
 			actual := mergeColumns(tc.newCols, tc.oldCols)
 			internals := cmp.AllowUnexported(inflatedColumn{}, cell{})
 			if diff := cmp.Diff(actual, tc.expected, internals, protocmp.Transform()); diff != "" {
-				t.Error("mergeColumns() got unexpected diff (-have, +want):\n%s", diff)
+				t.Errorf("mergeColumns() got unexpected diff (-have, +want):\n%s", diff)
 			}
 		})
 	}
@@ -1049,7 +1049,7 @@ func TestConstructGrid(t *testing.T) {
 		name     string
 		group    configpb.TestGroup
 		cols     []inflatedColumn
-		expected state.Grid
+		expected statepb.Grid
 	}{
 		{
 			name: "basically works",
@@ -1058,24 +1058,24 @@ func TestConstructGrid(t *testing.T) {
 			name: "multiple columns",
 			cols: []inflatedColumn{
 				{
-					column: &state.Column{Build: "15"},
+					column: &statepb.Column{Build: "15"},
 					cells: map[string]cell{
 						"green": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 						"red": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 						"only-15": {
-							result: state.Row_FLAKY,
+							result: statepb.Row_FLAKY,
 						},
 					},
 				},
 				{
-					column: &state.Column{Build: "10"},
+					column: &statepb.Column{Build: "10"},
 					cells: map[string]cell{
 						"full": {
-							result:  state.Row_PASS,
+							result:  statepb.Row_PASS,
 							cellID:  "cell",
 							icon:    "icon",
 							message: "message",
@@ -1085,31 +1085,31 @@ func TestConstructGrid(t *testing.T) {
 							},
 						},
 						"green": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 						"red": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 						"only-10": {
-							result: state.Row_FLAKY,
+							result: statepb.Row_FLAKY,
 						},
 					},
 				},
 			},
-			expected: state.Grid{
-				Columns: []*state.Column{
+			expected: statepb.Grid{
+				Columns: []*statepb.Column{
 					{Build: "15"},
 					{Build: "10"},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "full",
 							Id:   "full",
 						},
 						emptyCell,
 						cell{
-							result:  state.Row_PASS,
+							result:  statepb.Row_PASS,
 							cellID:  "cell",
 							icon:    "icon",
 							message: "message",
@@ -1120,36 +1120,36 @@ func TestConstructGrid(t *testing.T) {
 						},
 					),
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "green",
 							Id:   "green",
 						},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
 					),
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "only-10",
 							Id:   "only-10",
 						},
 						emptyCell,
-						cell{result: state.Row_FLAKY},
+						cell{result: statepb.Row_FLAKY},
 					),
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "only-15",
 							Id:   "only-15",
 						},
-						cell{result: state.Row_FLAKY},
+						cell{result: statepb.Row_FLAKY},
 						emptyCell,
 					),
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "red",
 							Id:   "red",
 						},
-						cell{result: state.Row_FAIL},
-						cell{result: state.Row_FAIL},
+						cell{result: statepb.Row_FAIL},
+						cell{result: statepb.Row_FAIL},
 					),
 				},
 			},
@@ -1161,49 +1161,49 @@ func TestConstructGrid(t *testing.T) {
 			},
 			cols: []inflatedColumn{
 				{
-					column: &state.Column{Build: "4"},
+					column: &statepb.Column{Build: "4"},
 					cells: map[string]cell{
 						"just-flaky": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 						"broken": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 					},
 				},
 				{
-					column: &state.Column{Build: "3"},
+					column: &statepb.Column{Build: "3"},
 					cells: map[string]cell{
 						"just-flaky": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 						"broken": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 					},
 				},
 			},
-			expected: state.Grid{
-				Columns: []*state.Column{
+			expected: statepb.Grid{
+				Columns: []*statepb.Column{
 					{Build: "4"},
 					{Build: "3"},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "broken",
 							Id:   "broken",
 						},
-						cell{result: state.Row_FAIL},
-						cell{result: state.Row_FAIL},
+						cell{result: statepb.Row_FAIL},
+						cell{result: statepb.Row_FAIL},
 					),
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "just-flaky",
 							Id:   "just-flaky",
 						},
-						cell{result: state.Row_FAIL},
-						cell{result: state.Row_PASS},
+						cell{result: statepb.Row_FAIL},
+						cell{result: statepb.Row_PASS},
 					),
 				},
 			},
@@ -1216,77 +1216,77 @@ func TestConstructGrid(t *testing.T) {
 			},
 			cols: []inflatedColumn{
 				{
-					column: &state.Column{Build: "4"},
+					column: &statepb.Column{Build: "4"},
 					cells: map[string]cell{
 						"still-broken": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 						"fixed": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 					},
 				},
 				{
-					column: &state.Column{Build: "3"},
+					column: &statepb.Column{Build: "3"},
 					cells: map[string]cell{
 						"still-broken": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 						"fixed": {
-							result: state.Row_PASS,
+							result: statepb.Row_PASS,
 						},
 					},
 				},
 				{
-					column: &state.Column{Build: "2"},
+					column: &statepb.Column{Build: "2"},
 					cells: map[string]cell{
 						"still-broken": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 						"fixed": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 					},
 				},
 				{
-					column: &state.Column{Build: "1"},
+					column: &statepb.Column{Build: "1"},
 					cells: map[string]cell{
 						"still-broken": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 						"fixed": {
-							result: state.Row_FAIL,
+							result: statepb.Row_FAIL,
 						},
 					},
 				},
 			},
-			expected: state.Grid{
-				Columns: []*state.Column{
+			expected: statepb.Grid{
+				Columns: []*statepb.Column{
 					{Build: "4"},
 					{Build: "3"},
 					{Build: "2"},
 					{Build: "1"},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "fixed",
 							Id:   "fixed",
 						},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_FAIL},
-						cell{result: state.Row_FAIL},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_FAIL},
+						cell{result: statepb.Row_FAIL},
 					),
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "still-broken",
 							Id:   "still-broken",
 						},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_FAIL},
-						cell{result: state.Row_FAIL},
-						cell{result: state.Row_FAIL},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_FAIL},
+						cell{result: statepb.Row_FAIL},
+						cell{result: statepb.Row_FAIL},
 					),
 				},
 			},
@@ -1318,14 +1318,14 @@ func TestConstructGrid(t *testing.T) {
 }
 
 func TestMarshalGrid(t *testing.T) {
-	g1 := state.Grid{
-		Columns: []*state.Column{
+	g1 := statepb.Grid{
+		Columns: []*statepb.Column{
 			{Build: "alpha"},
 			{Build: "second"},
 		},
 	}
-	g2 := state.Grid{
-		Columns: []*state.Column{
+	g2 := statepb.Grid{
+		Columns: []*statepb.Column{
 			{Build: "first"},
 			{Build: "second"},
 		},
@@ -1352,14 +1352,14 @@ func TestMarshalGrid(t *testing.T) {
 func TestAppendMetric(t *testing.T) {
 	cases := []struct {
 		name     string
-		metric   state.Metric
+		metric   statepb.Metric
 		idx      int32
 		value    float64
-		expected state.Metric
+		expected statepb.Metric
 	}{
 		{
 			name: "basically works",
-			expected: state.Metric{
+			expected: statepb.Metric{
 				Indices: []int32{0, 1},
 				Values:  []float64{0},
 			},
@@ -1368,33 +1368,33 @@ func TestAppendMetric(t *testing.T) {
 			name:  "start metric at random column",
 			idx:   7,
 			value: 11,
-			expected: state.Metric{
+			expected: statepb.Metric{
 				Indices: []int32{7, 1},
 				Values:  []float64{11},
 			},
 		},
 		{
 			name: "continue existing series",
-			metric: state.Metric{
+			metric: statepb.Metric{
 				Indices: []int32{6, 2},
 				Values:  []float64{6.1, 6.2},
 			},
 			idx:   8,
 			value: 88,
-			expected: state.Metric{
+			expected: statepb.Metric{
 				Indices: []int32{6, 3},
 				Values:  []float64{6.1, 6.2, 88},
 			},
 		},
 		{
 			name: "start new series",
-			metric: state.Metric{
+			metric: statepb.Metric{
 				Indices: []int32{3, 2},
 				Values:  []float64{6.1, 6.2},
 			},
 			idx:   8,
 			value: 88,
-			expected: state.Metric{
+			expected: statepb.Metric{
 				Indices: []int32{3, 2, 8, 1},
 				Values:  []float64{6.1, 6.2, 88},
 			},
@@ -1414,26 +1414,26 @@ func TestAppendMetric(t *testing.T) {
 func TestAppendCell(t *testing.T) {
 	cases := []struct {
 		name  string
-		row   state.Row
+		row   statepb.Row
 		cell  cell
 		count int
 
-		expected state.Row
+		expected statepb.Row
 	}{
 		{
 			name: "basically works",
-			expected: state.Row{
+			expected: statepb.Row{
 				Results: []int32{0, 0},
 			},
 		},
 		{
 			name: "first result",
 			cell: cell{
-				result: state.Row_PASS,
+				result: statepb.Row_PASS,
 			},
 			count: 1,
-			expected: state.Row{
-				Results:  []int32{int32(state.Row_PASS), 1},
+			expected: statepb.Row{
+				Results:  []int32{int32(statepb.Row_PASS), 1},
 				CellIds:  []string{""},
 				Messages: []string{""},
 				Icons:    []string{""},
@@ -1442,7 +1442,7 @@ func TestAppendCell(t *testing.T) {
 		{
 			name: "all fields filled",
 			cell: cell{
-				result:  state.Row_PASS,
+				result:  statepb.Row_PASS,
 				cellID:  "cell-id",
 				message: "hi",
 				icon:    "there",
@@ -1452,8 +1452,8 @@ func TestAppendCell(t *testing.T) {
 				},
 			},
 			count: 1,
-			expected: state.Row{
-				Results:  []int32{int32(state.Row_PASS), 1},
+			expected: statepb.Row{
+				Results:  []int32{int32(statepb.Row_PASS), 1},
 				CellIds:  []string{"cell-id"},
 				Messages: []string{"hi"},
 				Icons:    []string{"there"},
@@ -1461,7 +1461,7 @@ func TestAppendCell(t *testing.T) {
 					"golden",
 					"pi",
 				},
-				Metrics: []*state.Metric{
+				Metrics: []*statepb.Metric{
 					{
 						Name:    "pi",
 						Indices: []int32{0, 1},
@@ -1477,23 +1477,23 @@ func TestAppendCell(t *testing.T) {
 		},
 		{
 			name: "append same result",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FLAKY), 3,
+					int32(statepb.Row_FLAKY), 3,
 				},
 				CellIds:  []string{"", "", ""},
 				Messages: []string{"", "", ""},
 				Icons:    []string{"", "", ""},
 			},
 			cell: cell{
-				result:  state.Row_FLAKY,
+				result:  statepb.Row_FLAKY,
 				message: "echo",
 				cellID:  "again and",
 				icon:    "keeps going",
 			},
 			count: 2,
-			expected: state.Row{
-				Results:  []int32{int32(state.Row_FLAKY), 5},
+			expected: statepb.Row{
+				Results:  []int32{int32(statepb.Row_FLAKY), 5},
 				CellIds:  []string{"", "", "", "again and", "again and"},
 				Messages: []string{"", "", "", "echo", "echo"},
 				Icons:    []string{"", "", "", "keeps going", "keeps going"},
@@ -1501,22 +1501,22 @@ func TestAppendCell(t *testing.T) {
 		},
 		{
 			name: "append different result",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FLAKY), 3,
+					int32(statepb.Row_FLAKY), 3,
 				},
 				CellIds:  []string{"", "", ""},
 				Messages: []string{"", "", ""},
 				Icons:    []string{"", "", ""},
 			},
 			cell: cell{
-				result: state.Row_PASS,
+				result: statepb.Row_PASS,
 			},
 			count: 2,
-			expected: state.Row{
+			expected: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FLAKY), 3,
-					int32(state.Row_PASS), 2,
+					int32(statepb.Row_FLAKY), 3,
+					int32(statepb.Row_PASS), 2,
 				},
 				CellIds:  []string{"", "", "", "", ""},
 				Messages: []string{"", "", "", "", ""},
@@ -1525,22 +1525,22 @@ func TestAppendCell(t *testing.T) {
 		},
 		{
 			name: "append no result (results, cellIDs, no messages or icons)",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FLAKY), 3,
+					int32(statepb.Row_FLAKY), 3,
 				},
 				CellIds:  []string{"", "", ""},
 				Messages: []string{"", "", ""},
 				Icons:    []string{"", "", ""},
 			},
 			cell: cell{
-				result: state.Row_NO_RESULT,
+				result: statepb.Row_NO_RESULT,
 			},
 			count: 2,
-			expected: state.Row{
+			expected: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FLAKY), 3,
-					int32(state.Row_NO_RESULT), 2,
+					int32(statepb.Row_FLAKY), 3,
+					int32(statepb.Row_NO_RESULT), 2,
 				},
 				CellIds:  []string{"", "", "", "", ""},
 				Messages: []string{"", "", ""},
@@ -1549,8 +1549,8 @@ func TestAppendCell(t *testing.T) {
 		},
 		{
 			name: "add metric to series",
-			row: state.Row{
-				Results:  []int32{int32(state.Row_PASS), 5},
+			row: statepb.Row{
+				Results:  []int32{int32(statepb.Row_PASS), 5},
 				CellIds:  []string{"", "", "", "", "c"},
 				Messages: []string{"", "", "", "", "m"},
 				Icons:    []string{"", "", "", "", "i"},
@@ -1558,7 +1558,7 @@ func TestAppendCell(t *testing.T) {
 					"continued-series",
 					"new-series",
 				},
-				Metrics: []*state.Metric{
+				Metrics: []*statepb.Metric{
 					{
 						Name:    "continued-series",
 						Indices: []int32{0, 5},
@@ -1572,15 +1572,15 @@ func TestAppendCell(t *testing.T) {
 				},
 			},
 			cell: cell{
-				result: state.Row_PASS,
+				result: statepb.Row_PASS,
 				metrics: map[string]float64{
 					"continued-series": 5.1,
 					"new-series":       5.2,
 				},
 			},
 			count: 1,
-			expected: state.Row{
-				Results:  []int32{int32(state.Row_PASS), 6},
+			expected: statepb.Row{
+				Results:  []int32{int32(statepb.Row_PASS), 6},
 				CellIds:  []string{"", "", "", "", "c", ""},
 				Messages: []string{"", "", "", "", "m", ""},
 				Icons:    []string{"", "", "", "", "i", ""},
@@ -1588,7 +1588,7 @@ func TestAppendCell(t *testing.T) {
 					"continued-series",
 					"new-series",
 				},
-				Metrics: []*state.Metric{
+				Metrics: []*statepb.Metric{
 					{
 						Name:    "continued-series",
 						Indices: []int32{0, 6},
@@ -1606,8 +1606,8 @@ func TestAppendCell(t *testing.T) {
 			name:  "add a bunch of initial blank columns (eg a deleted row)",
 			cell:  emptyCell,
 			count: 7,
-			expected: state.Row{
-				Results: []int32{int32(state.Row_NO_RESULT), 7},
+			expected: statepb.Row{
+				Results: []int32{int32(statepb.Row_NO_RESULT), 7},
 				CellIds: []string{"", "", "", "", "", "", ""},
 			},
 		},
@@ -1635,7 +1635,7 @@ func TestAppendCell(t *testing.T) {
 	}
 }
 
-func setupRow(row *state.Row, cells ...cell) *state.Row {
+func setupRow(row *statepb.Row, cells ...cell) *statepb.Row {
 	for _, c := range cells {
 		appendCell(row, c, 1)
 	}
@@ -1645,30 +1645,30 @@ func setupRow(row *state.Row, cells ...cell) *state.Row {
 func TestAppendColumn(t *testing.T) {
 	cases := []struct {
 		name     string
-		grid     state.Grid
+		grid     statepb.Grid
 		col      inflatedColumn
-		expected state.Grid
+		expected statepb.Grid
 	}{
 		{
 			name: "append first column",
-			col:  inflatedColumn{column: &state.Column{Build: "10"}},
-			expected: state.Grid{
-				Columns: []*state.Column{
+			col:  inflatedColumn{column: &statepb.Column{Build: "10"}},
+			expected: statepb.Grid{
+				Columns: []*statepb.Column{
 					{Build: "10"},
 				},
 			},
 		},
 		{
 			name: "append additional column",
-			grid: state.Grid{
-				Columns: []*state.Column{
+			grid: statepb.Grid{
+				Columns: []*statepb.Column{
 					{Build: "10"},
 					{Build: "11"},
 				},
 			},
-			col: inflatedColumn{column: &state.Column{Build: "20"}},
-			expected: state.Grid{
-				Columns: []*state.Column{
+			col: inflatedColumn{column: &statepb.Column{Build: "20"}},
+			expected: statepb.Grid{
+				Columns: []*statepb.Column{
 					{Build: "10"},
 					{Build: "11"},
 					{Build: "20"},
@@ -1678,42 +1678,42 @@ func TestAppendColumn(t *testing.T) {
 		{
 			name: "add rows to first column",
 			col: inflatedColumn{
-				column: &state.Column{Build: "10"},
+				column: &statepb.Column{Build: "10"},
 				cells: map[string]cell{
 					"hello": {
-						result: state.Row_PASS,
+						result: statepb.Row_PASS,
 						cellID: "yes",
 						metrics: map[string]float64{
 							"answer": 42,
 						},
 					},
 					"world": {
-						result:  state.Row_FAIL,
+						result:  statepb.Row_FAIL,
 						message: "boom",
 						icon:    "X",
 					},
 				},
 			},
-			expected: state.Grid{
-				Columns: []*state.Column{
+			expected: statepb.Grid{
+				Columns: []*statepb.Column{
 					{Build: "10"},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "hello",
 							Id:   "hello",
 						},
 						cell{
-							result:  state.Row_PASS,
+							result:  statepb.Row_PASS,
 							cellID:  "yes",
 							metrics: map[string]float64{"answer": 42},
 						}),
-					setupRow(&state.Row{
+					setupRow(&statepb.Row{
 						Name: "world",
 						Id:   "world",
 					}, cell{
-						result:  state.Row_FAIL,
+						result:  statepb.Row_FAIL,
 						message: "boom",
 						icon:    "X",
 					}),
@@ -1722,65 +1722,65 @@ func TestAppendColumn(t *testing.T) {
 		},
 		{
 			name: "add empty cells",
-			grid: state.Grid{
-				Columns: []*state.Column{
+			grid: statepb.Grid{
+				Columns: []*statepb.Column{
 					{Build: "10"},
 					{Build: "11"},
 					{Build: "12"},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					setupRow(
-						&state.Row{Name: "deleted"},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
+						&statepb.Row{Name: "deleted"},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
 					),
 					setupRow(
-						&state.Row{Name: "always"},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
+						&statepb.Row{Name: "always"},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
 					),
 				},
 			},
 			col: inflatedColumn{
-				column: &state.Column{Build: "20"},
+				column: &statepb.Column{Build: "20"},
 				cells: map[string]cell{
-					"always": {result: state.Row_PASS},
-					"new":    {result: state.Row_PASS},
+					"always": {result: statepb.Row_PASS},
+					"new":    {result: statepb.Row_PASS},
 				},
 			},
-			expected: state.Grid{
-				Columns: []*state.Column{
+			expected: statepb.Grid{
+				Columns: []*statepb.Column{
 					{Build: "10"},
 					{Build: "11"},
 					{Build: "12"},
 					{Build: "20"},
 				},
-				Rows: []*state.Row{
+				Rows: []*statepb.Row{
 					setupRow(
-						&state.Row{Name: "deleted"},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
+						&statepb.Row{Name: "deleted"},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
 						emptyCell,
 					),
 					setupRow(
-						&state.Row{Name: "always"},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
-						cell{result: state.Row_PASS},
+						&statepb.Row{Name: "always"},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
+						cell{result: statepb.Row_PASS},
 					),
 					setupRow(
-						&state.Row{
+						&statepb.Row{
 							Name: "new",
 							Id:   "new",
 						},
 						emptyCell,
 						emptyCell,
 						emptyCell,
-						cell{result: state.Row_PASS},
+						cell{result: statepb.Row_PASS},
 					),
 				},
 			},
@@ -1789,7 +1789,7 @@ func TestAppendColumn(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			rows := map[string]*state.Row{}
+			rows := map[string]*statepb.Row{}
 			for _, r := range tc.grid.Rows {
 				rows[r.Name] = r
 			}
@@ -1808,33 +1808,33 @@ func TestAppendColumn(t *testing.T) {
 }
 
 func TestAlertRow(t *testing.T) {
-	var columns []*state.Column
+	var columns []*statepb.Column
 	for i, id := range []string{"a", "b", "c", "d", "e", "f"} {
-		columns = append(columns, &state.Column{
+		columns = append(columns, &statepb.Column{
 			Build:   id,
 			Started: 100 - float64(i),
 		})
 	}
 	cases := []struct {
 		name      string
-		row       state.Row
+		row       statepb.Row
 		failOpen  int
 		passClose int
-		expected  *state.AlertInfo
+		expected  *statepb.AlertInfo
 	}{
 		{
 			name: "never alert by default",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FAIL), 6,
+					int32(statepb.Row_FAIL), 6,
 				},
 			},
 		},
 		{
 			name: "passes do not alert",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_PASS), 6,
+					int32(statepb.Row_PASS), 6,
 				},
 			},
 			failOpen:  1,
@@ -1842,30 +1842,30 @@ func TestAlertRow(t *testing.T) {
 		},
 		{
 			name: "flakes do not alert",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FLAKY), 6,
+					int32(statepb.Row_FLAKY), 6,
 				},
 			},
 			failOpen: 1,
 		},
 		{
 			name: "intermittent failures do not alert",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FAIL), 2,
-					int32(state.Row_PASS), 1,
-					int32(state.Row_FAIL), 2,
+					int32(statepb.Row_FAIL), 2,
+					int32(statepb.Row_PASS), 1,
+					int32(statepb.Row_FAIL), 2,
 				},
 			},
 			failOpen: 3,
 		},
 		{
 			name: "new failures alert",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FAIL), 3,
-					int32(state.Row_PASS), 3,
+					int32(statepb.Row_FAIL), 3,
+					int32(statepb.Row_PASS), 3,
 				},
 				Messages: []string{"hello", "no", "no again", "very wrong"},
 				CellIds:  []string{"yes", "no", "no again", "very wrong"},
@@ -1875,10 +1875,10 @@ func TestAlertRow(t *testing.T) {
 		},
 		{
 			name: "too few passes do not close",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_PASS), 2,
-					int32(state.Row_FAIL), 4,
+					int32(statepb.Row_PASS), 2,
+					int32(statepb.Row_FAIL), 4,
 				},
 				Messages: []string{"nope", "no", "yay", "very wrong"},
 				CellIds:  []string{"wrong", "no", "yep", "very wrong"},
@@ -1889,10 +1889,10 @@ func TestAlertRow(t *testing.T) {
 		},
 		{
 			name: "flakes do not close",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FLAKY), 2,
-					int32(state.Row_FAIL), 4,
+					int32(statepb.Row_FLAKY), 2,
+					int32(statepb.Row_FAIL), 4,
 				},
 				Messages: []string{"nope", "no", "yay", "very wrong"},
 				CellIds:  []string{"wrong", "no", "yep", "very wrong"},
@@ -1902,13 +1902,13 @@ func TestAlertRow(t *testing.T) {
 		},
 		{
 			name: "count failures after flaky passes",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FAIL), 1,
-					int32(state.Row_FLAKY), 1,
-					int32(state.Row_FAIL), 1,
-					int32(state.Row_PASS), 1,
-					int32(state.Row_FAIL), 2,
+					int32(statepb.Row_FAIL), 1,
+					int32(statepb.Row_FLAKY), 1,
+					int32(statepb.Row_FAIL), 1,
+					int32(statepb.Row_PASS), 1,
+					int32(statepb.Row_FAIL), 2,
 				},
 				Messages: []string{"nope", "no", "buu", "wrong", "this one"},
 				CellIds:  []string{"wrong", "no", "buzz", "wrong2", "good job"},
@@ -1919,21 +1919,21 @@ func TestAlertRow(t *testing.T) {
 		},
 		{
 			name: "close alert",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_PASS), 1,
-					int32(state.Row_FAIL), 5,
+					int32(statepb.Row_PASS), 1,
+					int32(statepb.Row_FAIL), 5,
 				},
 			},
 			failOpen: 1,
 		},
 		{
 			name: "track through empty results",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_FAIL), 1,
-					int32(state.Row_NO_RESULT), 1,
-					int32(state.Row_FAIL), 4,
+					int32(statepb.Row_FAIL), 1,
+					int32(statepb.Row_NO_RESULT), 1,
+					int32(statepb.Row_FAIL), 4,
 				},
 				Messages: []string{"yay", "no", "buu", "wrong", "nono"},
 				CellIds:  []string{"yay-cell", "no", "buzz", "wrong2", "nada"},
@@ -1944,12 +1944,12 @@ func TestAlertRow(t *testing.T) {
 		},
 		{
 			name: "track passes through empty results",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_PASS), 1,
-					int32(state.Row_NO_RESULT), 1,
-					int32(state.Row_PASS), 1,
-					int32(state.Row_FAIL), 3,
+					int32(statepb.Row_PASS), 1,
+					int32(statepb.Row_NO_RESULT), 1,
+					int32(statepb.Row_PASS), 1,
+					int32(statepb.Row_FAIL), 3,
 				},
 			},
 			failOpen:  1,
@@ -1957,10 +1957,10 @@ func TestAlertRow(t *testing.T) {
 		},
 		{
 			name: "running cells advance compressed index",
-			row: state.Row{
+			row: statepb.Row{
 				Results: []int32{
-					int32(state.Row_RUNNING), 1,
-					int32(state.Row_FAIL), 5,
+					int32(statepb.Row_RUNNING), 1,
+					int32(statepb.Row_FAIL), 5,
 				},
 				Messages: []string{"running0", "fail1-expected", "fail2", "fail3", "fail4", "fail5"},
 				CellIds:  []string{"wrong", "yep", "no2", "no3", "no4", "no5"},
@@ -2002,7 +2002,7 @@ func TestBuildID(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			col := state.Column{
+			col := statepb.Column{
 				Build: tc.build,
 			}
 			if tc.extra != "" {
@@ -2018,7 +2018,7 @@ func TestBuildID(t *testing.T) {
 func TestStamp(t *testing.T) {
 	cases := []struct {
 		name     string
-		col      *state.Column
+		col      *statepb.Column
 		expected *timestamp.Timestamp
 	}{
 		{
@@ -2026,7 +2026,7 @@ func TestStamp(t *testing.T) {
 		},
 		{
 			name: "no nanos",
-			col: &state.Column{
+			col: &statepb.Column{
 				Started: 2,
 			},
 			expected: &timestamp.Timestamp{
@@ -2036,7 +2036,7 @@ func TestStamp(t *testing.T) {
 		},
 		{
 			name: "has nanos",
-			col: &state.Column{
+			col: &statepb.Column{
 				Started: 1.1,
 			},
 			expected: &timestamp.Timestamp{


### PR DESCRIPTION
Change state -> statepb, add package comment to updater, don't need 'break' in switch statement.

ETA: Also fixed some `go vet` errors (format directives in non-format functions, or %s for complicated values)