### PR TITLE
Continue reprocessing results until they are no longer running.

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -154,6 +154,23 @@ func groupPath(tg configpb.TestGroup) (*gcs.Path, error) {
 	return &p, nil
 }
 
+// truncateRunning filters out all columns until the oldest still running column.
+//
+// If there are 20 columns where all are complete except the 3rd and 7th, this will
+// return the 8th and later columns.
+func truncateRunning(cols []inflatedColumn) []inflatedColumn {
+	if len(cols) == 0 {
+		return cols
+	}
+	var stillRunning int
+	for i, c := range cols {
+		if c.cells["Overall"].result == statepb.Row_RUNNING {
+			stillRunning = i + 1
+		}
+	}
+	return cols[stillRunning:]
+}
+
 func updateGroup(parent context.Context, client gcs.Client, tg configpb.TestGroup, gridPath gcs.Path, concurrency int, write bool, groupTimeout, buildTimeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(parent, groupTimeout)
 	defer cancel()
@@ -181,7 +198,7 @@ func updateGroup(parent context.Context, client gcs.Client, tg configpb.TestGrou
 		log.WithField("path", gridPath).WithError(err).Error("Failed to download existing grid")
 	}
 	if old != nil {
-		oldCols = inflateGrid(old, stop, time.Now().Add(-4*time.Hour))
+		oldCols = truncateRunning(inflateGrid(old, stop, time.Now().Add(-4*time.Hour)))
 	}
 
 	var since *gcs.Path


### PR DESCRIPTION
Currently if jobs take more than 4 hours we will never find their final result: we will continue using the cached running value.

Avoid this by finding the oldest downloaded column that is still running. Drop it and everything more recent than it.
This will allow up to 24 hours for a job to complete (after which time the overall cell will automatically fail with a timeout message.


https://github.com/GoogleCloudPlatform/testgrid/blob/069a9fb0615756af0ba341a478de546517d5e299/pkg/updater/gcs.go#L167-L170