### PR TITLE
Create a beta-summarizer in canary.

### DIFF
--- a/cluster/canary/summarizer.yaml
+++ b/cluster/canary/summarizer.yaml
@@ -28,6 +28,39 @@ spec:
         - --confirm
         - --wait=5m
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: beta-summarizer
+  namespace: testgrid-canary
+  labels:
+    app: testgrid
+    channel: beta
+    component: summarizer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      component: beta-summarizer
+  template:
+    metadata:
+      labels:
+        app: testgrid
+        channel: beta
+        component: summarizer
+    spec:
+      serviceAccountName: summarizer
+      containers:
+      - name: summarizer
+        image: gcr.io/k8s-testgrid/summarizer:v20200807-v0.0.17-8-gd205182
+        args:
+        - --config=gs://k8s-testgrid-canary/config
+        - --confirm
+        - --grid-path=grid
+        - --summary-path=summary
+        - --wait=5m
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
This one will read state from grid/foo instead of foo and write to summary/summary_foo instead of summary_foo.