### PR TITLE
Support junit file names that do not match the regex.

### DIFF
--- a/util/gcs/read.go
+++ b/util/gcs/read.go
@@ -128,7 +128,7 @@ func ListBuilds(parent context.Context, lister Lister, path Path, after *Path) (
 }
 
 // junit_CONTEXT_TIMESTAMP_THREAD.xml
-var re = regexp.MustCompile(`.+/junit(_[^_]+)?(_\d+-\d+)?(_\d+)?\.xml$`)
+var re = regexp.MustCompile(`.+/junit((_[^_]+)?(_\d+-\d+)?(_\d+)?|.+)?\.xml$`)
 
 // dropPrefix removes the _ in _CONTEXT to help keep the regexp simple
 func dropPrefix(name string) string {
@@ -151,10 +151,14 @@ func parseSuitesMeta(name string) map[string]string {
 	if mat == nil {
 		return nil
 	}
+	c, ti, th := dropPrefix(mat[2]), dropPrefix(mat[3]), dropPrefix(mat[4])
+	if c == "" && ti == "" && th == "" {
+		c = mat[1]
+	}
 	return map[string]string{
-		"Context":   dropPrefix(mat[1]),
-		"Timestamp": dropPrefix(mat[2]),
-		"Thread":    dropPrefix(mat[3]),
+		"Context":   c,
+		"Timestamp": ti,
+		"Thread":    th,
 	}
 
 }

--- a/util/gcs/read_test.go
+++ b/util/gcs/read_test.go
@@ -270,6 +270,11 @@ func TestParseSuitesMeta(t *testing.T) {
 			timestamp: "20180102-1234",
 			thread:    "5555",
 		},
+		{
+			name:    "accept weird junit name",
+			input:   "./junit.e2e_suite.3.xml",
+			context: ".e2e_suite.3",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
We expect a format like: `junit.xml` or `junit_something.xml` or `junit_context_12-34_56.xml`.
Currently this rejects something like `junit.e2e.xml`. This change will put `.e2e` into context.
And also allow the updater to process these results.

In short, anything that both starts with `junit` and ends with `.xml` we want to try and process.

fixes https://github.com/GoogleCloudPlatform/testgrid/issues/213