### PR TITLE
Switch seconds-elapsed to test-duration-minutes

### DIFF
--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -177,14 +177,14 @@ func overallCell(result gcsResult) cell {
 	return c
 }
 
-const elapsedKey = "seconds-elapsed"
+const elapsedKey = "test-duration-minutes"
 
 // setElapsed inserts the seconds-elapsed metric.
 func setElapsed(metrics map[string]float64, seconds float64) map[string]float64 {
 	if metrics == nil {
 		metrics = map[string]float64{}
 	}
-	metrics[elapsedKey] = seconds
+	metrics[elapsedKey] = seconds / 60
 	return metrics
 }
 

--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -579,7 +579,7 @@ func TestSetElapsed(t *testing.T) {
 			name:    "nil map works",
 			seconds: 10,
 			expected: map[string]float64{
-				elapsedKey: 10,
+				elapsedKey: 10 / 60.0,
 			},
 		},
 		{
@@ -590,17 +590,17 @@ func TestSetElapsed(t *testing.T) {
 			seconds: 5,
 			expected: map[string]float64{
 				"hello":    7,
-				elapsedKey: 5,
+				elapsedKey: 5 / 60.0,
 			},
 		},
 		{
 			name: "override existing value",
 			metrics: map[string]float64{
-				elapsedKey: 3,
+				elapsedKey: 3 / 60.0,
 			},
 			seconds: 10,
 			expected: map[string]float64{
-				elapsedKey: 10,
+				elapsedKey: 10 / 60.0,
 			},
 		},
 	}

--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -164,7 +164,7 @@ func TestReadColumns(t *testing.T) {
 							icon:    "F",
 							message: "Build failed outside of test results",
 							metrics: map[string]float64{
-								"seconds-elapsed": 11,
+								"test-duration-minutes": 11 / 60.0,
 							},
 						},
 					},
@@ -178,7 +178,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 10,
+								"test-duration-minutes": 10 / 60.0,
 							},
 						},
 					},
@@ -248,7 +248,7 @@ func TestReadColumns(t *testing.T) {
 							icon:    "F",
 							message: "Build failed outside of test results",
 							metrics: map[string]float64{
-								"seconds-elapsed": 11,
+								"test-duration-minutes": 11 / 60.0,
 							},
 						},
 					},
@@ -266,7 +266,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 10,
+								"test-duration-minutes": 10 / 60.0,
 							},
 						},
 					},
@@ -324,7 +324,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 10,
+								"test-duration-minutes": 10 / 60.0,
 							},
 						},
 						"name good - context context-a - thread 33": {
@@ -401,7 +401,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 12,
+								"test-duration-minutes": 12 / 60.0,
 							},
 						},
 					},
@@ -415,7 +415,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 11,
+								"test-duration-minutes": 11 / 60.0,
 							},
 						},
 					},
@@ -488,7 +488,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 13,
+								"test-duration-minutes": 13 / 60.0,
 							},
 						},
 					},
@@ -502,7 +502,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 12,
+								"test-duration-minutes": 12 / 60.0,
 							},
 						},
 					},
@@ -576,7 +576,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 13,
+								"test-duration-minutes": 13 / 60.0,
 							},
 						},
 					},
@@ -590,7 +590,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 12,
+								"test-duration-minutes": 12 / 60.0,
 							},
 						},
 					},
@@ -604,7 +604,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 11,
+								"test-duration-minutes": 11 / 60.0,
 							},
 						},
 					},
@@ -618,7 +618,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 10,
+								"test-duration-minutes": 10 / 60.0,
 							},
 						},
 					},
@@ -692,7 +692,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 13,
+								"test-duration-minutes": 13 / 60.0,
 							},
 						},
 					},
@@ -706,7 +706,7 @@ func TestReadColumns(t *testing.T) {
 						"Overall": {
 							result: statuspb.TestStatus_PASS,
 							metrics: map[string]float64{
-								"seconds-elapsed": 12,
+								"test-duration-minutes": 12 / 60.0,
 							},
 						},
 					},


### PR DESCRIPTION
The python version uses `test-duration-minutes` rather than `seconds-elapsed` and lots of jobs seem to take many minutes to finish.

ref https://github.com/GoogleCloudPlatform/testgrid/issues/211