### PR TITLE
Handle xml documents with invalid utf-8 messages

### DIFF
--- a/metadata/junit/junit.go
+++ b/metadata/junit/junit.go
@@ -23,6 +23,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strings"
+	"unicode/utf8"
 )
 
 // Suites holds a <testsuites/> list of Suite results
@@ -105,12 +107,14 @@ func (jr Result) Message(max int) string {
 	case jr.Output != nil && *jr.Output != "":
 		msg = *jr.Output
 	}
-	l := len(msg)
-	if max == 0 || l <= max {
+	if l := len(msg); max > 0 && l > max {
+		h := max / 2
+		msg = msg[:h] + "..." + msg[l-h:]
+	}
+	if utf8.ValidString(msg) {
 		return msg
 	}
-	h := max / 2
-	return msg[:h] + "..." + msg[l-h-1:]
+	return fmt.Sprintf("invalid utf8: %s", strings.ToValidUTF8(msg, "?"))
 }
 
 func unmarshalXML(buf []byte, i interface{}) error {


### PR DESCRIPTION
ref https://github.com/GoogleCloudPlatform/testgrid/issues/236

Ensure that `row.Message()` is a valid UTF8 string.
Unit test this function.

Redhat occasionally has errors like the following:
```
ERRO[0003]pkg/updater/updater.go:71 github.com/GoogleCloudPlatform/testgrid/pkg/updater.Update.func1() Error updating group                          config="gs://k8s-testgrid/config" error="marshal grid: marshal: proto: field \"Row.Messages\" contains invalid UTF-8" group=release-openshift-ocp-installer-console-aws-4.6
```

This causes the updater to stop updating when it finds that column, which then results in everything after it failing to load.