### PR TITLE
Write hotlist IDs to summary.

### DIFF
--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -464,6 +464,7 @@ func failingTestSummaries(rows []*statepb.Row) []*summarypb.FailingTestSummary {
 			LinkedBugs:    row.BugId,
 			FailTestLink:  buildFailLink(alert.FailTestId, row.Id),
 			Properties:    alert.Properties,
+			HotlistIds:    alert.HotlistIds,
 		}
 		if alert.PassTime != nil {
 			sum.PassTimestamp = float64(alert.PassTime.Seconds)

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -1095,6 +1095,7 @@ func TestFailingTestSummaries(t *testing.T) {
 						Properties: map[string]string{
 							"ham": "eggs",
 						},
+						HotlistIds: []string{},
 					},
 				},
 				{},
@@ -1116,6 +1117,7 @@ func TestFailingTestSummaries(t *testing.T) {
 							"foo":   "bar",
 							"hello": "lots",
 						},
+						HotlistIds: []string{"111", "222"},
 					},
 				},
 				{},
@@ -1137,6 +1139,7 @@ func TestFailingTestSummaries(t *testing.T) {
 					Properties: map[string]string{
 						"ham": "eggs",
 					},
+					HotlistIds: []string{},
 				},
 				{
 					DisplayName:       "bar-name",
@@ -1155,6 +1158,7 @@ func TestFailingTestSummaries(t *testing.T) {
 						"foo":   "bar",
 						"hello": "lots",
 					},
+					HotlistIds: []string{"111", "222"},
 				},
 			},
 		},


### PR DESCRIPTION
This will properly record hotlist IDs from alerts into summary, for use in components like AutoBug.