### PR TITLE
Run canary updater less frequently.

### DIFF
--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -24,6 +24,7 @@ spec:
       - name: updater
         image: gcr.io/k8s-testgrid/updater:v20201203-v0.0.31-5-g5f8e850
         args:
+        - --build-concurrency=4
         - --build-timeout=10m
         - --config=gs://k8s-testgrid-canary/config
         - --confirm

--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -28,7 +28,7 @@ spec:
         - --config=gs://k8s-testgrid-canary/config
         - --confirm
         - --group-timeout=60m
-        - --wait=5m
+        - --wait=3h
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Still runs immediately after each update

/hold