### PR TITLE
Promote v20201203-v0.0.31-5-g5f8e850 to prod

### DIFF
--- a/cluster/prod/summarizer.yaml
+++ b/cluster/prod/summarizer.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: summarizer
       containers:
       - name: summarizer
-        image: gcr.io/k8s-testgrid/summarizer:v20201020-v0.0.25-8-g957c387
+        image: gcr.io/k8s-testgrid/summarizer:v20201203-v0.0.31-5-g5f8e850
         args:
         - --config=gs://k8s-testgrid/config
         - --confirm
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: summarizer
       containers:
       - name: summarizer
-        image: gcr.io/k8s-testgrid/summarizer:v20201020-v0.0.25-8-g957c387
+        image: gcr.io/k8s-testgrid/summarizer:v20201203-v0.0.31-5-g5f8e850
         args:
         - --config=gs://k8s-testgrid/config
         - --confirm

--- a/cluster/prod/updater.yaml
+++ b/cluster/prod/updater.yaml
@@ -22,8 +22,9 @@ spec:
       serviceAccountName: updater
       containers:
       - name: updater
-        image: gcr.io/k8s-testgrid/updater:v20201020-v0.0.25-8-g957c387
+        image: gcr.io/k8s-testgrid/updater:v20201203-v0.0.31-5-g5f8e850
         args:
+        - --build-concurrency=4
         - --build-timeout=10m
         - --config=gs://k8s-testgrid/config
         - --confirm


### PR DESCRIPTION
Also limit concurrent build updates to 4 per group (matching canary)