### PR TITLE
Fix readColumns race condition

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -124,6 +124,8 @@ func Update(parent context.Context, client gcs.Client, configPath gcs.Path, grid
 
 	groups := make(chan configpb.TestGroup)
 	var wg sync.WaitGroup
+	defer wg.Wait()
+	defer close(groups)
 
 	for i := 0; i < groupConcurrency; i++ {
 		wg.Add(1)
@@ -168,8 +170,6 @@ func Update(parent context.Context, client gcs.Client, configPath gcs.Path, grid
 			groups <- *tg
 		}
 	}
-	close(groups)
-	wg.Wait()
 	return nil
 }
 


### PR DESCRIPTION
Calling `wg.Add(1)` inside a goroutine races with `wg.Wait()` on the main thread.

Fix this by creating a `stopWG` 

See https://golang.org/pkg/sync/#WaitGroup.Add