### PR TITLE
Throttle group and build concurrency based on memory usage.

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -46,6 +46,9 @@ type options struct {
 	buildTimeout     time.Duration
 	gridPrefix       string
 	jsonLogs         bool
+
+	groupMemory uint64
+	buildMemory uint64
 }
 
 // validate ensures sane options
@@ -61,13 +64,15 @@ func (o *options) validate() error {
 	}
 	if o.buildConcurrency == 0 {
 		o.buildConcurrency = runtime.NumCPU()
-		if o.buildConcurrency > 4 {
-			o.buildConcurrency = 4
-		}
 	}
 
 	return nil
 }
+
+const (
+	defaultBuildMemory = 1e9 // 1G
+	defaultGroupMemory = 4e9 // 4G
+)
 
 // gatherOptions reads options from flags
 func gatherFlagOptions(fs *flag.FlagSet, args ...string) options {
@@ -85,6 +90,8 @@ func gatherFlagOptions(fs *flag.FlagSet, args ...string) options {
 	fs.DurationVar(&o.buildTimeout, "build-timeout", 3*time.Minute, "Maximum time to wait to read each build")
 	fs.StringVar(&o.gridPrefix, "grid-prefix", "grid", "Join this with the grid name to create the GCS suffix")
 	fs.BoolVar(&o.jsonLogs, "json-logs", false, "Uses a json logrus formatter when set")
+	fs.Uint64Var(&o.buildMemory, "build-memory", defaultBuildMemory, "Minimum free memory to read a new build")
+	fs.Uint64Var(&o.groupMemory, "group-memory", defaultGroupMemory, "Minimum free memory to read a new group")
 	fs.Parse(args)
 	return o
 }
@@ -129,6 +136,8 @@ func main() {
 		"group": opt.groupConcurrency,
 		"build": opt.buildConcurrency,
 	}).Info("Configured concurrency")
+
+	updater.GroupThrottle, updater.BuildThrottle = updater.MemThrottle(ctx, opt.groupMemory, opt.buildMemory)
 
 	groupUpdater := updater.GCS(opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm)
 	updateOnce := func() {

--- a/cmd/updater/main_test.go
+++ b/cmd/updater/main_test.go
@@ -114,16 +114,14 @@ func TestGatherFlagOptions(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ceil := runtime.NumCPU()
-			if ceil > 4 {
-				ceil = 4
-			}
 			expected := options{
 				buildTimeout:     3 * time.Minute,
-				buildConcurrency: ceil,
+				buildConcurrency: runtime.NumCPU(),
 				groupConcurrency: runtime.NumCPU(),
 				groupTimeout:     10 * time.Minute,
 				gridPrefix:       "grid",
+				groupMemory:      defaultGroupMemory,
+				buildMemory:      defaultBuildMemory,
 			}
 			if tc.expected != nil {
 				tc.expected(&expected)

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,15 @@ module github.com/GoogleCloudPlatform/testgrid
 
 require (
 	cloud.google.com/go/storage v1.10.1-0.20200805182106-fcd132957b02
+	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/client9/misspell v0.3.4
 	github.com/fvbommel/sortorder v1.0.1
+	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.1
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/shirou/gopsutil v3.20.11+incompatible
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
 	google.golang.org/api v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
+github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -60,6 +62,8 @@ github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui72
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
+github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
@@ -140,6 +144,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/shirou/gopsutil v3.20.11+incompatible h1:LJr4ZQK4mPpIV5gOa4jCOKOGb4ty4DZO54I4FGqIpto=
+github.com/shirou/gopsutil v3.20.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "gcs.go",
         "inflate.go",
+        "mem.go",
         "read.go",
         "updater.go",
     ],
@@ -21,6 +22,7 @@ go_library(
         "//util/gcs:go_default_library",
         "@com_github_fvbommel_sortorder//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_shirou_gopsutil//mem:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",

--- a/pkg/updater/mem.go
+++ b/pkg/updater/mem.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2020 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package updater
+
+import (
+	"context"
+	"time"
+
+	"github.com/shirou/gopsutil/mem"
+	"github.com/sirupsen/logrus"
+)
+
+// MemThrottle returns a group and build channel that ensures insufficient memory exists.
+func MemThrottle(ctx context.Context, groupSize, buildSize uint64) (<-chan int, <-chan int) {
+	group := make(chan int)
+	build := make(chan int)
+	go func() {
+		defer close(group)
+		defer close(build)
+
+		var lastNote string
+		var log logrus.FieldLogger
+		note := func(s string) {
+			if lastNote == s {
+				log.Debug(s)
+			} else {
+				log.Info(s)
+			}
+			lastNote = s
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			vm, err := mem.VirtualMemory()
+			if err != nil {
+				logrus.WithError(err).Warning("Failed to determine free memory")
+				time.Sleep(time.Second)
+				continue
+			}
+			avail := vm.Available
+			log = logrus.WithField("available", avail)
+			switch {
+			case avail > groupSize:
+				note("Starting group or build")
+				select {
+				case <-ctx.Done():
+					return
+				case group <- 1:
+				case build <- 1:
+				}
+			case avail > buildSize:
+				note("Staring build")
+				select {
+				case <-ctx.Done():
+					return
+				case build <- 1:
+				}
+			default:
+				note("Waiting for free memory")
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	}()
+	return group, build
+}

--- a/pkg/updater/read.go
+++ b/pkg/updater/read.go
@@ -57,6 +57,9 @@ func downloadGrid(ctx context.Context, opener gcs.Opener, path gcs.Path) (*state
 	return &g, err
 }
 
+// BuildThrottle allows control over starting to read a new column.
+var BuildThrottle <-chan int
+
 // readColumns will list, download and process builds into inflatedColumns.
 func readColumns(parent context.Context, client gcs.Downloader, group *configpb.TestGroup, builds []gcs.Build, stopTime time.Time, max int, buildTimeout time.Duration, concurrency int) ([]inflatedColumn, error) {
 	// Spawn build readers
@@ -94,6 +97,15 @@ func readColumns(parent context.Context, client gcs.Downloader, group *configpb.
 		defer wg.Done()
 		defer close(indices)
 		for i := range builds {
+			if BuildThrottle != nil {
+				select {
+				case <-ctx.Done():
+					return
+				case <-old:
+					return
+				case <-BuildThrottle:
+				}
+			}
 			select {
 			case <-ctx.Done():
 				return

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -112,6 +112,9 @@ func sortGroups(ctx context.Context, log logrus.FieldLogger, client gcs.Stater, 
 	return nil
 }
 
+// GroupThrottle allows control over starting to read a new group.
+var GroupThrottle <-chan int
+
 func Update(parent context.Context, client gcs.Client, configPath gcs.Path, gridPrefix string, groupConcurrency int, group string, updateGroup GroupUpdater) error {
 	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
@@ -130,6 +133,13 @@ func Update(parent context.Context, client gcs.Client, configPath gcs.Path, grid
 	for i := 0; i < groupConcurrency; i++ {
 		wg.Add(1)
 		go func() {
+			if GroupThrottle != nil {
+				select {
+				case <-ctx.Done():
+					return
+				case <-GroupThrottle:
+				}
+			}
 			for tg := range groups {
 				log := log.WithField("group", tg.Name)
 				tgp, err := testGroupPath(configPath, gridPrefix, tg.Name)
@@ -205,7 +215,10 @@ func logUpdate(ch <-chan int, total int, msg string) {
 			}
 		case now := <-timer.C:
 			elapsed := now.Sub(start)
-			rate := elapsed / time.Duration(current)
+			var rate time.Duration
+			if current > 0 {
+				rate = elapsed / time.Duration(current)
+			}
 			eta := time.Duration(total-current) * rate
 
 			logrus.WithFields(logrus.Fields{

--- a/repos.bzl
+++ b/repos.bzl
@@ -653,3 +653,27 @@ def go_repositories():
         sum = "h1:pMen7vLs8nvgEYhywH3KDWJIJTeEr2ULsVWHWYHQyBs=",
         version = "v3.0.0",
     )
+    go_repository(
+        name = "com_github_go_ole_go_ole",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/go-ole/go-ole",
+        sum = "h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=",
+        version = "v1.2.4",
+    )
+    go_repository(
+        name = "com_github_shirou_gopsutil",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/shirou/gopsutil",
+        sum = "h1:LJr4ZQK4mPpIV5gOa4jCOKOGb4ty4DZO54I4FGqIpto=",
+        version = "v3.20.11+incompatible",
+    )
+    go_repository(
+        name = "com_github_stackexchange_wmi",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/StackExchange/wmi",
+        sum = "h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=",
+        version = "v0.0.0-20190523213315-cbe66965904d",
+    )


### PR DESCRIPTION
Allows --group-memory and --build-memory to ensure that at least that much memory is free in order to
start processing a new group/build.

Also fix a divide-by-zero edge case and allow NumCPU concurrent builds again by default