### PR TITLE
Update XML unmarshalling.

### DIFF
--- a/metadata/junit/junit.go
+++ b/metadata/junit/junit.go
@@ -27,10 +27,34 @@ import (
 	"unicode/utf8"
 )
 
+type suiteOrSuites struct {
+	suites Suites
+}
+
+func (s *suiteOrSuites) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	switch start.Name.Local {
+	case "testsuites":
+		d.DecodeElement(&s.suites, &start)
+	case "testsuite":
+		var suite Suite
+		d.DecodeElement(&suite, &start)
+		s.suites.Suites = append(s.suites.Suites, suite)
+	default:
+		return fmt.Errorf("bad element name: %q", start.Name)
+	}
+	return nil
+}
+
 // Suites holds a <testsuites/> list of Suite results
 type Suites struct {
 	XMLName xml.Name `xml:"testsuites"`
 	Suites  []Suite  `xml:"testsuite"`
+}
+
+func (s *Suites) Truncate(max int) {
+	for i := range s.Suites {
+		s.Suites[i].Truncate(max)
+	}
 }
 
 // Suite holds <testsuite/> results
@@ -45,6 +69,16 @@ type Suite struct {
 	/*
 	* <properties><property name="go.version" value="go1.8.3"/></properties>
 	 */
+}
+
+// Truncate ensures that strings do not exceed the specified length.
+func (s *Suite) Truncate(max int) {
+	for i := range s.Suites {
+		s.Suites[i].Truncate(max)
+	}
+	for i := range s.Results {
+		s.Results[i].Truncate(max)
+	}
 }
 
 // Property defines the xml element that stores additional metrics about each benchmark.
@@ -107,18 +141,41 @@ func (jr Result) Message(max int) string {
 	case jr.Output != nil && *jr.Output != "":
 		msg = *jr.Output
 	}
-	if l := len(msg); max > 0 && l > max {
-		h := max / 2
-		msg = msg[:h] + "..." + msg[l-h:]
-	}
+	msg = truncate(msg, max)
 	if utf8.ValidString(msg) {
 		return msg
 	}
 	return fmt.Sprintf("invalid utf8: %s", strings.ToValidUTF8(msg, "?"))
 }
 
-func unmarshalXML(buf []byte, i interface{}) error {
-	reader := bytes.NewReader(buf)
+func truncate(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	l := len(s)
+	if l < max {
+		return s
+	}
+	h := max / 2
+	return s[:h] + "..." + s[l-h:]
+}
+
+func truncatePointer(str *string, max int) {
+	if str == nil {
+		return
+	}
+	s := truncate(*str, max)
+	str = &s
+}
+
+// Truncate ensures that strings do not exceed the specified length.
+func (jr Result) Truncate(max int) {
+	for _, s := range []*string{jr.Failure, jr.Skipped, jr.Error, jr.Output} {
+		truncatePointer(s, max)
+	}
+}
+
+func unmarshalXML(reader io.Reader, i interface{}) error {
 	dec := xml.NewDecoder(reader)
 	dec.CharsetReader = func(charset string, input io.Reader) (io.Reader, error) {
 		switch charset {
@@ -132,21 +189,22 @@ func unmarshalXML(buf []byte, i interface{}) error {
 	return dec.Decode(i)
 }
 
-func Parse(buf []byte) (Suites, error) {
-	var suites Suites
+// Parse returns the Suites representation of these XML bytes.
+func Parse(buf []byte) (*Suites, error) {
 	if len(buf) == 0 {
-		return suites, nil
+		return &Suites{}, nil
 	}
+	reader := bytes.NewReader(buf)
+	return ParseStream(reader)
+}
+
+// ParseStream reads bytes into a Suites object.
+func ParseStream(reader io.Reader) (*Suites, error) {
 	// Try to parse it as a <testsuites/> object
-	err := unmarshalXML(buf, &suites)
+	var s suiteOrSuites
+	err := unmarshalXML(reader, &s)
 	if err != nil {
-		// Maybe it is a <testsuite/> object instead
-		suites.Suites = append([]Suite(nil), Suite{})
-		ie := unmarshalXML(buf, &suites.Suites[0])
-		if ie != nil {
-			// Nope, it just doesn't parse
-			return suites, fmt.Errorf("not valid testsuites: %v nor testsuite: %v", err, ie)
-		}
+		return nil, err
 	}
-	return suites, nil
+	return &s.suites, nil
 }

--- a/metadata/junit/junit_test.go
+++ b/metadata/junit/junit_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package junit
 
 import (
+	"bytes"
 	"encoding/xml"
 	"testing"
 
@@ -171,16 +172,26 @@ func TestParse(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := Parse(tc.buf)
+			str := string(tc.buf)
 			switch {
 			case err != nil:
 				if tc.expected != nil {
-					t.Errorf("Parse(%v) got unexpected error: %v", tc.buf, err)
+					t.Errorf("Parse(%q) got unexpected error: %v", str, err)
 				}
 			case tc.expected == nil:
-				t.Errorf("Parse(%v) got %v, wanted an error", tc.buf, actual)
+				t.Errorf("Parse(%q) got %v, wanted an error", str, actual)
 			default:
-				if diff := cmp.Diff(actual, *tc.expected); diff != "" {
-					t.Errorf("Parse(%v) got unexpected diff:\n%s", tc.buf, diff)
+				if diff := cmp.Diff(actual, tc.expected); diff != "" {
+					t.Errorf("Parse(%q) got unexpected diff:\n%s", str, diff)
+				}
+			}
+			if len(tc.buf) > 0 && err == nil {
+				streamActual, err := ParseStream(bytes.NewReader(tc.buf))
+				if err != nil {
+					t.Errorf("ParseStream() got unexpected error: %v", err)
+				}
+				if diff := cmp.Diff(actual, streamActual); diff != "" {
+					t.Errorf("ParseStream() got unexpected diff:\n%s", diff)
 				}
 			}
 		})

--- a/util/gcs/read.go
+++ b/util/gcs/read.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"regexp"
 	"sort"
@@ -273,15 +272,11 @@ func readSuites(ctx context.Context, opener Opener, p Path) (*junit.Suites, erro
 		return nil, fmt.Errorf("open: %w", err)
 	}
 	defer r.Close()
-	buf, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, fmt.Errorf("read: %w", err)
-	}
-	suitesMeta, err := junit.Parse(buf)
+	suitesMeta, err := junit.ParseStream(r)
 	if err != nil {
 		return nil, fmt.Errorf("parse: %w", err)
 	}
-	return &suitesMeta, nil
+	return suitesMeta, nil
 }
 
 // Suites takes a channel of artifact names, parses those representing junit suites, writing the result to the suites channel.


### PR DESCRIPTION
* Improve how we distinguish between `<testsuite>` or `<testsuites>`
* This allows unmarshalling a stream
* Add ability to truncate long strings to a specified length