### PR TITLE
Automatically truncate junit suites.

### DIFF
--- a/metadata/junit/junit.go
+++ b/metadata/junit/junit.go
@@ -42,6 +42,7 @@ func (s *suiteOrSuites) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	default:
 		return fmt.Errorf("bad element name: %q", start.Name)
 	}
+	s.suites.Truncate(10000)
 	return nil
 }
 

--- a/pkg/updater/read.go
+++ b/pkg/updater/read.go
@@ -334,6 +334,8 @@ func readSuites(parent context.Context, client gcs.Downloader, build gcs.Build) 
 			if !more {
 				return suites, nil
 			}
+			const max = 1000
+			suite.Suites.Truncate(max)
 			suites = append(suites, suite)
 		}
 	}


### PR DESCRIPTION
* 10K when parsing XML
* 1K when putting them into a column.


These strings will get truncated to 140 chars by testgrid later, this minimizes memory overhead during that time.