### PR TITLE
Create ConditionalClient and Copier, allows multiple updater pods

### DIFF
--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+        "@org_golang_google_api//googleapi:go_default_library",
     ],
 )
 

--- a/pkg/updater/read.go
+++ b/pkg/updater/read.go
@@ -334,8 +334,7 @@ func readSuites(parent context.Context, client gcs.Downloader, build gcs.Build) 
 			if !more {
 				return suites, nil
 			}
-			const max = 1000
-			suite.Suites.Truncate(max)
+			suite.Suites.Truncate(1000)
 			suites = append(suites, suite)
 		}
 	}

--- a/util/gcs/client.go
+++ b/util/gcs/client.go
@@ -55,24 +55,62 @@ type Stater interface {
 	Stat(ctx context.Context, prefix Path) (*storage.ObjectAttrs, error)
 }
 
+// A copier can cloud copy an object to a new location if it
+type Copier interface {
+	// Copy an object to the specified path
+	Copy(ctx context.Context, from, to Path) error
+}
+
 // A Client can upload, download and stat.
 type Client interface {
 	Uploader
 	Downloader
 	Stater
+	Copier
+}
+
+// A ConditionalClient can limit actions to those matching conditions.
+type ConditionalClient interface {
+	Client
+	// If specifies conditions on the object read from and/or written to.
+	If(read, write *storage.Conditions) ConditionalClient
 }
 
 // NewClient returns a GCSUploadClient for the storage.Client.
-func NewClient(client *storage.Client) Client {
-	return realGCSClient{client}
+func NewClient(client *storage.Client) ConditionalClient {
+	return realGCSClient{client, nil, nil}
 }
 
 type realGCSClient struct {
-	client *storage.Client
+	client    *storage.Client
+	readCond  *storage.Conditions
+	writeCond *storage.Conditions
+}
+
+func (rgc realGCSClient) If(read, write *storage.Conditions) ConditionalClient {
+	return realGCSClient{
+		client:    rgc.client,
+		readCond:  read,
+		writeCond: write,
+	}
+}
+
+func (rgc realGCSClient) handle(path Path, cond *storage.Conditions) *storage.ObjectHandle {
+	oh := rgc.client.Bucket(path.Bucket()).Object(path.Object())
+	if cond == nil {
+		return oh
+	}
+	return oh.If(*cond)
+}
+
+func (rgc realGCSClient) Copy(ctx context.Context, from, to Path) error {
+	fromH := rgc.handle(from, rgc.readCond)
+	_, err := rgc.handle(to, rgc.writeCond).CopierFrom(fromH).Run(ctx)
+	return err
 }
 
 func (rgc realGCSClient) Open(ctx context.Context, path Path) (io.ReadCloser, error) {
-	r, err := rgc.client.Bucket(path.Bucket()).Object(path.Object()).NewReader(ctx)
+	r, err := rgc.handle(path, rgc.readCond).NewReader(ctx)
 	return r, err
 }
 
@@ -89,9 +127,9 @@ func (rgc realGCSClient) Objects(ctx context.Context, path Path, delimiter, star
 }
 
 func (rgc realGCSClient) Upload(ctx context.Context, path Path, buf []byte, worldReadable bool, cacheControl string) error {
-	return Upload(ctx, rgc.client, path, buf, worldReadable, cacheControl)
+	return UploadHandle(ctx, rgc.handle(path, rgc.writeCond), buf, worldReadable, cacheControl)
 }
 
 func (rgc realGCSClient) Stat(ctx context.Context, path Path) (*storage.ObjectAttrs, error) {
-	return rgc.client.Bucket(path.Bucket()).Object(path.Object()).Attrs(ctx)
+	return rgc.handle(path, rgc.readCond).Attrs(ctx)
 }


### PR DESCRIPTION
* Copier extends Client to allow copying.
* ConditionalClient extends client to require operations to meet prerequisites in order to run.

Use ConditionalClient to conditionally cloud copy an object before
starting. This will allow multiple worker pods to update in parallel
without central coordination:
* If multiple attempt workers to update the same group, only one will
  win the conditionally clone the object.
* Winner updates the object, others continue on to subsequent objects

Also mitigates against a problematic group or groups stopping updates for everyone:
* Before attempting to update the problematic group, the updater locks the group which bumps its last update timestamp
* Thus if the updater crashes, the problematic group will be at the end of the queue upon restart.