### PR TITLE
Update canary to v20201216-v0.0.33-28-g01968e7

### DIFF
--- a/cluster/canary/summarizer.yaml
+++ b/cluster/canary/summarizer.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: summarizer
       containers:
       - name: summarizer
-        image: gcr.io/k8s-testgrid/summarizer:v20201211-v0.0.33-12-gca2f05b
+        image: gcr.io/k8s-testgrid/summarizer:v20201216-v0.0.33-28-g01968e7
         args:
         - --config=gs://k8s-testgrid-canary/config
         - --confirm
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: summarizer
       containers:
       - name: summarizer
-        image: gcr.io/k8s-testgrid/summarizer:v20201211-v0.0.33-12-gca2f05b
+        image: gcr.io/k8s-testgrid/summarizer:v20201216-v0.0.33-28-g01968e7
         args:
         - --config=gs://k8s-testgrid-canary/config
         - --confirm

--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -8,7 +8,7 @@ metadata:
     component: updater
     app: testgrid
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: testgrid
@@ -22,13 +22,12 @@ spec:
       serviceAccountName: updater
       containers:
       - name: updater
-        image: gcr.io/k8s-testgrid/updater:v20201211-v0.0.33-12-gca2f05b
+        image: gcr.io/k8s-testgrid/updater:v20201216-v0.0.33-28-g01968e7
         args:
-        - --build-concurrency=4
-        - --build-timeout=10m
+        - --build-timeout=1m
         - --config=gs://k8s-testgrid-canary/config
         - --confirm
-        - --group-timeout=60m
+        - --group-timeout=5m
         - --wait=3h
 ---
 apiVersion: v1


### PR DESCRIPTION
Also:
* drop --group-timeout to 5m (from 60m)
* drop --build-timeout to 1m (from 10m)
* increase updater replicas to 2 (from 1)