### PR TITLE
Reduce frequency of canary summarizers to 1 hour.

### DIFF
--- a/cluster/canary/summarizer.yaml
+++ b/cluster/canary/summarizer.yaml
@@ -29,7 +29,7 @@ spec:
         args:
         - --config=gs://k8s-testgrid-canary/config
         - --confirm
-        - --wait=5m
+        - --wait=1h
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -63,7 +63,7 @@ spec:
         - --confirm
         - --grid-path=grid
         - --summary-path=summary
-        - --wait=5m
+        - --wait=1h
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
The canary updaters have a 3h cycle, so this is plenty.