### PR TITLE
Improve sleep message.

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -146,8 +146,12 @@ func main() {
 	timer := time.NewTimer(opt.wait)
 	defer timer.Stop()
 	for range timer.C {
+		until := time.Now().Add(opt.wait).Round(time.Second)
 		timer.Reset(opt.wait)
 		updateOnce()
-		logrus.WithField("wait", opt.wait).Info("Sleeping...")
+		logrus.WithFields(logrus.Fields{
+			"wait":  opt.wait,
+			"until": until,
+		}).Info("Sleeping...")
 	}
 }


### PR DESCRIPTION
The sleeping wait=5m is generally erroneous.
The time spent doing the update is subtracted from the wait time.
This is a substantial amount of time, often more than the wait period.
This means the next update happens much quicker.

Add the until field to make it more obvious when sleeping should stop.