### PR TITLE
Remove info for k8s robot from testgrid autobump config

### DIFF
--- a/cluster/testgrid-canary-autobump-config.yaml
+++ b/cluster/testgrid-canary-autobump-config.yaml
@@ -1,8 +1,6 @@
 ---
-gitHubLogin: "k8s-ci-robot"
+gitHubLogin: "google-oss-robot"
 gitHubToken: "/etc/github-token/oauth"
-gitName: "Kubernetes Prow Robot"
-gitEmail: "k8s.ci.robot@gmail.com"
 onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
 skipPullRequest: false
 gitHubOrg: "GoogleCloudPlatform"

--- a/cluster/testgrid-prod-autobump-config.yaml
+++ b/cluster/testgrid-prod-autobump-config.yaml
@@ -1,8 +1,6 @@
 ---
-gitHubLogin: "k8s-ci-robot"
+gitHubLogin: "google-oss-robot"
 gitHubToken: "/etc/github-token/oauth"
-gitName: "Kubernetes Prow Robot"
-gitEmail: "k8s.ci.robot@gmail.com"
 onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
 skipPullRequest: false
 gitHubOrg: "GoogleCloudPlatform"


### PR DESCRIPTION
The git name and email currently in the config are for the k8s-prow robot, which is not the one doing the autobump for testgrid. Removing the name and email will default the name and email to the one associated with the oauth token used for the job.