### PR TITLE
Add configuration merging functions to config library

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["config.go"],
+    srcs = [
+        "config.go",
+        "converge.go",
+    ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/config",
     visibility = ["//visibility:public"],
     deps = [
@@ -33,10 +36,14 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "converge_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pb/config:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
     ],
 )

--- a/config/converge.go
+++ b/config/converge.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"sort"
+
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/golang/protobuf/proto"
+)
+
+// Zero-memory member for hash sets
+type void struct{}
+
+var insert void
+
+// Converge merges together the Configurations given in the map set.
+// If there are duplicate entries, the string key may be added as a prefix to
+// maintain uniqueness for Dashboards, DashboardGroups, and TestGroups.
+// The config at key "" will not be modified.
+
+// The output protobuf will pass config.Validate if all its inputs pass config.Validate
+func Converge(shards map[string]*configpb.Configuration) (*configpb.Configuration, error) {
+	if len(shards) == 0 {
+		return nil, fmt.Errorf("No configurations to converge")
+	}
+
+	result := configpb.Configuration{}
+
+	// Go through shards in key string order, so the prefix results are predictable and alphabetical.
+	var keys []string
+	for key := range shards {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Dashboards and Dashboard Groups can't share names with each other
+	DashboardsAndGroups := make(map[string]void)
+	TestGroups := make(map[string]void)
+
+	for _, key := range keys {
+		cfg := shards[key]
+		NewDashboardsAndGroups := make(map[string]void)
+		NewTestGroups := make(map[string]void)
+		for _, testgroup := range cfg.TestGroups {
+			NewTestGroups[testgroup.Name] = insert
+		}
+		for _, dashboard := range cfg.Dashboards {
+			NewDashboardsAndGroups[dashboard.Name] = insert
+		}
+		for _, dashboardGroup := range cfg.DashboardGroups {
+			NewDashboardsAndGroups[dashboardGroup.Name] = insert
+		}
+
+		dashboardRenames := negotiateConversions(key, DashboardsAndGroups, NewDashboardsAndGroups)
+		testGroupRenames := negotiateConversions(key, TestGroups, NewTestGroups)
+
+		for olddash, newdash := range dashboardRenames {
+			RenameDashboardOrGroup(olddash, newdash, cfg)
+		}
+
+		for oldtest, newtest := range testGroupRenames {
+			RenameTestGroup(oldtest, newtest, cfg)
+		}
+
+		// Merge protos and cached sets
+		proto.Merge(&result, cfg)
+
+		for _, dash := range cfg.Dashboards {
+			DashboardsAndGroups[dash.Name] = insert
+		}
+		for _, group := range cfg.DashboardGroups {
+			DashboardsAndGroups[group.Name] = insert
+		}
+		for _, test := range cfg.TestGroups {
+			TestGroups[test.Name] = insert
+		}
+	}
+
+	return &result, nil
+}
+
+// Given two sets of strings, returns a "conversions" for each duplicate.
+// If there are no duplicates, returns a zero-length map.
+// If there are duplicates, returns a map of the string in "new" -> the string it should become.
+// Will try "prefix-string" first, then "prefix-2-string", etc.
+func negotiateConversions(prefix string, original, new map[string]void) map[string]string {
+	if len(original) == 0 || len(new) == 0 {
+		return nil
+	}
+
+	result := make(map[string]string)
+
+	for key := range new {
+		if _, exists := original[key]; exists {
+			candidate := fmt.Sprintf("%s-%s", prefix, key)
+			attempt := 1
+			for true {
+				_, existInOld := original[candidate]
+				_, existInNew := new[candidate]
+				if !existInOld && !existInNew {
+					result[key] = candidate
+					break
+				}
+				attempt++
+				candidate = fmt.Sprintf("%s-%d-%s", prefix, attempt, key)
+			}
+		}
+	}
+
+	return result
+}
+
+// Renames all references to TestGroup 'original' to 'new'.
+// Does not verify if the new name is already taken.
+func RenameTestGroup(original, new string, cfg *configpb.Configuration) *configpb.Configuration {
+	// If a TestGroup is changed, it needs to be changed for tabs that reference it also
+	for _, testGroup := range cfg.TestGroups {
+		if testGroup.Name == original {
+			testGroup.Name = new
+		}
+	}
+	for _, dashboard := range cfg.Dashboards {
+		for _, dashTab := range dashboard.DashboardTab {
+			if dashTab.TestGroupName == original {
+				dashTab.TestGroupName = new
+			}
+		}
+	}
+	return cfg
+}
+
+// Renames all Dashboards and DashboardGroups named 'original' to 'new'.
+// Since Dashboards and Dashboard Groups can't share names with each other, a valid Configuration will rename at most one item.
+func RenameDashboardOrGroup(original, new string, cfg *configpb.Configuration) *configpb.Configuration {
+	return RenameDashboard(original, new, RenameDashboardGroup(original, new, cfg))
+}
+
+// Renames all references to Dashboard 'original' to 'new'.
+// Does not verify if the new name is already taken.
+func RenameDashboard(original, new string, cfg *configpb.Configuration) *configpb.Configuration {
+	// If a dashboard is renamed, it needs to be changed for DashboardGroups that reference it also
+	for _, dashboard := range cfg.Dashboards {
+		if dashboard.Name == original {
+			dashboard.Name = new
+		}
+	}
+
+	for _, dashgroup := range cfg.DashboardGroups {
+		for i, dashboard := range dashgroup.DashboardNames {
+			if dashboard == original {
+				dashgroup.DashboardNames[i] = new
+			}
+		}
+	}
+
+	return cfg
+}
+
+// Renames all references to DashboardGroup 'original' to 'new'.
+// Does not verify if the new name is already taken.
+func RenameDashboardGroup(original, new string, cfg *configpb.Configuration) *configpb.Configuration {
+	for _, dashgroup := range cfg.DashboardGroups {
+		if dashgroup.Name == original {
+			dashgroup.Name = new
+		}
+	}
+
+	return cfg
+}

--- a/config/converge_test.go
+++ b/config/converge_test.go
@@ -1,0 +1,566 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/golang/protobuf/proto"
+)
+
+func TestConverge(t *testing.T) {
+	cases := []struct {
+		name     string
+		inputs   map[string]*configpb.Configuration
+		expected *configpb.Configuration
+	}{
+		{
+			name: "nil input; throws error",
+		},
+		{
+			name: "Merge with no conflicts; no name changes",
+			inputs: map[string]*configpb.Configuration{
+				"halloween": {
+					TestGroups: []*configpb.TestGroup{
+						aValidTestGroupNamed("pumpkin-decorator"),
+						aValidTestGroupNamed("cobweb-decorator"),
+						aValidTestGroupNamed("candy-corn-emitter"),
+					},
+					Dashboards: []*configpb.Dashboard{
+						{
+							Name: "Decorations",
+							DashboardTab: []*configpb.DashboardTab{
+								{
+									Name:          "Jack-O-Lanterns",
+									TestGroupName: "pumpkin-decorator",
+								},
+								{
+									Name:          "Spooky Cave",
+									TestGroupName: "cobweb-decorator",
+								},
+							},
+						},
+						{
+							Name: "Treats",
+							DashboardTab: []*configpb.DashboardTab{
+								{
+									Name:          "Candy Corn Only (sorry)",
+									TestGroupName: "candy-corn-emitter",
+								},
+							},
+						},
+					},
+					DashboardGroups: []*configpb.DashboardGroup{
+						{
+							Name:           "Halloween",
+							DashboardNames: []string{"Treats", "Decorations"},
+						},
+					},
+				},
+				"thanksgiving": {
+					TestGroups: []*configpb.TestGroup{
+						aValidTestGroupNamed("meal-preparer"),
+					},
+					Dashboards: []*configpb.Dashboard{
+						{
+							Name: "Thanksgiving",
+							DashboardTab: []*configpb.DashboardTab{
+								{
+									Name:          "Meal Prep",
+									TestGroupName: "meal-preparer",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &configpb.Configuration{
+				TestGroups: []*configpb.TestGroup{
+					aValidTestGroupNamed("pumpkin-decorator"),
+					aValidTestGroupNamed("cobweb-decorator"),
+					aValidTestGroupNamed("candy-corn-emitter"),
+					aValidTestGroupNamed("meal-preparer"),
+				},
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "Decorations",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "Jack-O-Lanterns",
+								TestGroupName: "pumpkin-decorator",
+							},
+							{
+								Name:          "Spooky Cave",
+								TestGroupName: "cobweb-decorator",
+							},
+						},
+					},
+					{
+						Name: "Treats",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "Candy Corn Only (sorry)",
+								TestGroupName: "candy-corn-emitter",
+							},
+						},
+					},
+					{
+						Name: "Thanksgiving",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "Meal Prep",
+								TestGroupName: "meal-preparer",
+							},
+						},
+					},
+				},
+				DashboardGroups: []*configpb.DashboardGroup{
+					{
+						Name:           "Halloween",
+						DashboardNames: []string{"Treats", "Decorations"},
+					},
+				},
+			},
+		},
+		{
+			name: "Merge with conflicts; renames with key-prefix",
+			inputs: map[string]*configpb.Configuration{
+				"halloween": {
+					TestGroups: []*configpb.TestGroup{
+						aValidTestGroupNamed("pumpkin-decorator"),
+						aValidTestGroupNamed("candy-emitter"),
+					},
+					Dashboards: []*configpb.Dashboard{
+						{
+							Name: "Decorations",
+							DashboardTab: []*configpb.DashboardTab{
+								{
+									Name:          "Living Room",
+									TestGroupName: "pumpkin-decorator",
+								},
+							},
+						},
+						{
+							Name: "Treats",
+							DashboardTab: []*configpb.DashboardTab{
+								{
+									Name:          "Candy",
+									TestGroupName: "candy-emitter",
+								},
+							},
+						},
+					},
+					DashboardGroups: []*configpb.DashboardGroup{
+						{
+							Name:           "To-Do",
+							DashboardNames: []string{"Treats", "Decorations"},
+						},
+					},
+				},
+				"crimbo": {
+					TestGroups: []*configpb.TestGroup{
+						aValidTestGroupNamed("tree-decorator"),
+						aValidTestGroupNamed("candy-emitter"),
+					},
+					Dashboards: []*configpb.Dashboard{
+						{
+							Name: "Decorations",
+							DashboardTab: []*configpb.DashboardTab{
+								{
+									Name:          "Living Room",
+									TestGroupName: "tree-decorator",
+								},
+							},
+						},
+						{
+							Name: "Treats",
+							DashboardTab: []*configpb.DashboardTab{
+								{
+									Name:          "Candy",
+									TestGroupName: "candy-emitter",
+								},
+							},
+						},
+					},
+					DashboardGroups: []*configpb.DashboardGroup{
+						{
+							Name:           "To-Do",
+							DashboardNames: []string{"Treats", "Decorations"},
+						},
+					},
+				},
+			},
+			expected: &configpb.Configuration{
+				TestGroups: []*configpb.TestGroup{
+					aValidTestGroupNamed("tree-decorator"),
+					aValidTestGroupNamed("candy-emitter"),
+					aValidTestGroupNamed("pumpkin-decorator"),
+					aValidTestGroupNamed("halloween-candy-emitter"),
+				},
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "Decorations",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "Living Room",
+								TestGroupName: "tree-decorator",
+							},
+						},
+					},
+					{
+						Name: "Treats",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "Candy",
+								TestGroupName: "candy-emitter",
+							},
+						},
+					},
+					{
+						Name: "halloween-Decorations",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "Living Room",
+								TestGroupName: "pumpkin-decorator",
+							},
+						},
+					},
+					{
+						Name: "halloween-Treats",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "Candy",
+								TestGroupName: "halloween-candy-emitter",
+							},
+						},
+					},
+				},
+				DashboardGroups: []*configpb.DashboardGroup{
+					{
+						Name:           "To-Do",
+						DashboardNames: []string{"Treats", "Decorations"},
+					},
+					{
+						Name:           "halloween-To-Do",
+						DashboardNames: []string{"halloween-Treats", "halloween-Decorations"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testcase := range cases {
+		t.Run(testcase.name, func(t *testing.T) {
+			for iname, input := range testcase.inputs {
+				err := Validate(input)
+				if err != nil {
+					t.Logf("Warning! Input %s doesn't validate; the result might not either.", iname)
+					t.Logf("Validation error: %v", err)
+				}
+			}
+
+			result, err := Converge(testcase.inputs)
+
+			if testcase.expected != nil {
+				if err := Validate(result); err != nil {
+					t.Errorf("Result doesn't validate: %v", result)
+					t.Errorf("Validation error: %v", err)
+				}
+
+				if !proto.Equal(testcase.expected, result) {
+					t.Errorf("Expected %v, but got %v", testcase.expected, result)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected an error, but got none.")
+				}
+			}
+
+		})
+	}
+}
+
+func TestRenameTestGroup(t *testing.T) {
+	cases := []struct {
+		name     string
+		old      string
+		new      string
+		input    *configpb.Configuration
+		expected *configpb.Configuration
+	}{
+		{
+			name: "Old string isn't in TestGroup; no change",
+			old:  "foo",
+			new:  "bar",
+			input: &configpb.Configuration{
+				TestGroups: []*configpb.TestGroup{
+					{
+						Name: "foo-group",
+					},
+				},
+			},
+			expected: &configpb.Configuration{
+				TestGroups: []*configpb.TestGroup{
+					{
+						Name: "foo-group",
+					},
+				},
+			},
+		},
+		{
+			name: "Changes Dashboard Tab references",
+			old:  "foo",
+			new:  "bar",
+			input: &configpb.Configuration{
+				TestGroups: []*configpb.TestGroup{
+					{
+						Name: "foo",
+					},
+				},
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "foo",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "foo",
+								TestGroupName: "foo",
+							},
+						},
+					},
+				},
+			},
+			expected: &configpb.Configuration{
+				TestGroups: []*configpb.TestGroup{
+					{
+						Name: "bar",
+					},
+				},
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "foo",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "foo",
+								TestGroupName: "bar",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testcase := range cases {
+		t.Run(testcase.name, func(t *testing.T) {
+			result := RenameTestGroup(testcase.old, testcase.new, testcase.input)
+
+			if !proto.Equal(testcase.expected, result) {
+				t.Errorf("Expected %v, but got %v", testcase.expected, result)
+			}
+		})
+	}
+}
+
+func TestRenameDashboard(t *testing.T) {
+	cases := []struct {
+		name     string
+		old      string
+		new      string
+		input    *configpb.Configuration
+		expected *configpb.Configuration
+	}{
+		{
+			name: "Old string isn't in Dashboard; do nothing",
+			old:  "foo",
+			new:  "bar",
+			input: &configpb.Configuration{
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "foo-group",
+					},
+				},
+			},
+			expected: &configpb.Configuration{
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "foo-group",
+					},
+				},
+			},
+		},
+		{
+			name: "Changes Dashboard Group reference",
+			old:  "foo",
+			new:  "bar",
+			input: &configpb.Configuration{
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "foo",
+					},
+				},
+				DashboardGroups: []*configpb.DashboardGroup{
+					{
+						Name:           "foo",
+						DashboardNames: []string{"foo"},
+					},
+				},
+			},
+			expected: &configpb.Configuration{
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "bar",
+					},
+				},
+				DashboardGroups: []*configpb.DashboardGroup{
+					{
+						Name:           "foo",
+						DashboardNames: []string{"bar"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testcase := range cases {
+		t.Run(testcase.name, func(t *testing.T) {
+			result := RenameDashboard(testcase.old, testcase.new, testcase.input)
+
+			if !proto.Equal(testcase.expected, result) {
+				t.Errorf("Expected %v, but got %v", testcase.expected, result)
+			}
+		})
+	}
+}
+
+func TestRenameDashboardGroup(t *testing.T) {
+	cases := []struct {
+		name     string
+		old      string
+		new      string
+		input    *configpb.Configuration
+		expected *configpb.Configuration
+	}{
+		{
+			name: "Old string isn't in Dashboard Group; do nothing",
+			old:  "foo",
+			new:  "bar",
+			input: &configpb.Configuration{
+				DashboardGroups: []*configpb.DashboardGroup{
+					{Name: "foo-foo"},
+				},
+			},
+			expected: &configpb.Configuration{
+				DashboardGroups: []*configpb.DashboardGroup{
+					{Name: "foo-foo"},
+				},
+			},
+		},
+		{
+			name: "Renames Dashboard Group",
+			old:  "foo",
+			new:  "bar",
+			input: &configpb.Configuration{
+				DashboardGroups: []*configpb.DashboardGroup{
+					{Name: "foo"},
+				},
+			},
+			expected: &configpb.Configuration{
+				DashboardGroups: []*configpb.DashboardGroup{
+					{Name: "bar"},
+				},
+			},
+		},
+	}
+
+	for _, testcase := range cases {
+		t.Run(testcase.name, func(t *testing.T) {
+			result := RenameDashboardGroup(testcase.old, testcase.new, testcase.input)
+
+			if !proto.Equal(testcase.expected, result) {
+				t.Errorf("Expected %v, but got %v", testcase.expected, result)
+			}
+		})
+	}
+}
+
+func TestNegotiateConversions(t *testing.T) {
+	cases := []struct {
+		Name     string
+		original []string
+		new      []string
+		expected map[string]string
+	}{
+		{
+			Name: "No sets; no conflicts",
+		},
+		{
+			Name:     "Sets with no conflict; no conflicts",
+			original: []string{"one", "two", "three"},
+			new:      []string{"un", "deux", "trois"},
+			expected: map[string]string{},
+		},
+		{
+			Name:     "Sets with conflicts; conflicts returned",
+			original: []string{"one", "two", "three"},
+			new:      []string{"three", "one", "four"},
+			expected: map[string]string{
+				"one":   "prefix-one",
+				"three": "prefix-three",
+			},
+		},
+		{
+			Name:     "Sets with conflicts with prefix; modified prefix returned",
+			original: []string{"ichi", "ni", "prefix-ichi"},
+			new:      []string{"ichi", "ni", "prefix-ni"},
+			expected: map[string]string{
+				"ichi": "prefix-2-ichi",
+				"ni":   "prefix-2-ni",
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			originalMap := make(map[string]void)
+			for _, a := range test.original {
+				originalMap[a] = insert
+			}
+
+			newMap := make(map[string]void)
+			for _, a := range test.new {
+				newMap[a] = insert
+			}
+
+			result := negotiateConversions("prefix", originalMap, newMap)
+
+			if !reflect.DeepEqual(test.expected, result) {
+				t.Errorf("Expected %v, but got %v", test.expected, result)
+			}
+		})
+	}
+}
+
+func aValidTestGroupNamed(name string) *configpb.TestGroup {
+	return &configpb.TestGroup{
+		Name:             name,
+		GcsPrefix:        "gcs://some/path",
+		DaysOfResults:    1,
+		NumColumnsRecent: 3,
+	}
+}


### PR DESCRIPTION
This will allow users to generate large configs from multiple disparate config proto sources, automatically renaming components to avoid duplicates.

Also exposes configuration-sensitive "rename" functions that will correctly rename references to config objects.