### PR TITLE
Add job name when results collate multiple jobs

### DIFF
--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -38,6 +38,8 @@ type gcsResult struct {
 	started  gcs.Started
 	finished gcs.Finished
 	suites   []gcs.SuitesMeta
+	job      string
+	build    string
 }
 
 const maxDuplicates = 20
@@ -106,8 +108,12 @@ func convertResult(ctx context.Context, log logrus.FieldLogger, nameCfg nameConf
 
 			parsed := make([]interface{}, len(nameCfg.parts))
 			for i, p := range nameCfg.parts {
-				if p == "Tests name" {
+				if p == testsName {
 					parsed[i] = r.Name
+					continue
+				}
+				if p == jobName {
+					parsed[i] = result.job
 					continue
 				}
 				v, present := suite.Metadata[p]

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -668,28 +668,6 @@ func appendCell(row *statepb.Row, cell cell, count int) {
 	}
 }
 
-type nameConfig struct {
-	format string
-	parts  []string
-}
-
-func makeNameConfig(tnc *configpb.TestNameConfig) nameConfig {
-	if tnc == nil {
-		return nameConfig{
-			format: "%s",
-			parts:  []string{"Tests name"},
-		}
-	}
-	nc := nameConfig{
-		format: tnc.NameFormat,
-		parts:  make([]string, len(tnc.NameElements)),
-	}
-	for i, e := range tnc.NameElements {
-		nc.parts[i] = e.TargetConfig
-	}
-	return nc
-}
-
 // appendColumn adds the build column to the grid.
 //
 // This handles details like:

--- a/util/gcs/read.go
+++ b/util/gcs/read.go
@@ -57,6 +57,24 @@ type Build struct {
 	suitesConcurrency int // override the max number of concurrent suite downloads
 }
 
+func (build Build) object() string {
+	o := build.Path.Object()
+	if strings.HasSuffix(o, "/") {
+		return o[0 : len(o)-1]
+	}
+	return o
+}
+
+// Build is the unique invocation id of the job.
+func (build Build) Build() string {
+	return path.Base(build.object())
+}
+
+// Job is the name of the job for this build
+func (build Build) Job() string {
+	return path.Base(path.Dir(build.object()))
+}
+
 func (build Build) String() string {
 	return build.Path.String()
 }

--- a/util/gcs/read_test.go
+++ b/util/gcs/read_test.go
@@ -49,6 +49,42 @@ func link(path Path, name, other string) storage.ObjectAttrs {
 	}
 }
 
+func TestBuildJob(t *testing.T) {
+	cases := []struct {
+		path  string
+		build string
+		job   string
+	}{
+		{
+			path:  "gs://bucket/path/job/hello",
+			build: "hello",
+			job:   "job",
+		},
+		{
+			path:  "gs://bucket/path/job/hello/",
+			build: "hello",
+			job:   "job",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			p, err := NewPath(tc.path)
+			if err != nil {
+				t.Fatal("NewPath(%q) got unexpected error: %v", tc.path, err)
+			}
+			b := Build{Path: *p}
+			job, build := b.Job(), b.Build()
+			if job != tc.job {
+				t.Errorf("Job got %q want %q", job, tc.job)
+			}
+			if build != tc.build {
+				t.Errorf("Build got %q want %q", build, tc.build)
+			}
+		})
+	}
+}
+
 func TestListBuilds(t *testing.T) {
 	path := newPathOrDie("gs://bucket/path/to/build/")
 	cases := []struct {


### PR DESCRIPTION
If `GcsPrefix: this-job,that-job` then ensure that the name config includes a `Job name` field (insert it to the front if not)