### PR TITLE
Pull numeric junit properties into row metrics.

### DIFF
--- a/pkg/updater/read.go
+++ b/pkg/updater/read.go
@@ -148,7 +148,7 @@ func readColumns(parent context.Context, client gcs.Downloader, group *configpb.
 					return
 				}
 				id := path.Base(b.Path.Object())
-				col, err := convertResult(ctx, log, nameCfg, id, heads, *result)
+				col, err := convertResult(ctx, log, nameCfg, id, heads, group.ShortTextMetric, *result)
 				if err != nil {
 					innerCancel()
 					select {


### PR DESCRIPTION
Cell metrics then get moved into row metrics here:
https://github.com/GoogleCloudPlatform/testgrid/blob/75fc13bde00135a34ab8b1f28e4a98c557cbad44/pkg/updater/updater.go#L640-L664

Allow short_text_metric to become the cell icon.

/assign @michelle192837 