### PR TITLE
Update broken-state calculation with neutral statuses.

### DIFF
--- a/internal/result/results_test.go
+++ b/internal/result/results_test.go
@@ -167,11 +167,11 @@ func TestCoalesce(t *testing.T) {
 		},
 		{
 			status:   statuspb.TestStatus_RUNNING,
-			expected: statuspb.TestStatus_FAIL,
+			expected: statuspb.TestStatus_UNKNOWN,
 		},
 		{
 			status:   statuspb.TestStatus_CANCEL,
-			expected: statuspb.TestStatus_FAIL,
+			expected: statuspb.TestStatus_UNKNOWN,
 		},
 		{
 			status:        statuspb.TestStatus_TOOL_FAIL,

--- a/pkg/summarizer/flakiness.go
+++ b/pkg/summarizer/flakiness.go
@@ -131,7 +131,7 @@ func parseGrid(grid *statepb.Grid, startTime int, endTime int) ([]*common.GridMe
 			if i >= len(grid.Columns) {
 				break
 			}
-			rowResult := result.Coalesce(nextRowResult, result.FailRunning)
+			rowResult := result.Coalesce(nextRowResult, result.ShowRunning)
 
 			// We still need to increment rowToMessageIndex even if we want to skip counting
 			// this column.

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -1698,6 +1698,68 @@ func TestGridMetrics(t *testing.T) {
 			brokenThreshold: .6,
 			expectedBroken:  false,
 		},
+		{
+			name:   "many non-passing/non-failing statuses is not broken",
+			cols:   4,
+			recent: 4,
+			rows: []*statepb.Row{
+				{
+					Name: "four aborts (foo)",
+					Results: []int32{
+						int32(statuspb.TestStatus_CATEGORIZED_ABORT), 4,
+					},
+				},
+				{
+					Name: "four aborts (bar)",
+					Results: []int32{
+						int32(statuspb.TestStatus_CATEGORIZED_ABORT), 4,
+					},
+				},
+				{
+					Name: "four aborts (baz)",
+					Results: []int32{
+						int32(statuspb.TestStatus_CATEGORIZED_ABORT), 4,
+					},
+				},
+			},
+			passingCols:     0,
+			filledCols:      4,
+			passingCells:    0,
+			filledCells:     12,
+			brokenThreshold: .6,
+			expectedBroken:  false,
+		},
+		{
+			name:   "many non-passing/non-failing statuses + failing statuses, not broken",
+			cols:   4,
+			recent: 4,
+			rows: []*statepb.Row{
+				{
+					Name: "four aborts (foo)",
+					Results: []int32{
+						int32(statuspb.TestStatus_CATEGORIZED_ABORT), 4,
+					},
+				},
+				{
+					Name: "four aborts (bar)",
+					Results: []int32{
+						int32(statuspb.TestStatus_CATEGORIZED_ABORT), 4,
+					},
+				},
+				{
+					Name: "four fails",
+					Results: []int32{
+						int32(statuspb.TestStatus_FAIL), 4,
+					},
+				},
+			},
+			passingCols:     0,
+			filledCols:      4,
+			passingCells:    0,
+			filledCells:     12,
+			brokenThreshold: .6,
+			expectedBroken:  false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -2122,10 +2184,10 @@ func TestCoalesceResult(t *testing.T) {
 			running:  result.IgnoreRunning,
 		},
 		{
-			name:     "running is no result when ignored",
+			name:     "running is neutral when shown",
 			result:   statuspb.TestStatus_RUNNING,
-			expected: statuspb.TestStatus_FAIL,
-			running:  result.FailRunning,
+			expected: statuspb.TestStatus_UNKNOWN,
+			running:  result.ShowRunning,
 		},
 		{
 			name:     "fail is fail",
@@ -2141,6 +2203,11 @@ func TestCoalesceResult(t *testing.T) {
 			name:     "simplify pass",
 			result:   statuspb.TestStatus_PASS_WITH_ERRORS,
 			expected: statuspb.TestStatus_PASS,
+		},
+		{
+			name:     "categorized abort is neutral",
+			result:   statuspb.TestStatus_CATEGORIZED_ABORT,
+			expected: statuspb.TestStatus_UNKNOWN,
 		},
 	}
 


### PR DESCRIPTION
We're counting any non-passing, non-no-result status as 'failing' for the purposes of calculating if a tab is in 'broken' state. Instead, treat non-passing, non-failing statuses as 'neutral'.