### PR TITLE
fix: link to configuration from standalone docs

### DIFF
--- a/standalone.md
+++ b/standalone.md
@@ -56,5 +56,5 @@ permission to read from these files.
 
 
 [testgrid.k8s.io]: (http://testgrid.k8s.io)
-[configuration]: (./config.md)
+[configuration]: (config.md)
 

--- a/standalone.md
+++ b/standalone.md
@@ -56,5 +56,5 @@ permission to read from these files.
 
 
 [testgrid.k8s.io]: (http://testgrid.k8s.io)
-[configuration]: (config.md)
+[configuration]: config.md
 


### PR DESCRIPTION
The previous PR #368 seems to generate a link "https://github.com/GoogleCloudPlatform/testgrid/blob/master/(./config.md)" which is invalid.