### PR TITLE
Add Config Merger for k8s in Canary

### DIFF
--- a/cluster/canary/config_merger.yaml
+++ b/cluster/canary/config_merger.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testgrid-config-merger
+  namespace: testgrid-canary
+  labels:
+    app: testgrid
+    channel: stable
+    component: config-merger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      channel: stable
+      component: config-merger
+  template:
+    metadata:
+      labels:
+        app: testgrid
+        channel: stable
+        component: config-merger
+    spec:
+      serviceAccountName: config-merger
+      containers:
+      - name: config-merger
+        image: gcr.io/k8s-testgrid/config_merger:latest # TODO(chases2): pin to a version that contains this PR
+        args:
+        - --config-url="https://raw.githubusercontent.com/kubernetes/test-infra/master/config/mergelists/canary.yaml"
+        - --confirm
+        - --wait=15m
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    # Uses same as updater
+    iam.gke.io/gcp-service-account: testgrid-canary@k8s-testgrid.iam.gserviceaccount.com
+  name: config-merger
+  namespace: testgrid-canary


### PR DESCRIPTION
Also allows config_merger to read from a URL with a special flag.

Do not merge until https://github.com/kubernetes/test-infra/pull/20986 merges, or the URL won't work.