### PR TITLE
Add JUnit "error" test cases

### DIFF
--- a/metadata/junit/junit.go
+++ b/metadata/junit/junit.go
@@ -102,6 +102,7 @@ type Result struct {
 	Failure    *string     `xml:"failure,omitempty"`
 	Output     *string     `xml:"system-out,omitempty"`
 	Error      *string     `xml:"system-err,omitempty"`
+	Errored    *string     `xml:"error,omitempty"`
 	Skipped    *string     `xml:"skipped,omitempty"`
 	Properties *Properties `xml:"properties,omitempty"`
 }
@@ -130,10 +131,12 @@ func (r *Result) SetProperty(name, value string) {
 
 // Message extracts the message for the junit test case.
 //
-// Will use the first non-empty <failure/>, <skipped/>, <system-err/>, <system-out/> value.
+// Will use the first non-empty <error/>, <failure/>, <skipped/>, <system-err/>, <system-out/> value.
 func (r Result) Message(max int) string {
 	var msg string
 	switch {
+	case r.Errored != nil && *r.Errored != "":
+		msg = *r.Errored
 	case r.Failure != nil && *r.Failure != "":
 		msg = *r.Failure
 	case r.Skipped != nil && *r.Skipped != "":
@@ -172,7 +175,7 @@ func truncatePointer(str *string, max int) {
 
 // Truncate ensures that strings do not exceed the specified length.
 func (r Result) Truncate(max int) {
-	for _, s := range []*string{r.Failure, r.Skipped, r.Error, r.Output} {
+	for _, s := range []*string{r.Errored, r.Failure, r.Skipped, r.Error, r.Output} {
 		truncatePointer(s, max)
 	}
 }

--- a/metadata/junit/junit_test.go
+++ b/metadata/junit/junit_test.go
@@ -39,7 +39,18 @@ func TestMessage(t *testing.T) {
 			name: "basically works",
 		},
 		{
-			name: "failure takes top priority",
+			name: "errored takes top priority",
+			jr: Result{
+				Errored: pstr("errored-0"),
+				Failure: pstr("failure-1"),
+				Skipped: pstr("skipped-2"),
+				Error:   pstr("error-3"),
+				Output:  pstr("output-4"),
+			},
+			expected: "errored-0",
+		},
+		{
+			name: "failure priorized over skipped, error and output",
 			jr: Result{
 				Failure: pstr("failure-0"),
 				Skipped: pstr("skipped-1"),
@@ -100,6 +111,9 @@ func TestMessage(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
+	pstr := func(s string) *string {
+		return &s
+	}
 	cases := []struct {
 		name     string
 		buf      []byte
@@ -134,6 +148,12 @@ func TestParse(t *testing.T) {
                             <testsuite name="fun">
                                 <testsuite name="knee">
                                     <testcase name="bone" time="6" />
+                                    <testcase name="head" time="3" >
+										<failure message="failure"> failure message </failure>
+									</testcase>
+                                    <testcase name="neck" time="2" >
+										<error message="error"> error message </error>
+									</testcase>
                                 </testsuite>
                                 <testcase name="word" time="7" />
                             </testsuite>
@@ -153,6 +173,16 @@ func TestParse(t *testing.T) {
 									{
 										Name: "bone",
 										Time: 6,
+									},
+									{
+										Name:    "head",
+										Time:    3,
+										Failure: pstr(" failure message "),
+									},
+									{
+										Name:    "neck",
+										Time:    2,
+										Errored: pstr(" error message "),
 									},
 								},
 							},


### PR DESCRIPTION
testgrid mark test as passed if they are of type "error" [1]. This
change add the type "error" and store it in the Result as Errored field.

[1] https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd#L75

Signed-off-by: Quique Llorente <ellorent@redhat.com>