### PR TITLE
Stop requiring optional cell ID field when alerting a row.

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -768,9 +768,13 @@ func alertRow(cols []*statepb.Column, row *statepb.Row, failuresToOpen, passesTo
 	if failures < failuresToOpen {
 		return nil
 	}
-	id := row.CellIds[failIdx]
+	var id string
+	var latestID string
+	if len(row.CellIds) > 0 { // not all rows have cell ids
+		id = row.CellIds[failIdx]
+		latestID = row.CellIds[latestFailIdx]
+	}
 	msg := row.Messages[latestFailIdx]
-	latestID := row.CellIds[latestFailIdx]
 	return alertInfo(totalFailures, msg, id, latestID, firstFail, latestFail, latestPass)
 }
 

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -2526,6 +2526,18 @@ func TestAlertRow(t *testing.T) {
 			expected: alertInfo(3, "no", "very wrong", "no", columns[2], columns[0], columns[3]),
 		},
 		{
+			name: "rows without cell IDs can alert",
+			row: statepb.Row{
+				Results: []int32{
+					int32(statuspb.TestStatus_FAIL), 3,
+					int32(statuspb.TestStatus_PASS), 3,
+				},
+				Messages: []string{"no", "no again", "very wrong", "yes", "hi", "hello"},
+			},
+			failOpen: 3,
+			expected: alertInfo(3, "no", "", "", columns[2], columns[0], columns[3]),
+		},
+		{
 			name: "too few passes do not close",
 			row: statepb.Row{
 				Results: []int32{


### PR DESCRIPTION
Technically these only exist on rows with `@TESTGRID@` in them, but
be more permissive in what we allow by directly checking for cell IDs rather
than looking at the row name.