### PR TITLE
Handle empty json files.

### DIFF
--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -19,6 +19,7 @@ package updater
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -41,6 +42,7 @@ type gcsResult struct {
 	suites   []gcs.SuitesMeta
 	job      string
 	build    string
+	missing  []string
 }
 
 const maxDuplicates = 20
@@ -374,6 +376,10 @@ func overallCell(result gcsResult) Cell {
 		finished = *result.finished.Timestamp
 	}
 	switch {
+	case len(result.missing) > 0:
+		c.Result = statuspb.TestStatus_FAIL
+		c.Message = fmt.Sprintf("Missing status from files: %s", strings.Join(result.missing, ", "))
+		c.Icon = "E"
 	case finished > 0: // completed result
 		var passed bool
 		res := result.finished.Result

--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -1353,6 +1353,30 @@ func TestOverallCell(t *testing.T) {
 			},
 		},
 		{
+			name: "missing results fail",
+			result: gcsResult{
+				started: gcs.Started{
+					Started: metadata.Started{
+						Timestamp: 100,
+					},
+				},
+				finished: gcs.Finished{
+					Finished: metadata.Finished{
+						Timestamp: pint(250),
+						Passed:    &yes,
+					},
+				},
+				missing: []string{
+					"podinfo.json",
+				},
+			},
+			expected: Cell{
+				Result:  statuspb.TestStatus_FAIL,
+				Message: "Missing status from files: podinfo.json",
+				Icon:    "E",
+			},
+		},
+		{
 			name: "passed result passes",
 			result: gcsResult{
 				started: gcs.Started{

--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -1085,6 +1085,21 @@ func TestReadResult(t *testing.T) {
 			},
 		},
 		{
+			name: "empty files report missing",
+			data: map[string]fakeObject{
+				"finished.json": {data: ""},
+				"started.json":  {data: ""},
+				"podinfo.json":  {data: ""},
+			},
+			expected: &gcsResult{
+				missing: []string{
+					"finished.json",
+					"podinfo.json",
+					"started.json",
+				},
+			},
+		},
+		{
 			name: "missing started.json reports pending",
 			data: map[string]fakeObject{
 				"finished.json":      {data: `{"passed": true}`},
@@ -1218,7 +1233,7 @@ func TestReadResult(t *testing.T) {
 			for name, fo := range tc.data {
 				p, err := path.ResolveReference(&url.URL{Path: name})
 				if err != nil {
-					t.Fatalf("path.ResolveReference(%q): %w", name, err)
+					t.Fatalf("path.ResolveReference(%q): %v", name, err)
 				}
 				fi.objects = append(fi.objects, storage.ObjectAttrs{
 					Name: p.Object(),
@@ -1389,7 +1404,7 @@ func TestReadSuites(t *testing.T) {
 			for name, fo := range tc.data {
 				p, err := path.ResolveReference(&url.URL{Path: name})
 				if err != nil {
-					t.Fatalf("path.ResolveReference(%q): %w", name, err)
+					t.Fatalf("path.ResolveReference(%q): %v", name, err)
 				}
 				fi.objects = append(fi.objects, storage.ObjectAttrs{
 					Name: p.Object(),


### PR DESCRIPTION
Reading these currently return io.EOF errors, which prevents reading more recent columns.
Detect this scenarioe explicitly and add the files to the missing list.
Report these missing files in the Overall cell.