### PR TITLE
Malformed junit files should fail the build but not the job.

### DIFF
--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -36,13 +36,13 @@ import (
 //
 // The suite results become rows and the job metadata is added to the column.
 type gcsResult struct {
-	podInfo  gcs.PodInfo
-	started  gcs.Started
-	finished gcs.Finished
-	suites   []gcs.SuitesMeta
-	job      string
-	build    string
-	missing  []string
+	podInfo   gcs.PodInfo
+	started   gcs.Started
+	finished  gcs.Finished
+	suites    []gcs.SuitesMeta
+	job       string
+	build     string
+	malformed []string
 }
 
 const maxDuplicates = 20
@@ -376,9 +376,9 @@ func overallCell(result gcsResult) Cell {
 		finished = *result.finished.Timestamp
 	}
 	switch {
-	case len(result.missing) > 0:
+	case len(result.malformed) > 0:
 		c.Result = statuspb.TestStatus_FAIL
-		c.Message = fmt.Sprintf("Missing status from files: %s", strings.Join(result.missing, ", "))
+		c.Message = fmt.Sprintf("Malformed artifacts: %s", strings.Join(result.malformed, ", "))
 		c.Icon = "E"
 	case finished > 0: // completed result
 		var passed bool

--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -1366,13 +1366,13 @@ func TestOverallCell(t *testing.T) {
 						Passed:    &yes,
 					},
 				},
-				missing: []string{
+				malformed: []string{
 					"podinfo.json",
 				},
 			},
 			expected: Cell{
 				Result:  statuspb.TestStatus_FAIL,
-				Message: "Missing status from files: podinfo.json",
+				Message: "Malformed artifacts: podinfo.json",
 				Icon:    "E",
 			},
 		},

--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -1092,7 +1092,7 @@ func TestReadResult(t *testing.T) {
 				"podinfo.json":  {data: ""},
 			},
 			expected: &gcsResult{
-				missing: []string{
+				malformed: []string{
 					"finished.json",
 					"podinfo.json",
 					"started.json",
@@ -1204,11 +1204,20 @@ func TestReadResult(t *testing.T) {
 			},
 		},
 		{
-			name: "artifact error returns error",
+			name: "artifact error added to malformed list",
 			data: map[string]fakeObject{
 				"started.json":       {data: `{"node": "fun"}`},
 				"finished.json":      {data: `{"passed": true}`},
 				"junit_super_88.xml": {openErr: errors.New("injected open error")},
+			},
+			expected: &gcsResult{
+				started: gcs.Started{
+					Started: metadata.Started{Node: "fun"},
+				},
+				finished: gcs.Finished{
+					Finished: metadata.Finished{Passed: &yes},
+				},
+				malformed: []string{"junit_super_88.xml"},
 			},
 		},
 	}


### PR DESCRIPTION
Right now a bad junit artfiact will return an error and prevent the system from
considering newer builds until the problematic artifact is resolved.

Change things up so that we fail abort the build and note the problematic artifact, but
continue processing other builds for this job.

ref https://github.com/GoogleCloudPlatform/testgrid/issues/413