### PR TITLE
Read JUnit 'error' cases as failures.

### DIFF
--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -250,6 +250,11 @@ func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, header
 			}
 
 			switch {
+			case r.Errored != nil:
+				c.Result = statuspb.TestStatus_FAIL
+				if c.Message != "" {
+					c.Icon = "F"
+				}
 			case r.Failure != nil:
 				c.Result = statuspb.TestStatus_FAIL
 				if c.Message != "" {

--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -559,6 +559,14 @@ func TestConvertResult(t *testing.T) {
 											Output:  pstr("irrelevant message"),
 										},
 										{
+											Name:    "errored no message",
+											Failure: pstr(""),
+										},
+										{
+											Name:    "errored",
+											Failure: pstr("oh no"),
+										},
+										{
 											Name:    "invisible skip",
 											Skipped: pstr(""),
 										},
@@ -604,6 +612,14 @@ func TestConvertResult(t *testing.T) {
 					},
 					"failed other message": {
 						Message: "irrelevant message",
+						Result:  statuspb.TestStatus_FAIL,
+						Icon:    "F",
+					},
+					"errored no message": {
+						Result: statuspb.TestStatus_FAIL,
+					},
+					"errored": {
+						Message: "oh no",
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "F",
 					},


### PR DESCRIPTION
As noted in #406, also resolve a TestGrid status for a JUnit 'error'. This should fix #408.