### PR TITLE
Deploy config merger to production

### DIFF
--- a/cluster/canary/BUILD.bazel
+++ b/cluster/canary/BUILD.bazel
@@ -21,6 +21,7 @@ k8s_objects(
         ":namespace",  # Must be first
         ":summarizer",
         ":updater",
+        ":config_merger",
     ],
 )
 
@@ -40,6 +41,13 @@ k8s_object(
     cluster = CLUSTER,
     kind = MULTI_KIND,
     template = "summarizer.yaml",
+)
+
+k8s_object(
+    name = "config_merger",
+    cluster = CLUSTER,
+    kind = MULTI_KIND,
+    template = "config_merger.yaml",
 )
 
 k8s_object(

--- a/cluster/prod/BUILD.bazel
+++ b/cluster/prod/BUILD.bazel
@@ -21,6 +21,7 @@ k8s_objects(
         ":namespace",  # Must be first
         ":summarizer",
         ":updater",
+        ":config_merger",
         ":knative-namespace",  # Must be first
         ":knative-summarizer",
         ":knative-updater",
@@ -43,6 +44,13 @@ k8s_object(
     cluster = CLUSTER,
     kind = MULTI_KIND,
     template = "summarizer.yaml",
+)
+
+k8s_object(
+    name = "config_merger",
+    cluster = CLUSTER,
+    kind = MULTI_KIND,
+    template = "config_merger.yaml",
 )
 
 k8s_object(

--- a/cluster/prod/config_merger.yaml
+++ b/cluster/prod/config_merger.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: testgrid-config-merger
-  namespace: testgrid-canary
+  namespace: testgrid
   labels:
     app: testgrid
     channel: stable
@@ -27,7 +27,7 @@ spec:
       - name: config-merger
         image: gcr.io/k8s-testgrid/config_merger:latest # TODO(chases2): pin to a version that contains this PR
         args:
-        - --config-url=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/mergelists/canary.yaml
+        - --config-url=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/mergelists/prod.yaml
         - --confirm
         - --wait=15m
 ---
@@ -38,4 +38,4 @@ metadata:
     # Uses same as updater
     iam.gke.io/gcp-service-account: testgrid-canary@k8s-testgrid.iam.gserviceaccount.com
   name: config-merger
-  namespace: testgrid-canary
+  namespace: testgrid


### PR DESCRIPTION
Adds the new controllers to the BUILD files for easier deployment
Adds some further logging to the config_merger image