### PR TITLE
Print Config Utility

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -28,6 +28,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//config/print:all-srcs",
         "//config/yamlcfg:all-srcs",
     ],
     tags = ["automanaged"],

--- a/config/print/BUILD.bazel
+++ b/config/print/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/GoogleCloudPlatform/testgrid/config/print",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//config:go_default_library",
+        "//util/gcs:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "print",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/config/print/README.md
+++ b/config/print/README.md
@@ -1,0 +1,12 @@
+# Config Printer
+
+The config printer is a debugging utility that prints a TestGrid configuration in a
+human-readable format. It will read from the local filesystem or Google Cloud Storage.
+
+## Usage and installation
+
+```sh
+go install ./config/print
+print gs://example/config
+```
+A Bazel `run` command also works, but the utility won't be able to read from the local file system as expected.

--- a/config/print/main.go
+++ b/config/print/main.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/GoogleCloudPlatform/testgrid/config"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+
+	"github.com/sirupsen/logrus"
+)
+
+type options struct {
+	configPath string
+	creds      string
+}
+
+func gatherOptions() options {
+	var o options
+	if len(os.Args) > 1 {
+		o.configPath = os.Args[1]
+	}
+	flag.StringVar(&o.configPath, "path", o.configPath, "Local or cloud config to read")
+	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
+	flag.Parse()
+	return o
+}
+
+func main() {
+	log := logrus.WithField("component", "config-printer")
+	opt := gatherOptions()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	storageClient, err := gcs.ClientWithCreds(ctx, opt.creds)
+	if err != nil {
+		log.WithError(err).Info("Can't make cloud storage client; proceeding")
+	}
+
+	cfg, err := config.Read(opt.configPath, ctx, storageClient)
+	if err != nil {
+		logrus.WithError(err).WithField("path", opt.configPath).Fatal("Can't read from path")
+	}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		logrus.WithError(err).Fatal("Can't marshal JSON")
+	}
+
+	fmt.Printf("%s\n", b)
+}


### PR DESCRIPTION
I wrote an experiment to see how well protos would deserialize into json objects (pretty well) and accidentally wrote a useful CLI config printing utility for debugging.

/lint