### PR TITLE
Modify TruncateRunning to truncate any running cell

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -321,13 +321,15 @@ func truncateRunning(cols []InflatedColumn) []InflatedColumn {
 	if len(cols) == 0 {
 		return cols
 	}
-	var stillRunning int
-	for i, c := range cols {
-		if c.Cells[overallRow].Result == statuspb.TestStatus_RUNNING {
-			stillRunning = i + 1
+	for i := len(cols) - 1; i >= 0; i-- {
+		for _, cell := range cols[i].Cells {
+			if cell.Result == statuspb.TestStatus_RUNNING {
+				return cols[i+1:]
+			}
 		}
 	}
-	return cols[stillRunning:]
+	// No cells are found to be running; do not truncate
+	return cols
 }
 
 var (

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -593,6 +593,35 @@ func TestTruncateRunning(t *testing.T) {
 				return cols[2:]
 			},
 		},
+		{
+			name: "drop running columns if any process is running",
+			cols: []InflatedColumn{
+				{
+					Column: &statepb.Column{Build: "running"},
+					Cells: map[string]cell{
+						"process1": {Result: statuspb.TestStatus_RUNNING},
+						"process2": {Result: statuspb.TestStatus_RUNNING},
+					},
+				},
+				{
+					Column: &statepb.Column{Build: "running-partially"},
+					Cells: map[string]cell{
+						"process1": {Result: statuspb.TestStatus_RUNNING},
+						"process2": {Result: statuspb.TestStatus_PASS},
+					},
+				},
+				{
+					Column: &statepb.Column{Build: "ok"},
+					Cells: map[string]cell{
+						"process1": {Result: statuspb.TestStatus_PASS},
+						"process2": {Result: statuspb.TestStatus_PASS},
+					},
+				},
+			},
+			expected: func(cols []inflatedColumn) []inflatedColumn {
+				return cols[2:]
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Modifies TruncateRunning to regenerate a row with any running job in it, not just the "Overall" row.

Allows for TestGrid to detect running jobs even when the "Overall" row isn't being injected.