### PR TITLE
Restrict cell and inflatedColumn aliases to unit tests.

### DIFF
--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -233,8 +233,8 @@ func SplitCells(originalName string, cells ...Cell) map[string]Cell {
 	return out
 }
 
-// convertResult returns an inflatedColumn representation of the GCS result.
-func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, headers []string, metricKey string, result gcsResult, opt groupOptions) (*inflatedColumn, error) {
+// convertResult returns an InflatedColumn representation of the GCS result.
+func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, headers []string, metricKey string, result gcsResult, opt groupOptions) (*InflatedColumn, error) {
 	cells := map[string][]Cell{}
 	var cellID string
 	if nameCfg.multiJob {
@@ -334,7 +334,7 @@ func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, header
 		cells[name] = append([]Cell{c}, cells[name]...)
 	}
 
-	out := inflatedColumn{
+	out := InflatedColumn{
 		Column: &statepb.Column{
 			Build:   id,
 			Started: float64(result.started.Timestamp * 1000),

--- a/pkg/updater/inflate.go
+++ b/pkg/updater/inflate.go
@@ -34,9 +34,6 @@ type InflatedColumn struct {
 	Cells  map[string]Cell
 }
 
-// TODO(fejta): rename everything to InflatedColumn
-type inflatedColumn = InflatedColumn
-
 // Cell holds a row's values for a given column
 type Cell struct {
 	Result statuspb.TestStatus
@@ -49,9 +46,6 @@ type Cell struct {
 
 	Metrics map[string]float64
 }
-
-// TODO(fejta): rename everything to Cell
-type cell = Cell
 
 // inflateGrid inflates the grid's rows into an InflatedColumn channel.
 func inflateGrid(grid *statepb.Grid, earliest, latest time.Time) []InflatedColumn {

--- a/pkg/updater/inflate_test.go
+++ b/pkg/updater/inflate_test.go
@@ -29,6 +29,12 @@ import (
 	statuspb "github.com/GoogleCloudPlatform/testgrid/pb/test_status"
 )
 
+// TODO(fejta): rename everything to InflatedColumn
+type inflatedColumn = InflatedColumn
+
+// TODO(fejta): rename everything to Cell
+type cell = Cell
+
 func blank(n int) []string {
 	var out []string
 	for i := 0; i < n; i++ {

--- a/pkg/updater/read.go
+++ b/pkg/updater/read.go
@@ -34,7 +34,7 @@ import (
 )
 
 func gcsColumnReader(client gcs.Client, buildTimeout time.Duration, concurrency int) ColumnReader {
-	return func(ctx context.Context, log logrus.FieldLogger, tg *configpb.TestGroup, oldCols []inflatedColumn, stop time.Time) ([]inflatedColumn, error) {
+	return func(ctx context.Context, log logrus.FieldLogger, tg *configpb.TestGroup, oldCols []InflatedColumn, stop time.Time) ([]InflatedColumn, error) {
 		tgPaths, err := groupPaths(tg)
 		if err != nil {
 			return nil, fmt.Errorf("group path: %w", err)
@@ -68,7 +68,7 @@ func gcsColumnReader(client gcs.Client, buildTimeout time.Duration, concurrency 
 }
 
 // readColumns will list, download and process builds into inflatedColumns.
-func readColumns(parent context.Context, client gcs.Downloader, group *configpb.TestGroup, builds []gcs.Build, stopTime time.Time, max int, buildTimeout time.Duration, concurrency int) ([]inflatedColumn, error) {
+func readColumns(parent context.Context, client gcs.Downloader, group *configpb.TestGroup, builds []gcs.Build, stopTime time.Time, max int, buildTimeout time.Duration, concurrency int) ([]InflatedColumn, error) {
 	// Spawn build readers
 	if concurrency == 0 {
 		return nil, errors.New("zero readers")
@@ -92,7 +92,7 @@ func readColumns(parent context.Context, client gcs.Downloader, group *configpb.
 		builds = builds[:max]
 	}
 	maxIdx := len(builds)
-	cols := make([]inflatedColumn, maxIdx)
+	cols := make([]InflatedColumn, maxIdx)
 	log.WithField("timeout", buildTimeout).Debug("Updating")
 	ec := make(chan error)
 	old := make(chan int)

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -330,7 +330,7 @@ func growMaxUpdateArea() {
 	updateAreaLock.Unlock()
 }
 
-func truncateBuilds(log logrus.FieldLogger, builds []gcs.Build, cols []inflatedColumn) []gcs.Build {
+func truncateBuilds(log logrus.FieldLogger, builds []gcs.Build, cols []InflatedColumn) []gcs.Build {
 	// determine the average number of rows per column
 	var rows int
 	for _, c := range cols {
@@ -391,7 +391,7 @@ func listBuilds(ctx context.Context, client gcs.Lister, since string, paths ...g
 }
 
 // A ColumnReader will find, process and return new columns to insert into the front of grid state.
-type ColumnReader func(ctx context.Context, log logrus.FieldLogger, tg *configpb.TestGroup, oldCols []inflatedColumn, stop time.Time) ([]inflatedColumn, error)
+type ColumnReader func(ctx context.Context, log logrus.FieldLogger, tg *configpb.TestGroup, oldCols []InflatedColumn, stop time.Time) ([]InflatedColumn, error)
 
 // InflateDropAppend updates groups by downloading the existing grid, dropping old rows and appending new ones.
 func InflateDropAppend(ctx context.Context, log logrus.FieldLogger, client gcs.Client, tg *configpb.TestGroup, gridPath gcs.Path, write bool, readCols ColumnReader) error {
@@ -404,7 +404,7 @@ func InflateDropAppend(ctx context.Context, log logrus.FieldLogger, client gcs.C
 
 	stop := time.Now().Add(-dur)
 
-	var oldCols []inflatedColumn
+	var oldCols []InflatedColumn
 
 	old, err := gcs.DownloadGrid(ctx, client, gridPath)
 	if err != nil {
@@ -602,7 +602,7 @@ func days(d float64) time.Duration {
 // constructGrid will append all the inflatedColumns into the returned Grid.
 //
 // The returned Grid has correctly compressed row values.
-func constructGrid(log logrus.FieldLogger, group *configpb.TestGroup, cols []inflatedColumn) *statepb.Grid {
+func constructGrid(log logrus.FieldLogger, group *configpb.TestGroup, cols []InflatedColumn) *statepb.Grid {
 	// Add the columns into a grid message
 	var grid statepb.Grid
 	rows := map[string]*statepb.Row{} // For fast target => row lookup
@@ -705,7 +705,7 @@ func hasCellID(name string) bool {
 // appendCell adds the rowResult column to the row.
 //
 // Handles the details like missing fields and run-length-encoding the result.
-func appendCell(row *statepb.Row, cell cell, start, count int) {
+func appendCell(row *statepb.Row, cell Cell, start, count int) {
 	latest := int32(cell.Result)
 	n := len(row.Results)
 	switch {


### PR DESCRIPTION
Production-bound code should use the exported Cell and InflatedColumn names.


