### PR TITLE
 Summarize tab by least recently updated order. 

### DIFF
--- a/pkg/summarizer/BUILD.bazel
+++ b/pkg/summarizer/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
     ],
 )
 

--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "@com_github_fvbommel_sortorder//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@com_google_cloud_go_storage//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
         "@org_golang_google_api//googleapi:go_default_library",
     ],
@@ -45,6 +44,7 @@ go_test(
         "//pb/state:go_default_library",
         "//pb/test_status:go_default_library",
         "//util/gcs:go_default_library",
+        "//util/gcs/fake:go_default_library",
         "@com_github_fvbommel_sortorder//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
@@ -52,7 +52,6 @@ go_test(
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
         "@io_k8s_api//core/v1:go_default_library",
-        "@org_golang_google_api//iterator:go_default_library",
         "@org_golang_google_protobuf//testing/protocmp:go_default_library",
     ],
 )

--- a/util/gcs/BUILD.bazel
+++ b/util/gcs/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "local_gcs.go",
         "read.go",
         "real_gcs.go",
+        "sort.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/util/gcs",
     visibility = ["//visibility:public"],
@@ -17,6 +18,7 @@ go_library(
         "//pb/state:go_default_library",
         "@com_github_fvbommel_sortorder//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@org_golang_google_api//iterator:go_default_library",
@@ -50,7 +52,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//util/gcs/fake:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/util/gcs/fake/BUILD.bazel
+++ b/util/gcs/fake/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["fake.go"],
+    importpath = "github.com/GoogleCloudPlatform/testgrid/util/gcs/fake",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//util/gcs:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
+        "@org_golang_google_api//iterator:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "fake_test.go",
+        "sort_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//util/gcs:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/util/gcs/fake/fake.go
+++ b/util/gcs/fake/fake.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"google.golang.org/api/iterator"
+)
+
+type UploadClient struct {
+	Client
+	Uploader
+	Stater
+}
+
+func (fuc UploadClient) If(read, write *storage.Conditions) gcs.ConditionalClient {
+	return fuc
+}
+
+type Stat struct {
+	Err   error
+	Attrs storage.ObjectAttrs
+}
+
+type Stater map[gcs.Path]Stat
+
+func (fs Stater) Stat(ctx context.Context, path gcs.Path) (*storage.ObjectAttrs, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("injected interrupt: %w", err)
+	}
+
+	ret, ok := fs[path]
+	if !ok {
+		return nil, storage.ErrObjectNotExist
+	}
+	if ret.Err != nil {
+		return nil, fmt.Errorf("injected upload error: %w", ret.Err)
+	}
+	return &ret.Attrs, nil
+}
+
+type Uploader map[gcs.Path]Upload
+
+func (fu Uploader) Copy(ctx context.Context, from, to gcs.Path) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("injected interrupt: %w", err)
+	}
+	u, present := fu[from]
+	if !present {
+		return storage.ErrObjectNotExist
+	}
+	if err := u.Err; err != nil {
+		return fmt.Errorf("injected from error: %w", err)
+	}
+
+	fu[to] = u
+	return nil
+}
+
+func (fuc Uploader) Upload(ctx context.Context, path gcs.Path, buf []byte, worldRead bool, cacheControl string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("injected interrupt: %w", err)
+	}
+	if err := fuc[path].Err; err != nil {
+		return fmt.Errorf("injected upload error: %w", err)
+	}
+
+	fuc[path] = Upload{
+		Buf:          buf,
+		CacheControl: cacheControl,
+		WorldRead:    worldRead,
+	}
+	return nil
+}
+
+type Upload struct {
+	Buf          []byte
+	CacheControl string
+	WorldRead    bool
+	Err          error
+}
+
+type Opener map[gcs.Path]Object
+
+func (fo Opener) Open(ctx context.Context, path gcs.Path) (io.ReadCloser, error) {
+	o, ok := fo[path]
+	if !ok {
+		return nil, fmt.Errorf("wrap not exist: %w", storage.ErrObjectNotExist)
+	}
+	if o.OpenErr != nil {
+		return nil, o.OpenErr
+	}
+	return &Reader{
+		Buf:      bytes.NewBufferString(o.Data),
+		ReadErr:  o.ReadErr,
+		CloseErr: o.CloseErr,
+	}, nil
+}
+
+type Object struct {
+	Data     string
+	OpenErr  error
+	ReadErr  error
+	CloseErr error
+}
+
+type Reader struct {
+	Buf      *bytes.Buffer
+	ReadErr  error
+	CloseErr error
+}
+
+func (fr *Reader) Read(p []byte) (int, error) {
+	if fr.ReadErr != nil {
+		return 0, fr.ReadErr
+	}
+	return fr.Buf.Read(p)
+}
+
+func (fr *Reader) Close() error {
+	if fr.CloseErr != nil {
+		return fr.CloseErr
+	}
+	fr.ReadErr = errors.New("already closed")
+	fr.CloseErr = fr.ReadErr
+	return nil
+}
+
+type Lister map[gcs.Path]Iterator
+
+func (fl Lister) Objects(ctx context.Context, path gcs.Path, _, offset string) gcs.Iterator {
+	f := fl[path]
+	f.ctx = ctx
+	return &f
+}
+
+type Iterator struct {
+	Objects []storage.ObjectAttrs
+	Idx     int
+	Err     int // must be > 0
+	ctx     context.Context
+	Offset  string
+}
+
+type Client struct {
+	Lister
+	Opener
+}
+
+func (fi *Iterator) Next() (*storage.ObjectAttrs, error) {
+	if fi.ctx.Err() != nil {
+		return nil, fi.ctx.Err()
+	}
+	for fi.Idx < len(fi.Objects) {
+		if fi.Offset == "" {
+			break
+		}
+		name, prefix := fi.Objects[fi.Idx].Name, fi.Objects[fi.Idx].Prefix
+		if name != "" && name < fi.Offset {
+			continue
+		}
+		if prefix != "" && prefix < fi.Offset {
+			continue
+		}
+		fi.Idx++
+	}
+	if fi.Idx >= len(fi.Objects) {
+		return nil, iterator.Done
+	}
+	if fi.Idx > 0 && fi.Idx == fi.Err {
+		return nil, errors.New("injected Iterator error")
+	}
+
+	o := fi.Objects[fi.Idx]
+	fi.Idx++
+	return &o, nil
+}

--- a/util/gcs/fake/fake_test.go
+++ b/util/gcs/fake/fake_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+)
+
+func TestInterfaces(t *testing.T) {
+	var (
+		_ gcs.Uploader          = &Uploader{}
+		_ gcs.Downloader        = &Client{}
+		_ gcs.Lister            = &Lister{}
+		_ gcs.Iterator          = &Iterator{}
+		_ gcs.Opener            = &Opener{}
+		_ gcs.Copier            = &Uploader{}
+		_ gcs.Client            = &UploadClient{}
+		_ gcs.ConditionalClient = &UploadClient{}
+	)
+}

--- a/util/gcs/fake/sort_test.go
+++ b/util/gcs/fake/sort_test.go
@@ -1,0 +1,388 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake // Needs to be in fake package to access the fakes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/googleapi"
+)
+
+func mustPath(s string) *gcs.Path {
+	p, err := gcs.NewPath(s)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func TestLeastRecentlyUpdated(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name      string
+		ctx       context.Context
+		client    Stater
+		paths     []gcs.Path
+		wantPaths []gcs.Path
+		wantGens  map[gcs.Path]int64
+	}{
+		{
+			name: "already sorted",
+			client: Stater{
+				*mustPath("gs://bucket/first"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 101,
+					},
+				},
+				*mustPath("gs://bucket/second"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 102,
+						Updated:    now.Add(time.Minute),
+					},
+				},
+				*mustPath("gs://bucket/third"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 103,
+						Updated:    now.Add(2 * time.Minute),
+					},
+				},
+			},
+			paths: []gcs.Path{
+				*mustPath("gs://bucket/first"),
+				*mustPath("gs://bucket/second"),
+				*mustPath("gs://bucket/third"),
+			},
+			wantPaths: []gcs.Path{
+				*mustPath("gs://bucket/first"),
+				*mustPath("gs://bucket/second"),
+				*mustPath("gs://bucket/third"),
+			},
+			wantGens: map[gcs.Path]int64{
+				*mustPath("gs://bucket/first"):  101,
+				*mustPath("gs://bucket/second"): 102,
+				*mustPath("gs://bucket/third"):  103,
+			},
+		},
+		{
+			name: "unsorted",
+			client: Stater{
+				*mustPath("gs://bucket/first"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 101,
+					},
+				},
+				*mustPath("gs://bucket/second"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 102,
+						Updated:    now.Add(time.Minute),
+					},
+				},
+				*mustPath("gs://bucket/third"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 103,
+						Updated:    now.Add(2 * time.Minute),
+					},
+				},
+			},
+			paths: []gcs.Path{
+				*mustPath("gs://bucket/third"),
+				*mustPath("gs://bucket/first"),
+				*mustPath("gs://bucket/second"),
+			},
+			wantPaths: []gcs.Path{
+				*mustPath("gs://bucket/first"),
+				*mustPath("gs://bucket/second"),
+				*mustPath("gs://bucket/third"),
+			},
+			wantGens: map[gcs.Path]int64{
+				*mustPath("gs://bucket/first"):  101,
+				*mustPath("gs://bucket/second"): 102,
+				*mustPath("gs://bucket/third"):  103,
+			},
+		},
+		{
+			name: "missing",
+			client: Stater{
+				*mustPath("gs://bucket/first"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 101,
+					},
+				},
+				*mustPath("gs://bucket/third"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 103,
+						Updated:    now.Add(2 * time.Minute),
+					},
+				},
+			},
+			paths: []gcs.Path{
+				*mustPath("gs://bucket/third"),
+				*mustPath("gs://bucket/first"),
+				*mustPath("gs://bucket/missing"),
+			},
+			wantPaths: []gcs.Path{
+				*mustPath("gs://bucket/missing"),
+				*mustPath("gs://bucket/first"),
+				*mustPath("gs://bucket/third"),
+			},
+			wantGens: map[gcs.Path]int64{
+				*mustPath("gs://bucket/first"):   101,
+				*mustPath("gs://bucket/third"):   103,
+				*mustPath("gs://bucket/missing"): 0,
+			},
+		},
+		{
+			name: "error",
+			client: Stater{
+				*mustPath("gs://bucket/first"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 101,
+					},
+				},
+				*mustPath("gs://bucket/third"): {
+					Attrs: storage.ObjectAttrs{
+						Generation: 103,
+						Updated:    now.Add(2 * time.Minute),
+					},
+				},
+				*mustPath("gs://bucket/error"): {
+					Err: errors.New("injected error"),
+				},
+			},
+			paths: []gcs.Path{
+				*mustPath("gs://bucket/third"),
+				*mustPath("gs://bucket/first"),
+				*mustPath("gs://bucket/error"),
+			},
+			wantPaths: []gcs.Path{
+				*mustPath("gs://bucket/error"),
+				*mustPath("gs://bucket/first"),
+				*mustPath("gs://bucket/third"),
+			},
+			wantGens: map[gcs.Path]int64{
+				*mustPath("gs://bucket/first"): 101,
+				*mustPath("gs://bucket/third"): 103,
+				*mustPath("gs://bucket/error"): -1,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := tc.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			got := gcs.LeastRecentlyUpdated(ctx, logrus.WithField("name", tc.name), tc.client, tc.paths)
+			if diff := cmp.Diff(tc.wantGens, got, cmp.AllowUnexported(gcs.Path{})); diff != "" {
+				t.Errorf("unexpected generation diff (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantPaths, tc.paths, cmp.AllowUnexported(gcs.Path{})); diff != "" {
+				t.Errorf("unexpected path diffs (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTouch(t *testing.T) {
+	path := mustPath("gs://bucket/obj")
+
+	cases := []struct {
+		name       string
+		ctx        context.Context
+		client     ConditionalClient
+		generation int64
+		buf        []byte
+		expected   Uploader
+		badCond    bool
+		err        bool
+	}{
+		{
+			name: "canceled context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			generation: 123,
+			client: ConditionalClient{
+				UploadClient: UploadClient{
+					Uploader: Uploader{
+						*path: {
+							Buf:        []byte("hi"),
+							Generation: 123,
+						},
+					},
+					Stater: Stater{
+						*path: Stat{
+							Attrs: storage.ObjectAttrs{
+								Generation: 123,
+							},
+						},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name:       "same gen",
+			generation: 123,
+			client: ConditionalClient{
+				UploadClient: UploadClient{
+					Uploader: Uploader{
+						*path: {
+							Buf:        []byte("hi"),
+							Generation: 123,
+						},
+					},
+					Stater: Stater{
+						*path: Stat{
+							Attrs: storage.ObjectAttrs{
+								Generation: 123,
+							},
+						},
+					},
+				},
+			},
+			expected: Uploader{
+				*path: {
+					Buf:        []byte("hi"),
+					Generation: 124,
+				},
+			},
+		},
+		{
+			name:       "wrong read gen",
+			generation: 123,
+			client: ConditionalClient{
+				UploadClient: UploadClient{
+					Uploader: Uploader{
+						*path: {
+							Err: errors.New("should not get here"),
+						},
+					},
+					Stater: Stater{
+						*path: Stat{
+							Attrs: storage.ObjectAttrs{
+								Generation: 777,
+							},
+						},
+					},
+				},
+			},
+			badCond: true,
+			err:     true,
+		},
+		{
+			name:       "fail copy",
+			generation: 123,
+			client: ConditionalClient{
+				UploadClient: UploadClient{
+					Uploader: Uploader{
+						*path: {
+							Err: errors.New("upload should fail"),
+						},
+					},
+					Stater: Stater{
+						*path: Stat{
+							Attrs: storage.ObjectAttrs{
+								Generation: 123,
+							},
+						},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "upload",
+			client: ConditionalClient{
+				UploadClient: UploadClient{
+					Uploader: Uploader{},
+					Stater:   Stater{},
+				},
+			},
+			buf: []byte("hello"),
+			expected: Uploader{
+				*path: {
+					Buf:          []byte("hello"),
+					Generation:   1,
+					CacheControl: "no-cache",
+				},
+			},
+		},
+		{
+			name: "fail upload",
+			client: ConditionalClient{
+				UploadClient: UploadClient{
+					Uploader: Uploader{
+						*path: {
+							Err: errors.New("upload should fail"),
+						},
+					},
+					Stater: Stater{},
+				},
+			},
+			err: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := tc.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			err := gcs.Touch(ctx, tc.client, *path, tc.generation, tc.buf)
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("got unexpected error: %v", err)
+				}
+				if tc.badCond {
+					var ee *googleapi.Error
+					if !errors.As(err, &ee) {
+						t.Errorf("wanted googleapi.Error, got %v", err)
+					}
+					if got, want := ee.Code, http.StatusPreconditionFailed; want != got {
+						t.Errorf("wanted %v got %v", want, got)
+					}
+				}
+			case tc.err:
+				t.Error("failed to receive an error")
+			default:
+				if diff := cmp.Diff(tc.expected, tc.client.Uploader); diff != "" {
+					t.Errorf("got unexpected diff (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/util/gcs/sort.go
+++ b/util/gcs/sort.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcs
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+)
+
+// LeastRecentlyUpdated sorts paths by their update timestamp, noting generations and any errors.
+func LeastRecentlyUpdated(ctx context.Context, log logrus.FieldLogger, client Stater, paths []Path) map[Path]int64 {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	log.Debug("Sorting groups")
+	updated := make(map[Path]time.Time, len(paths))
+	generations := make(map[Path]int64, len(paths))
+	var wg sync.WaitGroup
+	var lock sync.Mutex
+	for _, apath := range paths {
+		wg.Add(1)
+		path := apath
+		go func() {
+			defer wg.Done()
+			attrs, err := client.Stat(ctx, path)
+			lock.Lock()
+			defer lock.Unlock()
+			switch {
+			case err == storage.ErrObjectNotExist:
+				generations[path] = 0
+			case err != nil:
+				log.WithError(err).WithField("path", path).Warning("Stat failed")
+				generations[path] = -1
+			default:
+				updated[path] = attrs.Updated
+				generations[path] = attrs.Generation
+			}
+		}()
+	}
+	wg.Wait()
+
+	sort.SliceStable(paths, func(i, j int) bool {
+		return !updated[paths[i]].After(updated[paths[j]])
+	})
+
+	if n := len(paths) - 1; n > 0 {
+		p0 := paths[0]
+		pn := paths[n]
+		log.WithFields(logrus.Fields{
+			"newest-path": pn,
+			"newest":      updated[pn],
+			"oldest-path": p0,
+			"oldest":      updated[p0],
+		}).Info("Sorted")
+	}
+
+	return generations
+}
+
+// Touch attempts to win an update of the object.
+//
+// Cloud copies the current object to itself when the object already exists.
+// Otherwise uploads genZero bytes.
+func Touch(ctx context.Context, client ConditionalClient, path Path, generation int64, genZero []byte) error {
+	var cond storage.Conditions
+	if generation != 0 {
+		// Attempt to cloud-copy the object to its current location
+		// - only 1 will win in a concurrent situation
+		// - Increases the last update time.
+		cond.GenerationMatch = generation
+		return client.If(&cond, &cond).Copy(ctx, path, path)
+	}
+
+	// New group, upload the bytes for this situation.
+	cond.DoesNotExist = true
+	return client.If(&cond, &cond).Upload(ctx, path, genZero, DefaultACL, "no-cache")
+}


### PR DESCRIPTION
Refactor `LeastRecentlyUpdated` into `util/gcs`
Move GCS fakes into `util/gcs/fake`
Refactor updater to use `LeastRecentlyUpdated`
Teach summarizer to use `LeastRecentlyUpdated`


Reviewing just the second commit should minimize eye strain (first commit moves the fakes)