### PR TITLE
Allow custom sorting mechanics.

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -133,7 +133,7 @@ func main() {
 		"build": opt.buildConcurrency,
 	}).Info("Configured concurrency")
 
-	groupUpdater := updater.GCS(opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm)
+	groupUpdater := updater.GCS(opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm, updater.SortStarted)
 	updateOnce := func() {
 		start := time.Now()
 		if err := updater.Update(ctx, client, opt.config, opt.gridPrefix, opt.groupConcurrency, opt.group, groupUpdater, opt.confirm); err != nil {

--- a/pkg/updater/inflate.go
+++ b/pkg/updater/inflate.go
@@ -77,8 +77,8 @@ func inflateGrid(grid *statepb.Grid, earliest, latest time.Time) []InflatedColum
 		if when > latest.Unix() {
 			continue
 		}
-		if when < earliest.Unix() && len(cols) > 0 {
-			break // Always keep at least one old column
+		if when < earliest.Unix() && len(cols) > 0 { // Always keep at least one old column
+			continue // Do not assume they are sorted by start time.
 		}
 		cols = append(cols, item)
 


### PR DESCRIPTION
`InflateDropAppend` callers must now provide a column sorting strategy.
* Allow strategy to vary per test group.
Provide a `SortStarted` which sorts columns by their start date.
Ensure inflated columns are:
* `SortStarted` after inflation, before processing
* Sorted according to provided strategy before converting to a grid message.