### PR TITLE
Add CellID when commit_override_strftime is set

### DIFF
--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -239,6 +239,8 @@ func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, header
 	var cellID string
 	if nameCfg.multiJob {
 		cellID = result.job + "/" + id
+	} else if opt.addCellID {
+		cellID = id
 	}
 
 	meta := result.finished.Metadata.Strings()
@@ -326,8 +328,8 @@ func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, header
 	}
 
 	for name, c := range injectedCells {
+		c.CellID = cellID
 		if nameCfg.multiJob {
-			c.CellID = cellID
 			jobName := result.job + "." + name
 			cells[jobName] = append([]Cell{c}, cells[jobName]...)
 		}

--- a/pkg/updater/read.go
+++ b/pkg/updater/read.go
@@ -238,12 +238,14 @@ func readColumns(parent context.Context, client gcs.Downloader, group *configpb.
 type groupOptions struct {
 	merge          bool
 	analyzeProwJob bool
+	addCellID      bool
 }
 
 func makeOptions(group *configpb.TestGroup) groupOptions {
 	return groupOptions{
 		merge:          !group.DisableMergedStatus,
 		analyzeProwJob: !group.DisableProwjobAnalysis,
+		addCellID:      group.CommitOverrideStrftime != "",
 	}
 }
 


### PR DESCRIPTION
Without this there is no way to configure testgrid to open the correct spyglass URL when clicking on a cell.