### PR TITLE
Ensure context has something to read.

### DIFF
--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -1495,6 +1495,9 @@ func TestReadSuites(t *testing.T) {
 		},
 		{
 			name: "cancelled context returns err",
+			data: map[string]fakeObject{
+				"junit.xml": {Data: `<testsuite><testcase name="hi"/></testsuite>`},
+			},
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()


### PR DESCRIPTION
Should mitigate flakiness

`bazelisk test //pkg/updater:all --runs_per_test=100`

fixes https://github.com/GoogleCloudPlatform/testgrid/issues/466