### PR TITLE
Export InflateGrid.

### DIFF
--- a/pkg/updater/inflate.go
+++ b/pkg/updater/inflate.go
@@ -66,8 +66,11 @@ type Cell struct {
 	Issues []string
 }
 
-// inflateGrid inflates the grid's rows into an InflatedColumn channel.
-func inflateGrid(grid *statepb.Grid, earliest, latest time.Time) ([]InflatedColumn, map[string][]string) {
+// InflateGrid inflates the grid's rows into an InflatedColumn channel.
+//
+// Drops columns before earliest or more recent than latest.
+// Also returns a map of issues associated with each row name.
+func InflateGrid(grid *statepb.Grid, earliest, latest time.Time) ([]InflatedColumn, map[string][]string) {
 	var cols []InflatedColumn
 
 	// nothing is blocking, so no need for a parent context.
@@ -128,7 +131,10 @@ func inflateRow(parent context.Context, row *statepb.Row) <-chan Cell {
 		}
 		var val *float64
 		for result := range inflateResults(ctx, row.Results) {
-			c := Cell{Result: result}
+			c := Cell{
+				Result: result,
+				ID:     row.Id,
+			}
 			for name, ch := range Metrics {
 				select {
 				case <-ctx.Done():

--- a/pkg/updater/inflate_test.go
+++ b/pkg/updater/inflate_test.go
@@ -548,12 +548,12 @@ func TestInflateGrid(t *testing.T) {
 			if tc.wantIssues == nil {
 				tc.wantIssues = map[string][]string{}
 			}
-			actual, issues := inflateGrid(tc.grid, tc.earliest, tc.latest)
+			actual, issues := InflateGrid(tc.grid, tc.earliest, tc.latest)
 			if diff := cmp.Diff(tc.expected, actual, cmp.AllowUnexported(inflatedColumn{}, cell{}), protocmp.Transform()); diff != "" {
-				t.Errorf("inflateGrid() got unexpected diff (-want +got):\n%s", diff)
+				t.Errorf("InflateGrid() got unexpected diff (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantIssues, issues); diff != "" {
-				t.Errorf("inflateGrid() got unexpected issue diff (-want +got):\n%s", diff)
+				t.Errorf("InflateGrid() got unexpected issue diff (-want +got):\n%s", diff)
 			}
 		})
 

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -424,7 +424,7 @@ func InflateDropAppend(ctx context.Context, log logrus.FieldLogger, client gcs.C
 	}
 	if old != nil {
 		var cols []InflatedColumn
-		cols, issues = inflateGrid(old, stop, time.Now().Add(-reprocess))
+		cols, issues = InflateGrid(old, stop, time.Now().Add(-reprocess))
 		SortStarted(tg, cols) // Our processing requires descending start time.
 		oldCols = truncateRunning(cols)
 	}


### PR DESCRIPTION
Grid state fields are compressed using a variety of encodings (run-length, sparse, etc).
Getting this correct is non-trivial. Mulitple controllers need to read the grid state and
work with and/or modify this data, so export this function.

Also preserve the cell.ID when inflating cells.