### PR TITLE
Refactor writes to return new object metadata.

### DIFF
--- a/pkg/merger/merger.go
+++ b/pkg/merger/merger.go
@@ -138,7 +138,7 @@ func MergeAndUpdate(ctx context.Context, client mergeClient, list MergeList, ski
 		return fmt.Errorf("can't marshal merged proto: %w", err)
 	}
 
-	if err := client.Upload(ctx, *list.Path, buf, gcs.DefaultACL, "no-cache"); err != nil {
+	if _, err := client.Upload(ctx, *list.Path, buf, gcs.DefaultACL, "no-cache"); err != nil {
 		return fmt.Errorf("can't upload merged proto to %s: %w", list.Path, err)
 	}
 

--- a/pkg/merger/merger_test.go
+++ b/pkg/merger/merger_test.go
@@ -445,10 +445,10 @@ type fakeUploader struct {
 	err      error
 }
 
-func (fu *fakeUploader) Upload(context.Context, gcs.Path, []byte, bool, string) error {
+func (fu *fakeUploader) Upload(context.Context, gcs.Path, []byte, bool, string) (*storage.ObjectAttrs, error) {
 	if fu.err != nil {
-		return fmt.Errorf("injected upload error: %w", fu.err)
+		return nil, fmt.Errorf("injected upload error: %w", fu.err)
 	}
 	fu.uploaded = true
-	return nil
+	return nil, nil
 }

--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//util/metrics:go_default_library",
         "@com_github_fvbommel_sortorder//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
         "@org_golang_google_api//googleapi:go_default_library",
     ],

--- a/util/gcs/client.go
+++ b/util/gcs/client.go
@@ -25,7 +25,7 @@ import (
 
 // Uploader adds upload capabilities to a GCS client.
 type Uploader interface {
-	Upload(context.Context, Path, []byte, bool, string) error
+	Upload(context.Context, Path, []byte, bool, string) (*storage.ObjectAttrs, error)
 }
 
 // Downloader can list files and open them for reading.
@@ -57,7 +57,7 @@ type Stater interface {
 // A Copier can cloud copy an object to a new location.
 type Copier interface {
 	// Copy an object to the specified path
-	Copy(ctx context.Context, from, to Path) error
+	Copy(ctx context.Context, from, to Path) (*storage.ObjectAttrs, error)
 }
 
 // A Client can upload, download and stat.
@@ -104,7 +104,7 @@ func (gc gcsClient) clientFromPath(path Path) ConditionalClient {
 }
 
 // Copy copies the contents of 'from' into 'to'.
-func (gc gcsClient) Copy(ctx context.Context, from, to Path) error {
+func (gc gcsClient) Copy(ctx context.Context, from, to Path) (*storage.ObjectAttrs, error) {
 	client := gc.clientFromPath(from)
 	return client.Copy(ctx, from, to)
 }
@@ -122,7 +122,7 @@ func (gc gcsClient) Objects(ctx context.Context, path Path, delimiter, startOffs
 }
 
 // Upload writes content to the given path.
-func (gc gcsClient) Upload(ctx context.Context, path Path, buf []byte, worldReadable bool, cacheControl string) error {
+func (gc gcsClient) Upload(ctx context.Context, path Path, buf []byte, worldReadable bool, cacheControl string) (*storage.ObjectAttrs, error) {
 	client := gc.clientFromPath(path)
 	return client.Upload(ctx, path, buf, worldReadable, cacheControl)
 }

--- a/util/gcs/fake/sort_test.go
+++ b/util/gcs/fake/sort_test.go
@@ -361,7 +361,7 @@ func TestTouch(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			err := gcs.Touch(ctx, tc.client, *path, tc.generation, tc.buf)
+			_, err := gcs.Touch(ctx, tc.client, *path, tc.generation, tc.buf)
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/util/gcs/local_gcs.go
+++ b/util/gcs/local_gcs.go
@@ -75,10 +75,10 @@ func (lc localClient) If(_, _ *storage.Conditions) ConditionalClient {
 	return NewLocalClient()
 }
 
-func (lc localClient) Copy(ctx context.Context, from, to Path) error {
+func (lc localClient) Copy(ctx context.Context, from, to Path) (*storage.ObjectAttrs, error) {
 	buf, err := ioutil.ReadFile(cleanFilepath(from))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	return lc.Upload(ctx, to, buf, false, "")
 }
@@ -102,8 +102,12 @@ func (lc localClient) Objects(ctx context.Context, path Path, delimiter, startOf
 	}
 }
 
-func (lc localClient) Upload(ctx context.Context, path Path, buf []byte, _ bool, _ string) error {
-	return ioutil.WriteFile(cleanFilepath(path), buf, 0666)
+func (lc localClient) Upload(ctx context.Context, path Path, buf []byte, _ bool, _ string) (*storage.ObjectAttrs, error) {
+	err := ioutil.WriteFile(cleanFilepath(path), buf, 0666)
+	if err != nil {
+		return nil, err
+	}
+	return lc.Stat(ctx, path)
 }
 
 func (lc localClient) Stat(ctx context.Context, path Path) (*storage.ObjectAttrs, error) {

--- a/util/gcs/real_gcs.go
+++ b/util/gcs/real_gcs.go
@@ -55,10 +55,9 @@ func (rgc realGCSClient) handle(path Path, cond *storage.Conditions) *storage.Ob
 	return oh.If(*cond)
 }
 
-func (rgc realGCSClient) Copy(ctx context.Context, from, to Path) error {
+func (rgc realGCSClient) Copy(ctx context.Context, from, to Path) (*storage.ObjectAttrs, error) {
 	fromH := rgc.handle(from, rgc.readCond)
-	_, err := rgc.handle(to, rgc.writeCond).CopierFrom(fromH).Run(ctx)
-	return err
+	return rgc.handle(to, rgc.writeCond).CopierFrom(fromH).Run(ctx)
 }
 
 func (rgc realGCSClient) Open(ctx context.Context, path Path) (io.ReadCloser, error) {
@@ -78,7 +77,7 @@ func (rgc realGCSClient) Objects(ctx context.Context, path Path, delimiter, star
 	})
 }
 
-func (rgc realGCSClient) Upload(ctx context.Context, path Path, buf []byte, worldReadable bool, cacheControl string) error {
+func (rgc realGCSClient) Upload(ctx context.Context, path Path, buf []byte, worldReadable bool, cacheControl string) (*storage.ObjectAttrs, error) {
 	return UploadHandle(ctx, rgc.handle(path, rgc.writeCond), buf, worldReadable, cacheControl)
 }
 

--- a/util/gcs/sort.go
+++ b/util/gcs/sort.go
@@ -36,26 +36,34 @@ func LeastRecentlyUpdated(ctx context.Context, log logrus.FieldLogger, client St
 	generations := make(map[Path]int64, len(paths))
 	var wg sync.WaitGroup
 	var lock sync.Mutex
-	for _, apath := range paths {
-		wg.Add(1)
-		path := apath
+	ch := make(chan Path)
+	const workers = 20
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
 		go func() {
 			defer wg.Done()
-			attrs, err := client.Stat(ctx, path)
-			lock.Lock()
-			defer lock.Unlock()
-			switch {
-			case err == storage.ErrObjectNotExist:
-				generations[path] = 0
-			case err != nil:
-				log.WithError(err).WithField("path", path).Warning("Stat failed")
-				generations[path] = -1
-			default:
-				updated[path] = attrs.Updated
-				generations[path] = attrs.Generation
+			for path := range ch {
+				log.WithField("path", path).Trace("Stat object...")
+				attrs, err := client.Stat(ctx, path)
+				lock.Lock()
+				switch {
+				case err == storage.ErrObjectNotExist:
+					generations[path] = 0
+				case err != nil:
+					log.WithError(err).WithField("path", path).Warning("Stat failed")
+					generations[path] = -1
+				default:
+					updated[path] = attrs.Updated
+					generations[path] = attrs.Generation
+				}
+				lock.Unlock()
 			}
 		}()
 	}
+	for _, apath := range paths {
+		ch <- apath
+	}
+	close(ch)
 	wg.Wait()
 
 	sort.SliceStable(paths, func(i, j int) bool {
@@ -80,7 +88,7 @@ func LeastRecentlyUpdated(ctx context.Context, log logrus.FieldLogger, client St
 //
 // Cloud copies the current object to itself when the object already exists.
 // Otherwise uploads genZero bytes.
-func Touch(ctx context.Context, client ConditionalClient, path Path, generation int64, genZero []byte) error {
+func Touch(ctx context.Context, client ConditionalClient, path Path, generation int64, genZero []byte) (*storage.ObjectAttrs, error) {
 	var cond storage.Conditions
 	if generation != 0 {
 		// Attempt to cloud-copy the object to its current location


### PR DESCRIPTION
When we lock a dashboard by cloud copying it over itself it is useful to track the new generation.
This allows us to conditionally write the new state with the assumption is hasn't changed.

Also, update LeastRecentlyUpdated to set a ceiling on the number of concurrent Stats.
Attempting to stat all paths concurrently is not optimally efficient and can run into
open file limits on some systems.

https://pkg.go.dev/cloud.google.com/go/storage#Copier.Run
https://pkg.go.dev/cloud.google.com/go/storage#Writer.Attrs