### PR TITLE
Fix lint errors, again.

### DIFF
--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -47,9 +47,24 @@ import (
 	"github.com/GoogleCloudPlatform/testgrid/util/metrics"
 )
 
+// Metrics holds metrics relevant to the Updater.
 type Metrics struct {
 	Successes metrics.Counter
 	Errors    metrics.Counter
+}
+
+// Error increments the counter for failed updates.
+func (mets *Metrics) Error() {
+	if mets.Errors != nil {
+		mets.Errors.Add(1, "summarizer")
+	}
+}
+
+// Success increments the counter for successful updates.
+func (mets *Metrics) Success() {
+	if mets.Successes != nil {
+		mets.Successes.Add(1, "summarizer")
+	}
 }
 
 // gridReader returns the grid content and metadata (last updated time, generation id)
@@ -157,13 +172,11 @@ func Update(ctx context.Context, client gcs.ConditionalClient, mets *Metrics, co
 		var errs []string
 		for err := range errCh {
 			if err == nil {
-				if mets.Successes != nil {
-					mets.Successes.Add(1, "summarizer")
-				}
+				mets.Success()
 				continue
 			}
 			if mets.Errors != nil {
-				mets.Errors.Add(1, "summarizer")
+				mets.Error()
 			}
 			errs = append(errs, err.Error())
 		}

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -46,17 +46,20 @@ import (
 	"github.com/GoogleCloudPlatform/testgrid/util/metrics"
 )
 
+// Metrics holds metrics relevant to the Updater.
 type Metrics struct {
 	Successes metrics.Counter
 	Errors    metrics.Counter
 }
 
+// Error increments the counter for failed updates.
 func (mets *Metrics) Error() {
 	if mets.Errors != nil {
 		mets.Errors.Add(1, "updater")
 	}
 }
 
+// Success increments the counter for successful updates.
 func (mets *Metrics) Success() {
 	if mets.Successes != nil {
 		mets.Successes.Add(1, "updater")

--- a/util/gcs/fake/fake.go
+++ b/util/gcs/fake/fake.go
@@ -196,6 +196,7 @@ type Upload struct {
 	Generation   int64
 }
 
+// Attrs returns file attributes.
 func (u Upload) Attrs(path gcs.Path) *storage.ObjectAttrs {
 	return &storage.ObjectAttrs{
 		Bucket:       path.Bucket(),


### PR DESCRIPTION
Also use the same metric functions in Summarizer as in Updater, for consistency.