### PR TITLE
Escape buildFailLink

### DIFF
--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -601,7 +601,7 @@ func failingTestSummaries(rows []*statepb.Row) []*summarypb.FailingTestSummary {
 // buildFailLink creates a search link
 // TODO(#134): Build proper url for both internal and external jobs
 func buildFailLink(testID, target string) string {
-	return fmt.Sprintf("%s %s", testID, target)
+	return fmt.Sprintf("%s %s", url.PathEscape(testID), url.PathEscape(target))
 }
 
 // overallStatus determines whether the tab is stale, failing, flaky or healthy.


### PR DESCRIPTION
Short-term, it's not possible to tokenize this field if either one contains a space in it.

Long-term, I'm not sure that the summarizer should be responsible for creating these links. The stub suggests that an implementation for building a fail link should be passed in, but I think we want to expose the failBuildID and latestFailBuildID directly and let components that want to display a link construct them.