### PR TITLE
Refactor Opener interface to return attributes.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -515,7 +515,7 @@ func MarshalBytes(c *configpb.Configuration) ([]byte, error) {
 
 // ReadGCS opens the config at path and unmarshals it into a Configuration proto.
 func ReadGCS(ctx context.Context, opener gcs.Opener, path gcs.Path) (*configpb.Configuration, error) {
-	r, err := opener.Open(ctx, path)
+	r, _, err := opener.Open(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open config: %v", err)
 	}

--- a/hack/compare_states.go
+++ b/hack/compare_states.go
@@ -201,7 +201,7 @@ func main() {
 			errorMsgs = append(errorMsgs, fmt.Sprintf("gcs.NewPath(%q): %v", firstP, err))
 			continue
 		}
-		firstGrid, err := gcs.DownloadGrid(ctx, client, *firstPath)
+		firstGrid, _, err := gcs.DownloadGrid(ctx, client, *firstPath)
 		if err != nil {
 			errorMsgs = append(errorMsgs, fmt.Sprintf("gcs.DownloadGrid(%q): %v", firstP, err))
 			continue
@@ -211,7 +211,7 @@ func main() {
 			errorMsgs = append(errorMsgs, fmt.Sprintf("gcs.NewPath(%q): %v", secondP, err))
 			continue
 		}
-		secondGrid, err := gcs.DownloadGrid(ctx, client, *secondPath)
+		secondGrid, _, err := gcs.DownloadGrid(ctx, client, *secondPath)
 		if err != nil {
 			errorMsgs = append(errorMsgs, fmt.Sprintf("gcs.DownloadGrid(%q): %v", secondP, err))
 			continue

--- a/pkg/merger/merger_test.go
+++ b/pkg/merger/merger_test.go
@@ -415,15 +415,15 @@ type fakeMergeClient struct {
 
 type fakeOpener map[string]fakeObject
 
-func (fo fakeOpener) Open(_ context.Context, path gcs.Path) (io.ReadCloser, error) {
+func (fo fakeOpener) Open(_ context.Context, path gcs.Path) (io.ReadCloser, *storage.ReaderObjectAttrs, error) {
 	o, ok := fo[path.String()]
 	if !ok {
-		return nil, fmt.Errorf("wrap not exist: %w", storage.ErrObjectNotExist)
+		return nil, nil, fmt.Errorf("wrap not exist: %w", storage.ErrObjectNotExist)
 	}
 	if o.err != nil {
-		return nil, fmt.Errorf("injected open error: %w", o.err)
+		return nil, nil, fmt.Errorf("injected open error: %w", o.err)
 	}
-	return ioutil.NopCloser(bytes.NewReader(o.buf)), nil
+	return ioutil.NopCloser(bytes.NewReader(o.buf)), nil, nil
 }
 
 type fakeObject struct {

--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -281,15 +281,14 @@ func writeSummary(ctx context.Context, client gcs.Client, path gcs.Path, sum *su
 
 // pathReader returns a reader for the specified path and last modified, generation metadata.
 func pathReader(ctx context.Context, client gcs.Client, path gcs.Path) (io.ReadCloser, time.Time, int64, error) {
-	r, err := client.Open(ctx, path)
+	r, attrs, err := client.Open(ctx, path)
 	if err != nil {
 		return nil, time.Time{}, 0, fmt.Errorf("client.Open(): %w", err)
 	}
-	stat, err := client.Stat(ctx, path)
-	if err != nil {
-		return nil, time.Time{}, 0, fmt.Errorf("client.Stat(): %w", err)
+	if attrs == nil {
+		return r, time.Time{}, 0, nil
 	}
-	return r, stat.Updated, stat.Generation, nil
+	return r, attrs.LastModified, attrs.Generation, nil
 }
 
 // updateDashboard will summarize all the tabs (through errors), returning an error if any fail to summarize.

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -417,7 +417,8 @@ func InflateDropAppend(ctx context.Context, log logrus.FieldLogger, client gcs.C
 	var oldCols []InflatedColumn
 	var issues map[string][]string
 
-	old, err := gcs.DownloadGrid(ctx, client, gridPath)
+	// TODO(fejta): track metadata
+	old, _, err := gcs.DownloadGrid(ctx, client, gridPath)
 	if err != nil {
 		log.WithField("path", gridPath).WithError(err).Error("Failed to download existing grid")
 	}

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -1722,12 +1722,12 @@ func TestInflateDropAppend(t *testing.T) {
 				fakeDownloader := fakeOpener{
 					uploadPath: {Data: string(actual[uploadPath].Buf)},
 				}
-				actualGrid, err := gcs.DownloadGrid(ctx, fakeDownloader, uploadPath)
+				actualGrid, _, err := gcs.DownloadGrid(ctx, fakeDownloader, uploadPath)
 				if err != nil {
 					t.Errorf("actual gcs.DownloadGrid() got unexpected error: %v", err)
 				}
 				fakeDownloader[uploadPath] = fakeObject{Data: string(tc.expected.Buf)}
-				expectedGrid, err := gcs.DownloadGrid(ctx, fakeDownloader, uploadPath)
+				expectedGrid, _, err := gcs.DownloadGrid(ctx, fakeDownloader, uploadPath)
 				if err != nil {
 					t.Errorf("expected gcs.DownloadGrid() got unexpected error: %v", err)
 				}

--- a/util/gcs/client.go
+++ b/util/gcs/client.go
@@ -46,7 +46,7 @@ type Iterator interface {
 
 // An Opener opens a path for reading.
 type Opener interface {
-	Open(ctx context.Context, path Path) (io.ReadCloser, error)
+	Open(ctx context.Context, path Path) (io.ReadCloser, *storage.ReaderObjectAttrs, error)
 }
 
 // A Stater can stat an object and get its attributes.
@@ -110,7 +110,7 @@ func (gc gcsClient) Copy(ctx context.Context, from, to Path) (*storage.ObjectAtt
 }
 
 // Open returns a handle for a given path.
-func (gc gcsClient) Open(ctx context.Context, path Path) (io.ReadCloser, error) {
+func (gc gcsClient) Open(ctx context.Context, path Path) (io.ReadCloser, *storage.ReaderObjectAttrs, error) {
 	client := gc.clientFromPath(path)
 	return client.Open(ctx, path)
 }

--- a/util/gcs/fake/fake.go
+++ b/util/gcs/fake/fake.go
@@ -210,24 +210,25 @@ func (u Upload) Attrs(path gcs.Path) *storage.ObjectAttrs {
 type Opener map[gcs.Path]Object
 
 // Open returns a handle for a given path.
-func (fo Opener) Open(ctx context.Context, path gcs.Path) (io.ReadCloser, error) {
+func (fo Opener) Open(ctx context.Context, path gcs.Path) (io.ReadCloser, *storage.ReaderObjectAttrs, error) {
 	o, ok := fo[path]
 	if !ok {
-		return nil, fmt.Errorf("wrap not exist: %w", storage.ErrObjectNotExist)
+		return nil, nil, fmt.Errorf("wrap not exist: %w", storage.ErrObjectNotExist)
 	}
 	if o.OpenErr != nil {
-		return nil, o.OpenErr
+		return nil, nil, o.OpenErr
 	}
 	return &Reader{
 		Buf:      bytes.NewBufferString(o.Data),
 		ReadErr:  o.ReadErr,
 		CloseErr: o.CloseErr,
-	}, nil
+	}, o.Attrs, nil
 }
 
 // Object holds data for an object.
 type Object struct {
 	Data     string
+	Attrs    *storage.ReaderObjectAttrs
 	OpenErr  error
 	ReadErr  error
 	CloseErr error

--- a/util/gcs/gcs.go
+++ b/util/gcs/gcs.go
@@ -196,26 +196,26 @@ func UploadHandle(ctx context.Context, handle *storage.ObjectHandle, buf []byte,
 }
 
 // DownloadGrid downloads and decompresses a grid from the specified path.
-func DownloadGrid(ctx context.Context, opener Opener, path Path) (*statepb.Grid, error) {
+func DownloadGrid(ctx context.Context, opener Opener, path Path) (*statepb.Grid, *storage.ReaderObjectAttrs, error) {
 	var g statepb.Grid
-	r, err := opener.Open(ctx, path)
+	r, attrs, err := opener.Open(ctx, path)
 	if err != nil && err == storage.ErrObjectNotExist {
-		return &g, nil
+		return &g, nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("open: %w", err)
+		return nil, nil, fmt.Errorf("open: %w", err)
 	}
 	defer r.Close()
 	zr, err := zlib.NewReader(r)
 	if err != nil {
-		return nil, fmt.Errorf("open zlib: %w", err)
+		return nil, nil, fmt.Errorf("open zlib: %w", err)
 	}
 	pbuf, err := ioutil.ReadAll(zr)
 	if err != nil {
-		return nil, fmt.Errorf("decompress: %w", err)
+		return nil, nil, fmt.Errorf("decompress: %w", err)
 	}
 	err = proto.Unmarshal(pbuf, &g)
-	return &g, err
+	return &g, attrs, err
 }
 
 // MarshalGrid serializes a state proto into zlib-compressed bytes.

--- a/util/gcs/local_gcs.go
+++ b/util/gcs/local_gcs.go
@@ -83,8 +83,9 @@ func (lc localClient) Copy(ctx context.Context, from, to Path) (*storage.ObjectA
 	return lc.Upload(ctx, to, buf, false, "")
 }
 
-func (lc localClient) Open(ctx context.Context, path Path) (io.ReadCloser, error) {
-	return os.Open(cleanFilepath(path))
+func (lc localClient) Open(ctx context.Context, path Path) (io.ReadCloser, *storage.ReaderObjectAttrs, error) {
+	r, err := os.Open(cleanFilepath(path))
+	return r, &storage.ReaderObjectAttrs{}, err
 }
 
 func (lc localClient) Objects(ctx context.Context, path Path, delimiter, startOffset string) Iterator {

--- a/util/gcs/read.go
+++ b/util/gcs/read.go
@@ -310,7 +310,7 @@ func parseSuitesMeta(name string) map[string]string {
 
 // readJSON will decode the json object stored in GCS.
 func readJSON(ctx context.Context, opener Opener, p Path, i interface{}) error {
-	reader, err := opener.Open(ctx, p)
+	reader, _, err := opener.Open(ctx, p)
 	if errors.Is(err, storage.ErrObjectNotExist) {
 		return err
 	}
@@ -408,7 +408,7 @@ type SuitesMeta struct {
 }
 
 func readSuites(ctx context.Context, opener Opener, p Path) (*junit.Suites, error) {
-	r, err := opener.Open(ctx, p)
+	r, _, err := opener.Open(ctx, p)
 	if err != nil {
 		return nil, fmt.Errorf("open: %w", err)
 	}

--- a/util/gcs/read_test.go
+++ b/util/gcs/read_test.go
@@ -772,23 +772,24 @@ func TestReadJSON(t *testing.T) {
 
 type fakeOpener map[Path]fakeObject
 
-func (fo fakeOpener) Open(ctx context.Context, path Path) (io.ReadCloser, error) {
+func (fo fakeOpener) Open(ctx context.Context, path Path) (io.ReadCloser, *storage.ReaderObjectAttrs, error) {
 	o, ok := fo[path]
 	if !ok {
-		return nil, fmt.Errorf("wrap not exist: %w", storage.ErrObjectNotExist)
+		return nil, nil, fmt.Errorf("wrap not exist: %w", storage.ErrObjectNotExist)
 	}
 	if o.openErr != nil {
-		return nil, o.openErr
+		return nil, nil, o.openErr
 	}
 	return ioutil.NopCloser(&fakeReader{
 		buf:      bytes.NewBufferString(o.data),
 		readErr:  o.readErr,
 		closeErr: o.closeErr,
-	}), nil
+	}), o.attrs, nil
 }
 
 type fakeObject struct {
 	data     string
+	attrs    *storage.ReaderObjectAttrs
 	openErr  error
 	readErr  error
 	closeErr error

--- a/util/gcs/real_gcs.go
+++ b/util/gcs/real_gcs.go
@@ -60,9 +60,12 @@ func (rgc realGCSClient) Copy(ctx context.Context, from, to Path) (*storage.Obje
 	return rgc.handle(to, rgc.writeCond).CopierFrom(fromH).Run(ctx)
 }
 
-func (rgc realGCSClient) Open(ctx context.Context, path Path) (io.ReadCloser, error) {
+func (rgc realGCSClient) Open(ctx context.Context, path Path) (io.ReadCloser, *storage.ReaderObjectAttrs, error) {
 	r, err := rgc.handle(path, rgc.readCond).NewReader(ctx)
-	return r, err
+	if r == nil {
+		return nil, nil, err
+	}
+	return r, &r.Attrs, err
 }
 
 func (rgc realGCSClient) Objects(ctx context.Context, path Path, delimiter, startOffset string) Iterator {


### PR DESCRIPTION
This allows the consumer of the open file to know various metadata, such as when it was last modified and/or
the object generation. This can help minimize conflicts by minimizing the time between when we discover the
generation of a downloaded object and when we attempt to update it, assuming the remote generation is unchanged.