### PR TITLE
Refactor updater to continually send groups to be updated.

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config.go",
         "converge.go",
+        "queue.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/config",
     visibility = ["//visibility:public"],
@@ -13,7 +14,9 @@ go_library(
         "//util/gcs:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
+        "@org_bitbucket_creachadair_stringset//:go_default_library",
     ],
 )
 
@@ -40,11 +43,14 @@ go_test(
     srcs = [
         "config_test.go",
         "converge_test.go",
+        "queue_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//pb/config:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
+        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
     ],
 )

--- a/config/queue.go
+++ b/config/queue.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"container/heap"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"bitbucket.org/creachadair/stringset"
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/sirupsen/logrus"
+)
+
+// TestGroupQueue can send test groups to receivers at a specific frequency.
+//
+// Also contains the ability to modify the next time to send groups.
+// First call must be to Init().
+// Exported methods are safe to call concurrently.
+type TestGroupQueue struct {
+	queue priorityQueue
+	items map[string]*item
+	lock  sync.RWMutex
+}
+
+// Init (or reinit) the queue with the specified groups, which should be updated at frequency.
+func (q *TestGroupQueue) Init(testGroups []*configpb.TestGroup, when time.Time) {
+	n := len(testGroups)
+	found := stringset.NewSize(n)
+
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	if q.items == nil {
+		q.items = make(map[string]*item, n)
+	}
+	if q.queue == nil {
+		q.queue = make(priorityQueue, 0, n)
+	}
+	items := q.items
+
+	for _, tg := range testGroups {
+		name := tg.Name
+		found.Add(name)
+		it, ok := items[name]
+		if !ok {
+			it = &item{
+				tg:    tg,
+				when:  when,
+				index: len(q.queue),
+			}
+			heap.Push(&q.queue, it)
+			items[name] = it
+		} else {
+			it.tg = tg
+		}
+	}
+
+	for name, it := range items {
+		if found.Contains(name) {
+			continue
+		}
+		heap.Remove(&q.queue, it.index)
+		delete(q.items, name)
+	}
+}
+
+// FixAll will fix multiple groups inside a single critical section.
+func (q *TestGroupQueue) FixAll(whens map[string]time.Time) error {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	var missing []string
+	for name, when := range whens {
+		it, ok := q.items[name]
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		it.when = when
+	}
+	heap.Init(&q.queue)
+	if len(missing) > 0 {
+		return fmt.Errorf("not found: %v", missing)
+	}
+	return nil
+}
+
+// Fix the next time to send the group to receivers.
+func (q *TestGroupQueue) Fix(name string, when time.Time) error {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	it, ok := q.items[name]
+	if !ok {
+		return errors.New("not found")
+	}
+	it.when = when
+	heap.Fix(&q.queue, it.index)
+	return nil
+}
+
+// Status of the queue: depth, next item and when the next item is ready.
+func (q *TestGroupQueue) Status() (int, *configpb.TestGroup, time.Time) {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	var tg *configpb.TestGroup
+	var when time.Time
+	if it := q.queue.peek(); it != nil {
+		tg = it.tg
+		when = it.when
+	}
+	return len(q.queue), tg, when
+}
+
+// Send test groups to receivers until the context expires.
+//
+// Pops items off the queue when frequency is zero.
+// Otherwise reschedules the item after the specified frequency has elapsed.
+func (q *TestGroupQueue) Send(ctx context.Context, receivers chan<- *configpb.TestGroup, frequency time.Duration) error {
+	var next func() (*configpb.TestGroup, time.Time)
+	if frequency == 0 {
+		next = func() (*configpb.TestGroup, time.Time) {
+			if len(q.queue) == 0 {
+				return nil, time.Time{}
+			}
+			it := heap.Pop(&q.queue).(*item)
+			return it.tg, it.when
+		}
+	} else {
+		next = func() (*configpb.TestGroup, time.Time) {
+			it := q.queue.peek()
+			if it == nil {
+				return nil, time.Time{}
+			}
+			when := it.when
+			it.when = time.Now().Add(frequency)
+			heap.Fix(&q.queue, it.index)
+			return it.tg, when
+		}
+	}
+
+	for {
+		q.lock.Lock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		tg, when := next()
+		q.lock.Unlock()
+
+		if tg == nil {
+			if frequency == 0 {
+				return nil
+			}
+			time.Sleep(time.Second)
+			continue
+		}
+
+		dur := when.Sub(time.Now())
+		if dur > 0 {
+			logrus.WithFields(logrus.Fields{
+				"duration": dur.Round(100 * time.Millisecond),
+				"group":    tg.Name,
+				"when":     when,
+			}).Info("Sleeping...")
+			time.Sleep(dur)
+		}
+		select {
+		case receivers <- tg:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+type priorityQueue []*item
+
+func (pq priorityQueue) Len() int { return len(pq) }
+func (pq priorityQueue) Less(i, j int) bool {
+	return pq[i].when.Before(pq[j].when)
+}
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *priorityQueue) Push(something interface{}) {
+	it := something.(*item)
+	it.index = len(*pq)
+	*pq = append(*pq, it)
+}
+
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	it.index = -1
+	old[n-1] = nil
+	*pq = old[0 : n-1]
+	return it
+}
+
+func (pq priorityQueue) peek() *item {
+	n := len(pq)
+	if n == 0 {
+		return nil
+	}
+	return pq[0]
+}
+
+type item struct {
+	tg    *configpb.TestGroup
+	when  time.Time
+	index int
+}

--- a/config/queue_test.go
+++ b/config/queue_test.go
@@ -1,0 +1,689 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"container/heap"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestInit(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name   string
+		q      *TestGroupQueue
+		groups []*configpb.TestGroup
+		when   time.Time
+
+		next []*configpb.TestGroup
+	}{
+		{
+			name: "add",
+			q:    &TestGroupQueue{},
+			groups: []*configpb.TestGroup{
+				{
+					Name: "hi",
+				},
+			},
+			when: now,
+
+			next: []*configpb.TestGroup{
+				{
+					Name: "hi",
+				},
+			},
+		},
+		{
+			name: "remove",
+			q: func() *TestGroupQueue {
+				var q TestGroupQueue
+				q.Init([]*configpb.TestGroup{
+					{
+						Name: "drop",
+					},
+					{
+						Name: "keep",
+					},
+				}, now)
+				return &q
+			}(),
+			groups: []*configpb.TestGroup{
+				{
+					Name: "keep",
+				},
+				{
+					Name: "add",
+				},
+			},
+			when: now.Add(-time.Minute),
+
+			next: []*configpb.TestGroup{
+				{
+					Name: "add",
+				},
+				{
+					Name: "keep",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.q.Init(tc.groups, tc.when)
+
+			var got []*configpb.TestGroup
+			for range tc.next {
+				got = append(got, heap.Pop(&tc.q.queue).(*item).tg)
+			}
+			if diff := cmp.Diff(tc.next, got, protocmp.Transform()); diff != "" {
+				t.Errorf("FixAll() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFixAll(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name  string
+		q     *TestGroupQueue
+		fixes map[string]time.Time
+
+		next []*configpb.TestGroup
+		err  bool
+	}{
+		{
+			name: "empty",
+			q:    &TestGroupQueue{},
+		},
+		{
+			name: "basic",
+			q: func() *TestGroupQueue {
+				var q TestGroupQueue
+				q.Init([]*configpb.TestGroup{
+					{
+						Name: "first-now-second",
+					},
+					{
+						Name: "second-now-fifth",
+					},
+					{
+						Name: "third",
+					},
+					{
+						Name: "fourth-now-first",
+					},
+					{
+						Name: "fifth-now-fourth",
+					},
+				}, now)
+				return &q
+			}(),
+			fixes: map[string]time.Time{
+				"fourth-now-first": now.Add(-2 * time.Minute),
+				"first-now-second": now.Add(-time.Minute),
+				"second-now-fifth": now.Add(2 * time.Minute),
+				"fifth-now-fourth": now.Add(time.Minute),
+			},
+
+			next: []*configpb.TestGroup{
+				{
+					Name: "fourth-now-first",
+				},
+				{
+					Name: "first-now-second",
+				},
+				{
+					Name: "third",
+				},
+				{
+					Name: "fifth-now-fourth",
+				},
+				{
+					Name: "second-now-fifth",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.q.FixAll(tc.fixes); (err != nil) != tc.err {
+				t.Errorf("FixAll() got unexpected error %v, wanted err=%t", err, tc.err)
+			}
+			var got []*configpb.TestGroup
+			for range tc.next {
+				got = append(got, heap.Pop(&tc.q.queue).(*item).tg)
+			}
+			if diff := cmp.Diff(tc.next, got, protocmp.Transform()); diff != "" {
+				t.Errorf("FixAll() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFix(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		fix  string
+		when time.Time
+		q    *TestGroupQueue
+
+		next []*configpb.TestGroup
+		err  bool
+	}{
+		{
+			name: "missing",
+			fix:  "missing",
+			q:    &TestGroupQueue{},
+			err:  true,
+		},
+		{
+			name: "basic",
+			fix:  "basic",
+			q: func() *TestGroupQueue {
+				var q TestGroupQueue
+				q.Init([]*configpb.TestGroup{
+					{
+						Name: "basic",
+					},
+					{
+						Name: "was-later-now-first",
+					},
+				}, now)
+				return &q
+			}(),
+			when: now.Add(time.Minute),
+			next: []*configpb.TestGroup{
+				{
+					Name: "was-later-now-first",
+				},
+				{
+					Name: "basic",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.q.Fix(tc.fix, tc.when); (err != nil) != tc.err {
+				t.Errorf("Fix() got unexpected error %v, wanted err=%t", err, tc.err)
+			}
+			var got []*configpb.TestGroup
+			for range tc.next {
+				got = append(got, heap.Pop(&tc.q.queue).(*item).tg)
+			}
+			if diff := cmp.Diff(tc.next, got, protocmp.Transform()); diff != "" {
+				t.Errorf("Fix() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		q    *TestGroupQueue
+
+		depth int
+		next  *configpb.TestGroup
+		when  time.Time
+	}{
+		{
+			name: "empty",
+			q:    &TestGroupQueue{},
+		},
+		{
+			name: "single",
+			q: func() *TestGroupQueue {
+				var q TestGroupQueue
+				q.Init([]*configpb.TestGroup{
+					{
+						Name: "hi",
+					},
+				}, now)
+				return &q
+			}(),
+			depth: 1,
+			next: &configpb.TestGroup{
+				Name: "hi",
+			},
+			when: now,
+		},
+		{
+			name: "multi",
+			q: func() *TestGroupQueue {
+				var q TestGroupQueue
+				q.Init([]*configpb.TestGroup{
+					{
+						Name: "hi",
+					},
+					{
+						Name: "middle",
+					},
+					{
+						Name: "there",
+					},
+				}, now)
+				q.Fix("middle", now.Add(-time.Minute))
+				return &q
+			}(),
+			depth: 3,
+			next: &configpb.TestGroup{
+				Name: "middle",
+			},
+			when: now.Add(-time.Minute),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			depth, next, when := tc.q.Status()
+			if want, got := tc.depth, depth; want != got {
+				t.Errorf("Status() wanted depth %d, got %d", want, got)
+			}
+			if diff := cmp.Diff(tc.next, next, protocmp.Transform()); diff != "" {
+				t.Errorf("Status() got unexpected next diff (-want +got):\n%s", diff)
+			}
+			if !when.Equal(tc.when) {
+				t.Errorf("Status() wanted when %v, got %v", tc.when, when)
+			}
+		})
+	}
+}
+
+func TestSend(t *testing.T) {
+	cases := []struct {
+		name      string
+		q         *TestGroupQueue
+		receivers func(context.Context) (context.Context, chan<- *configpb.TestGroup, func() []*configpb.TestGroup)
+		freq      time.Duration
+
+		want []*configpb.TestGroup
+	}{
+		{
+			name: "empty",
+			q:    &TestGroupQueue{},
+			receivers: func(ctx context.Context) (context.Context, chan<- *configpb.TestGroup, func() []*configpb.TestGroup) {
+				ch := make(chan *configpb.TestGroup)
+				go func() {
+					for {
+						select {
+						case tg := <-ch:
+							t.Fatalf("Send() receiver got unexpected group: %v", tg)
+						case <-ctx.Done():
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []*configpb.TestGroup { return nil }
+			},
+		},
+		{
+			name: "empty loop",
+			q:    &TestGroupQueue{},
+			receivers: func(ctx context.Context) (context.Context, chan<- *configpb.TestGroup, func() []*configpb.TestGroup) {
+				ch := make(chan *configpb.TestGroup)
+				ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+				go func() {
+					for {
+						select {
+						case tg := <-ch:
+							t.Fatalf("Send() receiver got unexpected group: %v", tg)
+						case <-ctx.Done():
+							cancel()
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []*configpb.TestGroup { return nil }
+			},
+			freq: time.Microsecond,
+		},
+		{
+			name: "single",
+			q: func() *TestGroupQueue {
+				var q TestGroupQueue
+				q.Init([]*configpb.TestGroup{
+					{
+						Name: "hi",
+					},
+				}, time.Now())
+				return &q
+			}(),
+			receivers: func(ctx context.Context) (context.Context, chan<- *configpb.TestGroup, func() []*configpb.TestGroup) {
+				ch := make(chan *configpb.TestGroup)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				var got []*configpb.TestGroup
+				ctx, cancel := context.WithCancel(ctx)
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case tg := <-ch:
+							got = append(got, tg)
+							cancel()
+						case <-ctx.Done():
+							cancel()
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []*configpb.TestGroup {
+					wg.Wait()
+					return got
+				}
+			},
+			want: []*configpb.TestGroup{
+				{
+					Name: "hi",
+				},
+			},
+		},
+		{
+			name: "single loop",
+			q: func() *TestGroupQueue {
+				var q TestGroupQueue
+				q.Init([]*configpb.TestGroup{
+					{
+						Name: "hi",
+					},
+				}, time.Now())
+				return &q
+			}(),
+			receivers: func(ctx context.Context) (context.Context, chan<- *configpb.TestGroup, func() []*configpb.TestGroup) {
+				ch := make(chan *configpb.TestGroup)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				var got []*configpb.TestGroup
+				ctx, cancel := context.WithCancel(ctx)
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case tg := <-ch:
+							got = append(got, tg)
+							if len(got) == 3 {
+								cancel()
+							}
+						case <-ctx.Done():
+							cancel()
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []*configpb.TestGroup {
+					wg.Wait()
+					return got
+				}
+			},
+			freq: time.Microsecond,
+			want: []*configpb.TestGroup{
+				{
+					Name: "hi",
+				},
+				{
+					Name: "hi",
+				},
+				{
+					Name: "hi",
+				},
+			},
+		},
+		{
+			name: "multi",
+			q: func() *TestGroupQueue {
+				var q TestGroupQueue
+				q.Init([]*configpb.TestGroup{
+					{
+						Name: "hi",
+					},
+					{
+						Name: "there",
+					},
+				}, time.Now())
+				return &q
+			}(),
+			receivers: func(ctx context.Context) (context.Context, chan<- *configpb.TestGroup, func() []*configpb.TestGroup) {
+				ch := make(chan *configpb.TestGroup)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				var got []*configpb.TestGroup
+				ctx, cancel := context.WithCancel(ctx)
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case tg := <-ch:
+							got = append(got, tg)
+							if len(got) == 2 {
+								cancel()
+							}
+						case <-ctx.Done():
+							cancel()
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []*configpb.TestGroup {
+					wg.Wait()
+					return got
+				}
+			},
+			want: []*configpb.TestGroup{
+				{
+					Name: "hi",
+				},
+				{
+					Name: "there",
+				},
+			},
+		},
+		{
+			name: "multi loop",
+			q: func() *TestGroupQueue {
+				var q TestGroupQueue
+				q.Init([]*configpb.TestGroup{
+					{
+						Name: "hi",
+					},
+					{
+						Name: "there",
+					},
+				}, time.Now())
+				return &q
+			}(),
+			receivers: func(ctx context.Context) (context.Context, chan<- *configpb.TestGroup, func() []*configpb.TestGroup) {
+				ch := make(chan *configpb.TestGroup)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				var got []*configpb.TestGroup
+				ctx, cancel := context.WithCancel(ctx)
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case tg := <-ch:
+							got = append(got, tg)
+							if len(got) == 6 {
+								cancel()
+							}
+						case <-ctx.Done():
+							cancel()
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []*configpb.TestGroup {
+					wg.Wait()
+					return got
+				}
+			},
+			freq: time.Microsecond,
+			want: []*configpb.TestGroup{
+				{
+					Name: "hi",
+				},
+				{
+					Name: "there",
+				},
+				{
+					Name: "hi",
+				},
+				{
+					Name: "there",
+				},
+				{
+					Name: "hi",
+				},
+				{
+					Name: "there",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ctx, channel, get := tc.receivers(ctx)
+			if err := tc.q.Send(ctx, channel, tc.freq); err != ctx.Err() {
+				t.Errorf("Send() returned unexpected error: want %v, got %v", ctx.Err(), err)
+			}
+			got := get()
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("Send() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPriorityQueue(t *testing.T) {
+	cases := []struct {
+		name  string
+		items []*item
+		want  []*configpb.TestGroup
+	}{
+		{
+			name: "basic",
+		},
+		{
+			name: "single",
+			items: []*item{
+				{
+					tg: &configpb.TestGroup{
+						Name: "hi",
+					},
+				},
+			},
+			want: []*configpb.TestGroup{
+				{
+					Name: "hi",
+				},
+			},
+		},
+		{
+			name: "desc",
+			items: []*item{
+				{
+					tg: &configpb.TestGroup{
+						Name: "young",
+					},
+					when: time.Now(),
+				},
+				{
+					tg: &configpb.TestGroup{
+						Name: "old",
+					},
+					when: time.Now().Add(-time.Hour),
+				},
+			},
+			want: []*configpb.TestGroup{
+				{
+					Name: "old",
+				},
+				{
+					Name: "young",
+				},
+			},
+		},
+		{
+			name: "asc",
+			items: []*item{
+				{
+					tg: &configpb.TestGroup{
+						Name: "old",
+					},
+					when: time.Now().Add(-time.Hour),
+				},
+				{
+					tg: &configpb.TestGroup{
+						Name: "young",
+					},
+					when: time.Now(),
+				},
+			},
+			want: []*configpb.TestGroup{
+				{
+					Name: "old",
+				},
+				{
+					Name: "young",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pq := priorityQueue(tc.items)
+			heap.Init(&pq)
+			var got []*configpb.TestGroup
+			for i, w := range tc.want {
+				g := pq.peek().tg
+				if diff := cmp.Diff(w, g, protocmp.Transform()); diff != "" {
+					t.Errorf("%d peek() got unexpected diff (-want +got):\n%s", i, diff)
+				}
+				got = append(got, heap.Pop(&pq).(*item).tg)
+			}
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("priorityQueue() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/GoogleCloudPlatform/testgrid
 
 require (
+	bitbucket.org/creachadair/stringset v0.0.9
 	cloud.google.com/go/storage v1.10.1-0.20200805182106-fcd132957b02
 	github.com/client9/misspell v0.3.4
 	github.com/fvbommel/sortorder v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bitbucket.org/creachadair/stringset v0.0.9 h1:L4vld9nzPt90UZNrXjNelTshD74ps4P5NGs3Iq6yN3o=
+bitbucket.org/creachadair/stringset v0.0.9/go.mod h1:t+4WcQ4+PXTa8aQdNKe40ZP6iwesoMFWAxPGd3UGjyY=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -45,6 +47,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/creachadair/staticfile v0.1.3/go.mod h1:a3qySzCIXEprDGxk6tSxSI+dBBdLzqeBOMhZ+o2d3pM=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pb/config:go_default_library",
         "//pb/state:go_default_library",
         "//pb/test_status:go_default_library",
-        "//util:go_default_library",
         "//util/gcs:go_default_library",
         "//util/metrics:go_default_library",
         "@com_github_fvbommel_sortorder//:go_default_library",

--- a/repos.bzl
+++ b/repos.bzl
@@ -949,3 +949,19 @@ def go_repositories():
         sum = "h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=",
         version = "v0.0.0-20190525122527-15d366b2352e",
     )
+    go_repository(
+        name = "com_github_creachadair_staticfile",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/creachadair/staticfile",
+        sum = "h1:RhyrMgi7IQn3GejgmGtFuCec58vboEMt5CH6N3ulRJk=",
+        version = "v0.1.3",
+    )
+    go_repository(
+        name = "org_bitbucket_creachadair_stringset",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "bitbucket.org/creachadair/stringset",
+        sum = "h1:L4vld9nzPt90UZNrXjNelTshD74ps4P5NGs3Iq6yN3o=",
+        version = "v0.0.9",
+    )

--- a/util/metrics/log.go
+++ b/util/metrics/log.go
@@ -58,7 +58,7 @@ func (m *logInt64) Set(n int64, fields ...string) {
 	for i, field := range fields {
 		log.WithField(m.fields[i], field)
 	}
-	m.val += n
+	m.val = n
 	log.Infof("int64 %q.Set(%d) = %d", m.Name(), n, m.val)
 }
 


### PR DESCRIPTION
Currently updater will wait until all groups have been updated once before updating them a second time.
Instead groups are put into a priority queue based on how recently they were updated.
As soon as an item is sent for an update, its moved to the back of the queue.

This helps mitigate the situation where 99% of the groups have been updated but the last one is taking a long time.
Instead of waiting for this one to finish, the other groupConcurrency workers will being updating the other groups
while this one is finishing.