### PR TITLE
Code cleanup.

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -424,7 +424,7 @@ func truncateRunning(cols []InflatedColumn) []InflatedColumn {
 }
 
 var (
-	maxUpdateArea  int = 20000
+	maxUpdateArea  = 20000
 	updateAreaLock sync.RWMutex
 )
 

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -306,7 +306,7 @@ type fakeInt64 struct {
 	values []int64
 }
 
-func (fc *fakeInt64) Name() string { return "fake-int64" }
+func (fi *fakeInt64) Name() string { return "fake-int64" }
 
 func (fi *fakeInt64) Set(n int64, _ ...string) {
 	fi.values = append(fi.values, n)


### PR DESCRIPTION
Do not call t.Fatal() within a go routine.
Do not use unnecessary typing
Use consistent struct receiver name.