### PR TITLE
Lock access to reading the generation.

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -271,7 +271,7 @@ func Update(parent context.Context, client gcs.ConditionalClient, mets *Metrics,
 	if err != nil {
 		return err
 	}
-	var lock sync.Mutex
+	var lock sync.RWMutex
 	var wg sync.WaitGroup
 	wg.Add(groupConcurrency)
 	defer wg.Wait()
@@ -289,7 +289,9 @@ func Update(parent context.Context, client gcs.ConditionalClient, mets *Metrics,
 					log.WithError(err).Error("Bad path")
 					continue
 				}
+				lock.RLock()
 				gen, ok := generations[tg.Name]
+				lock.RUnlock()
 				if !ok {
 					gen = -1
 				}


### PR DESCRIPTION
Golang will panic if a map is concurrently read and written.
We guard the map write (L303) but we also need to protect when we read from this map.

Switch to use an RWMutex so that we can concurrently read.