### PR TITLE
Reduce concurrency.

### DIFF
--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -24,11 +24,13 @@ spec:
       - name: updater
         image: gcr.io/k8s-testgrid/updater:v20210712-v0.0.76-15-gb105a47 
         args:
-        - --build-timeout=1m
+        - --build-concurrency=2
+        - --build-timeout=2m
         - --config=gs://k8s-testgrid-canary/config
         - --confirm
+        - --group-concurrency=4
+        - --group-timeout=10m
         - --json-logs
-        - --group-timeout=5m
         - --wait=3h
 ---
 apiVersion: v1

--- a/cluster/prod/updater.yaml
+++ b/cluster/prod/updater.yaml
@@ -24,12 +24,14 @@ spec:
       - name: updater
         image: gcr.io/k8s-testgrid/updater:v20210712-v0.0.76-15-gb105a47
         args:
-        - --build-timeout=1m
+        - --build-timeout=2m
+        - --build-concurrency=2
+        - --group-concurrency=4
         - --config=gs://k8s-testgrid/config
         - --confirm
         - --json-logs
-        - --group-timeout=5m
-        - --wait=5m
+        - --group-timeout=10m
+        - --wait=10m
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
We are running into evictions because of memory pressure, so reduce the
number of builds and groups we process in parallel.

This, combined with the fact that we now process new groups last means we struggle to process new groups.
https://github.com/GoogleCloudPlatform/testgrid/blob/95cfeb295b8d6e732fe4cc3f8ab74e67ed33ea8e/config/queue.go#L185

/cc @chizhg 