### PR TITLE
Refactor ColumnReader to use channels.

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -98,7 +98,7 @@ func gatherFlagOptions(fs *flag.FlagSet, args ...string) options {
 	fs.Var(&o.config, "config", "gs://path/to/config.pb")
 	fs.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
 	fs.BoolVar(&o.confirm, "confirm", false, "Upload data if set")
-	fs.Var(&o.groups, "test-groups", "Only update named groups if set")
+	fs.Var(&o.groups, "test-group", "Only update named groups if set (repeatable)")
 	fs.IntVar(&o.groupConcurrency, "group-concurrency", 0, "Manually define the number of groups to concurrently update if non-zero")
 	fs.IntVar(&o.buildConcurrency, "build-concurrency", 0, "Manually define the number of builds to concurrently read if non-zero")
 	fs.DurationVar(&o.wait, "wait", 0, "Ensure at least this much time has passed since the last loop (exit if zero).")

--- a/util/metrics/log.go
+++ b/util/metrics/log.go
@@ -244,7 +244,7 @@ func (g gauge) qps() string {
 	if qps == 0 {
 		return "0 per second"
 	}
-	if qps > 0.01 {
+	if qps < 0.5 {
 		return fmt.Sprintf("%.2f per second", qps)
 	}
 	seconds := time.Second / time.Duration(qps)


### PR DESCRIPTION
Instead of processing all columns and then returning them, send each column to a channel as they are processed.

Requires refactoring the code to start from the oldest result rather than the newest
- Hint (aka build id) is authoritative, not the start time, so stop overriding this value.
- Do use the original stop time in order to spend less time downloading old builds we will just throw away

Obviates the need for truncating results, instead we will track how long we have to update and gracefully stop
requesting more columns after half the time has elapsed, leaving the second half for uploading.

Detect this scenario and immediately request another update cycle for this group (rather than waiting the normal cycle).

Serialize build processing (keeping group concurrency) for the time being (we're still getting eviction errors, will revisit this later).

Also:
* change flag name back to `--test-group=foo --test-group=bar` as this makes more sense than `--test-groups=foo --test-groups=bar`
* Prefer `once per 10 seconds` over `0.1 qps`