### PR TITLE
Emit synthetic columns for ancient builds.

### DIFF
--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -523,7 +523,9 @@ func TestReadColumns(t *testing.T) {
 				GcsPrefix: "bucket/path/to/build/",
 			},
 			expected: []InflatedColumn{
-				// drop 10, 11 and 12
+				ancientColumn("10", .01, nil),
+				ancientColumn("11", .02, nil),
+				ancientColumn("12", .03, nil),
 				{
 					Column: &statepb.Column{
 						Build:   "13",


### PR DESCRIPTION
Otherwise we risk repeating work if we spend the entire cycle reading and skipping old builds
without ever outputting a column. So instead report that this is happening just like we do with
other types of unprocessable builds.