### PR TITLE
API deployment cluster in canary (only)

### DIFF
--- a/cluster/canary/BUILD.bazel
+++ b/cluster/canary/BUILD.bazel
@@ -19,6 +19,7 @@ k8s_objects(
     name = "canary",
     objects = [
         ":namespace",  # Must be first
+        ":api",
         ":summarizer",
         ":updater",
         ":config_merger",
@@ -28,6 +29,13 @@ k8s_objects(
 CLUSTER = "{STABLE_TESTGRID_CLUSTER}"
 
 MULTI_KIND = None
+
+k8s_object(
+    name = "api",
+    cluster = CLUSTER,
+    kind = MULTI_KIND,
+    template = "api.yaml",
+)
 
 k8s_object(
     name = "updater",

--- a/cluster/canary/api.yaml
+++ b/cluster/canary/api.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testgrid-api
+  namespace: testgrid-canary
+  labels:
+    app: testgrid
+    channel: stable
+    component: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      channel: stable
+      component: api
+  template:
+    metadata:
+      labels:
+        app: testgrid
+        channel: stable
+        component: api
+    spec:
+      serviceAccountName: api
+      containers:
+      - name: api
+        image: gcr.io/k8s-testgrid/api:latest # TODO(chases2): tag to version
+        args:
+        - --scope=gs://testgrid-canary
+        - --port=8080
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: testgrid-canary-api@k8s-testgrid.iam.gserviceaccount.com
+  name: api
+  namespace: testgrid-canary
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: api
+spec:
+  selector:
+    app: api
+  ports:
+  - protocol: TCP
+    targetPort: 8080
+    port: 80
+    name: http
+  type: LoadBalancer

--- a/pkg/api/v1/BUILD.bazel
+++ b/pkg/api/v1/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//config:go_default_library",
         "//pb/api/v1:go_default_library",
         "//util/gcs:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/pkg/api/v1/config_test.go
+++ b/pkg/api/v1/config_test.go
@@ -38,11 +38,13 @@ func TestConfigPath(t *testing.T) {
 		defaultBucket string
 		url           string
 		expected      *gcs.Path
+		expectDefault bool
 	}{
 		{
 			name:          "Defaults to default",
 			defaultBucket: "gs://example",
 			expected:      getPathOrDie(t, "gs://example/config"),
+			expectDefault: true,
 		},
 		{
 			name:          "Use config if specified",
@@ -70,9 +72,13 @@ func TestConfigPath(t *testing.T) {
 				t.Fatalf("Can't form request")
 			}
 
-			result, err := s.configPath(request)
+			result, isDefault, err := s.configPath(request)
 			if test.expected == nil && err == nil {
 				t.Fatalf("Expected an error, but got none")
+			}
+
+			if test.expectDefault != isDefault {
+				t.Errorf("Default Flag: Want %t, got %t", test.expectDefault, isDefault)
 			}
 
 			if test.expected != nil && result.String() != test.expected.String() {


### PR DESCRIPTION
Adds extra logging when a default scope is used but still can't read