### PR TITLE
Implement GetDashboardGroup

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.10.1-0.20200805182106-fcd132957b02 h1:Ytgsmpx0p7nr4tJD1NLVa/9+dJt1uXntp3+QA4KcSus=
 cloud.google.com/go/storage v1.10.1-0.20200805182106-fcd132957b02/go.mod h1:bdhVveip9CJX75wUu7ALOTnCSKjv6PHRY0bCeBmePnw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -68,6 +69,7 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -21,9 +21,10 @@ import (
 	"context"
 	"path"
 
+	"github.com/gorilla/mux"
+
 	v1 "github.com/GoogleCloudPlatform/testgrid/pkg/api/v1"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
-	"github.com/gorilla/mux"
 )
 
 // RouterOptions are the options needed to GetRouter
@@ -50,7 +51,7 @@ func GetRouter(options RouterOptions) (*mux.Router, error) {
 		Host:          path.Join(options.Hostname, v1Infix),
 		DefaultBucket: options.HomeBucket,
 	}
-	sub1.HandleFunc("/dashboard-groups", s.ListDashboardGroups).Methods("GET")
+	v1.Route(sub1, s)
 
 	return sub1, nil
 }

--- a/pkg/api/v1/BUILD.bazel
+++ b/pkg/api/v1/BUILD.bazel
@@ -5,13 +5,16 @@ go_library(
     srcs = [
         "config.go",
         "json.go",
+        "server.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/pkg/api/v1",
     visibility = ["//visibility:public"],
     deps = [
         "//config:go_default_library",
         "//pb/api/v1:go_default_library",
+        "//pb/config:go_default_library",
         "//util/gcs:go_default_library",
+        "@com_github_gorilla_mux//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1
 
 import (

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -1,0 +1,25 @@
+package v1
+
+import (
+	"github.com/gorilla/mux"
+
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+)
+
+// Server contains the necessary settings and i/o objects needed to serve this api
+type Server struct {
+	Client        gcs.Client
+	Host          string
+	DefaultBucket string
+}
+
+// Route applies all the v1 API functions provided by the Server to the Router given.
+// If the router is nil, a new one is instantiated.
+func Route(r *mux.Router, s Server) *mux.Router {
+	if r == nil {
+		r = mux.NewRouter()
+	}
+	r.HandleFunc("/dashboard-groups", s.ListDashboardGroups).Methods("GET")
+	r.HandleFunc("/dashboard-groups/{dashboard-group}", s.GetDashboardGroup).Methods("GET")
+	return r
+}


### PR DESCRIPTION
xref #549 

- Refactors testing to use a router instead of server functions directly so test cases are more intuitive
- Deduplicates reused code between the two API functions