### PR TITLE
Use buffered channels instead of concurrency.

### DIFF
--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -510,7 +510,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Name: "this",
@@ -573,7 +573,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Name: "this",
@@ -625,7 +625,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Name: "this",
@@ -676,7 +676,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: []junit.Result{
@@ -801,7 +801,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: []junit.Result{
@@ -972,7 +972,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: []junit.Result{
@@ -1057,7 +1057,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: []junit.Result{
@@ -1080,7 +1080,7 @@ func TestConvertResult(t *testing.T) {
 						},
 					},
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: []junit.Result{
@@ -1145,7 +1145,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: []junit.Result{
@@ -1166,7 +1166,7 @@ func TestConvertResult(t *testing.T) {
 						},
 					},
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: []junit.Result{
@@ -1223,7 +1223,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: []junit.Result{
@@ -1244,7 +1244,7 @@ func TestConvertResult(t *testing.T) {
 						},
 					},
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: []junit.Result{
@@ -1306,7 +1306,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Results: func() []junit.Result {
@@ -1515,7 +1515,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				suites: []gcs.SuitesMeta{
 					{
-						Suites: junit.Suites{
+						Suites: &junit.Suites{
 							Suites: []junit.Suite{
 								{
 									Name: "this",

--- a/util/gcs/sort_test.go
+++ b/util/gcs/sort_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcs
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -51,32 +52,32 @@ func TestSort(t *testing.T) {
 			name: "stable", // already sorted elements do not move
 			builds: []Build{
 				{
-					baseName:          "c",
-					suitesConcurrency: 7,
+					Path:     Path{url: url.URL{Host: "foo"}},
+					baseName: "c",
 				},
 				{
-					baseName:          "c",
-					suitesConcurrency: 1,
+					Path:     Path{url: url.URL{Host: "bar"}},
+					baseName: "c",
 				},
 				{
-					baseName:          "c",
-					suitesConcurrency: 5,
+					Path:     Path{url: url.URL{Path: "other"}},
+					baseName: "c",
 				},
 				{baseName: "a"},
 				{baseName: "b"},
 			},
 			want: []Build{
 				{
-					baseName:          "c",
-					suitesConcurrency: 7,
+					Path:     Path{url: url.URL{Host: "foo"}},
+					baseName: "c",
 				},
 				{
-					baseName:          "c",
-					suitesConcurrency: 1,
+					Path:     Path{url: url.URL{Host: "bar"}},
+					baseName: "c",
 				},
 				{
-					baseName:          "c",
-					suitesConcurrency: 5,
+					Path:     Path{url: url.URL{Path: "other"}},
+					baseName: "c",
 				},
 				{baseName: "b"},
 				{baseName: "a"},


### PR DESCRIPTION
Currently we start many go threads to read artifacts and builds in parallel. This causes a lot of
memory pressure. So instead switch to channels with a 1 item buffer. This allows each go routine
to continue working on the second item as soon as it finishes the first one. Things will only block
if the second item is completed before the first item is read.

Assuming everything is processing quickly this should result in similar performance but with better
performance when things slow down (memory consumed for 1-2 items instead of N).

Also: reject junit files more than 100MB, failing these builds with a note about the error.