### PR TITLE
Check preconditions when reading.

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -155,7 +155,7 @@ func main() {
 		"build": opt.buildConcurrency,
 	}).Info("Configured concurrency")
 
-	groupUpdater := updater.GCS(opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm, updater.SortStarted)
+	groupUpdater := updater.GCS(client, opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm, updater.SortStarted)
 
 	mets := setupMetrics(ctx)
 

--- a/config/queue.go
+++ b/config/queue.go
@@ -111,8 +111,8 @@ func (q *TestGroupQueue) FixAll(whens map[string]time.Time) error {
 				"group": name,
 				"when":  when,
 			}).Info("Fixing groups")
+			it.when = when
 		}
-		it.when = when
 	}
 	heap.Init(&q.queue)
 	if len(missing) > 0 {
@@ -136,9 +136,9 @@ func (q *TestGroupQueue) Fix(name string, when time.Time) error {
 			"group": name,
 			"when":  when,
 		}).Info("Fixed group")
+		it.when = when
+		heap.Fix(&q.queue, it.index)
 	}
-	it.when = when
-	heap.Fix(&q.queue, it.index)
 	return nil
 }
 

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -76,7 +76,7 @@ func TestGCS(t *testing.T) {
 			// either because the context is canceled or things like client are unset)
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			updater := GCS(0, 0, 0, false, SortStarted)
+			updater := GCS(nil, 0, 0, 0, false, SortStarted)
 			defer func() {
 				if r := recover(); r != nil {
 					if !tc.fail {
@@ -316,7 +316,7 @@ func TestUpdate(t *testing.T) {
 				client.Lister[buildsPath] = fi
 			}
 
-			groupUpdater := GCS(*tc.groupTimeout, *tc.buildTimeout, tc.buildConcurrency, !tc.skipConfirm, SortStarted)
+			groupUpdater := GCS(client, *tc.groupTimeout, *tc.buildTimeout, tc.buildConcurrency, !tc.skipConfirm, SortStarted)
 			mets := &Metrics{
 				Successes:    &fakeCounter{},
 				Errors:       &fakeCounter{},

--- a/util/gcs/BUILD.bazel
+++ b/util/gcs/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
         "@org_golang_google_api//iterator:go_default_library",
         "@org_golang_google_api//option:go_default_library",
     ],


### PR DESCRIPTION
The official storage client does this incorrectly: it uses the XML api for reads but sends ifGenerationMatch
parameters (for the json api) rather than the required x-goog-if-generation-match headers. So instead check
this manually when the response comes back.

Also:
* fix some related issues (cannot use the testgroup's conditions to read objects, similar thing for reading
the config).
* Only fix the update time if the group already exists and has a written state
* Only fix the heap when the update time changes.