### PR TITLE
Add option in GetRouter to override the storage client

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -50,7 +50,7 @@ func main() {
 	opt := gatherOptions()
 
 	log.WithField("port", opt.port).Info("Listening...")
-	router, err := api.GetRouter(opt.router)
+	router, err := api.GetRouter(opt.router, nil)
 	if err != nil {
 		log.WithError(err).WithField("router-options", opt.router).Fatal("Can't create router")
 	}

--- a/pkg/api/BUILD.bazel
+++ b/pkg/api/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/api/v1:go_default_library",
         "//util/gcs:go_default_library",
         "@com_github_gorilla_mux//:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
     ],
 )
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"cloud.google.com/go/storage"
 	v1 "github.com/GoogleCloudPlatform/testgrid/pkg/api/v1"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 )
@@ -36,11 +37,14 @@ type RouterOptions struct {
 
 // GetRouter returns an http router that serves TestGrid's API
 // It also instantiates necessary caching and i/o objects
-func GetRouter(options RouterOptions) (*mux.Router, error) {
+func GetRouter(options RouterOptions, storageClient *storage.Client) (*mux.Router, error) {
 	r := mux.NewRouter()
-	storageClient, err := gcs.ClientWithCreds(context.Background(), options.GcsCredentials)
-	if err != nil {
-		return nil, err
+	if storageClient == nil {
+		sc, err := gcs.ClientWithCreds(context.Background(), options.GcsCredentials)
+		if err != nil {
+			return nil, err
+		}
+		storageClient = sc
 	}
 
 	const v1Infix = "/api/v1"


### PR DESCRIPTION
The current GCS storage client doesn't provide means to authenticate in other ways. This is needed so caller can initialize storage client and pass it to GetRouter method.