### PR TITLE
Do not use a buffered channel for newCols.

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -513,7 +513,7 @@ func InflateDropAppend(ctx context.Context, alog logrus.FieldLogger, client gcs.
 		oldCols = truncateRunning(cols)
 	}
 
-	newCols := make(chan InflatedColumn, 1)
+	newCols := make(chan InflatedColumn)
 	ec := make(chan error)
 
 	log.Trace("Reading first column...")


### PR DESCRIPTION
Adding a buffer to this channel means that readCols can return after sending the items to the channel but
before anyone reads them. Once readCols returns this go routine will try and send the err to ec, and this
creates a race condition where the main routines reads the err before the buffered items on the channel,
thus dropping some already processed columns and losing work and introducing flakiness.

/assign @michelle192837 