### PR TITLE
Try and deflake TestReadColumns

### DIFF
--- a/pkg/updater/read.go
+++ b/pkg/updater/read.go
@@ -74,9 +74,6 @@ func readColumns(ctx context.Context, client gcs.Downloader, log logrus.FieldLog
 		return
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel() // do not leak go routines
-
 	nameCfg := makeNameConfig(group)
 	var heads []string
 	for _, h := range group.ColumnHeader {

--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -786,6 +786,7 @@ func TestReadColumns(t *testing.T) {
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
+				ctx.Err()
 				return ctx
 			}(),
 		},
@@ -967,6 +968,7 @@ func TestReadColumns(t *testing.T) {
 				tc.ctx = context.Background()
 			}
 			ctx, cancel := context.WithCancel(tc.ctx)
+			ctx.Err()
 			defer cancel()
 			client := fakeClient{
 				Lister: fake.Lister{},


### PR DESCRIPTION
/assign @michelle192837 

There are no longer go routines in readColumns so we do not need to create a new context to cancel, which should mitigate flakiness along with ensuring we've checked the err.