### PR TITLE
Ignore columns with no cells.

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -533,6 +533,11 @@ func InflateDropAppend(ctx context.Context, alog logrus.FieldLogger, client gcs.
 	case <-ctx.Done():
 		return false, fmt.Errorf("first column: %w", ctx.Err())
 	case col := <-newCols:
+		if len(col.Cells) == 0 {
+			// Group all empty columns together by setting build/name empty.
+			col.Column.Build = ""
+			col.Column.Name = ""
+		}
 		cols = append(cols, col)
 	case err := <-ec:
 		if err != nil {
@@ -553,6 +558,11 @@ func InflateDropAppend(ctx context.Context, alog logrus.FieldLogger, client gcs.
 			case <-ctx.Done():
 				return false, ctx.Err()
 			case col := <-newCols:
+				if len(col.Cells) == 0 {
+					// Group all empty columns together by setting build/name empty.
+					col.Column.Build = ""
+					col.Column.Name = ""
+				}
 				cols = append(cols, col)
 			case err := <-ec:
 				if err != nil {


### PR DESCRIPTION
ETA: Instead of just throwing away empty columns, this groups all empty columns together, keeping the hint of the latest empty column. Thanks Erick for the suggestion!

This ignores empty columns instead of processing them into the grid. (This will not progress the latest 'hint' for the grid past the last non-empty column, so it's possible to repeat work, but in my estimation this should not be a significant issue. If it is, swap to an artificial 'last processed' column that we keep at the beginning to make sure the hint progresses).