### PR TITLE
TestGrid Dynamic List - support extract email list from []interface{}

### DIFF
--- a/metadata/job.go
+++ b/metadata/job.go
@@ -131,10 +131,10 @@ func (m Metadata) Strings() map[string]string {
 	return bm
 }
 
-/* GetListOfStrings get list of strings if exist, and true if they key is present.
+/* MultiString get list of strings if exist, and true if they key is present.
 If value is list of strings we return it as is.
 If value is list of interfaces, we try convert it into list of strings, if fail we return an empty list */
-func (m Metadata) GetListOfStrings(name string) ([]string, bool) {
+func (m Metadata) MultiString(name string) ([]string, bool) {
 	if v, ok := m[name]; !ok {
 		return []string{}, false
 	} else if lstStr, good := v.([]string); good {

--- a/metadata/job.go
+++ b/metadata/job.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metadata
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -132,29 +131,24 @@ func (m Metadata) Strings() map[string]string {
 	return bm
 }
 
-// ConvertToListOfStrings convert an interface to list of strings, support if the type of the interface
-// is list of strings or list of interfaces, where each interface in the list is a string.
-func ConvertToListOfStrings(rawInterface interface{}) ([]string, error) {
-	switch t := rawInterface.(type) {
-	case []string:
-		return t, nil
-	case []interface{}:
-		emails := []string{}
-		for _, item := range t {
-			switch tt := item.(type) {
-			case string:
-				emails = append(emails, tt)
-				break
-			default:
-				return []string{}, fmt.Errorf("one of the items in the list of the"+
-					" interfaces is not a string. value: '%v' type: %T", tt, tt)
+// GetListOfStrings get list of strings if exist, and true if they key is present.
+func (m Metadata) GetListOfStrings(name string) ([]string, bool) {
+	if v, ok := m[name]; !ok {
+		return []string{}, false
+	} else if lstStr, good := v.([]string); good {
+		return lstStr, true
+	} else if lstInter, good := v.([]interface{}); good {
+		convertedStrings := []string{}
+		for _, inter := range lstInter {
+			if s, good := inter.(string); !good {
+				return []string{}, true
+			} else {
+				convertedStrings = append(convertedStrings, s)
 			}
 		}
-		return emails, nil
-	default:
-		return []string{}, fmt.Errorf("rawInterface type is not list of "+
-			"strings or interfaces. value: '%v' type: %T", t, t)
+		return convertedStrings, true
 	}
+	return []string{}, true
 }
 
 // firstFilled returns the first non-empty option or else def.

--- a/metadata/job.go
+++ b/metadata/job.go
@@ -131,7 +131,9 @@ func (m Metadata) Strings() map[string]string {
 	return bm
 }
 
-// GetListOfStrings get list of strings if exist, and true if they key is present.
+/* GetListOfStrings get list of strings if exist, and true if they key is present.
+If value is list of strings we return it as is.
+If value is list of interfaces, we try convert it into list of strings, if fail we return an empty list */
 func (m Metadata) GetListOfStrings(name string) ([]string, bool) {
 	if v, ok := m[name]; !ok {
 		return []string{}, false

--- a/metadata/job.go
+++ b/metadata/job.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metadata
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -129,6 +130,31 @@ func (m Metadata) Strings() map[string]string {
 		// TODO(fejta): handle sub items
 	}
 	return bm
+}
+
+// ConvertToListOfStrings convert an interface to list of strings, support if the type of the interface
+// is list of strings or list of interfaces, where each interface in the list is a string.
+func ConvertToListOfStrings(rawInterface interface{}) ([]string, error) {
+	switch t := rawInterface.(type) {
+	case []string:
+		return t, nil
+	case []interface{}:
+		emails := []string{}
+		for _, item := range t {
+			switch tt := item.(type) {
+			case string:
+				emails = append(emails, tt)
+				break
+			default:
+				return []string{}, fmt.Errorf("one of the items in the list of the"+
+					" interfaces is not a string. value: '%v' type: %T", tt, tt)
+			}
+		}
+		return emails, nil
+	default:
+		return []string{}, fmt.Errorf("rawInterface type is not list of "+
+			"strings or interfaces. value: '%v' type: %T", t, t)
+	}
 }
 
 // firstFilled returns the first non-empty option or else def.

--- a/metadata/job.go
+++ b/metadata/job.go
@@ -131,9 +131,9 @@ func (m Metadata) Strings() map[string]string {
 	return bm
 }
 
-/* MultiString get list of strings if exist, and true if they key is present.
-If value is list of strings we return it as is.
-If value is list of interfaces, we try convert it into list of strings, if fail we return an empty list */
+// MultiString get list of strings if exist, and true if they key is present.
+// If value is list of strings we return it as is.
+// If value is list of interfaces, we try convert it into list of strings, if fail we return an empty list
 func (m Metadata) MultiString(name string) ([]string, bool) {
 	if v, ok := m[name]; !ok {
 		return []string{}, false
@@ -142,11 +142,11 @@ func (m Metadata) MultiString(name string) ([]string, bool) {
 	} else if lstInter, good := v.([]interface{}); good {
 		convertedStrings := []string{}
 		for _, inter := range lstInter {
-			if s, good := inter.(string); !good {
+			s, good := inter.(string)
+			if !good {
 				return []string{}, true
-			} else {
-				convertedStrings = append(convertedStrings, s)
 			}
+			convertedStrings = append(convertedStrings, s)
 		}
 		return convertedStrings, true
 	}

--- a/metadata/job_test.go
+++ b/metadata/job_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestMeta(t *testing.T) {
 	world := "world"
+	olam := "olam"
 	const key = "target-key"
 	cases := []struct {
 		name    string
@@ -101,6 +102,71 @@ func TestMeta(t *testing.T) {
 				return actual.Meta(key)
 			},
 			val: (*Metadata)(nil),
+		},
+		{
+			name: "get list of strings",
+			in: Metadata{
+				key: []string{world, olam},
+			},
+			call: func(actual Metadata) (interface{}, bool) {
+				return actual.GetListOfStrings(key)
+			},
+			val:     []string{world, olam},
+			present: true,
+		},
+		{
+			name: "get list of strings from list of interfaces",
+			in: Metadata{
+				key: []interface{}{world, olam},
+			},
+			call: func(actual Metadata) (interface{}, bool) {
+				return actual.GetListOfStrings(key)
+			},
+			val:     []string{world, olam},
+			present: true,
+		},
+		{
+			name: "non string in list of interfaces",
+			in: Metadata{
+				key: []interface{}{world, 1337},
+			},
+			call: func(actual Metadata) (interface{}, bool) {
+				return actual.GetListOfStrings(key)
+			},
+			val:     []string{},
+			present: true,
+		},
+		{
+			name: "not list of strings",
+			in: Metadata{
+				key: []int{42, 1337},
+			},
+			call: func(actual Metadata) (interface{}, bool) {
+				return actual.GetListOfStrings(key)
+			},
+			val:     []string{},
+			present: true,
+		},
+		{
+			name: "given empty list",
+			in: Metadata{
+				key: []interface{}{},
+			},
+			call: func(actual Metadata) (interface{}, bool) {
+				return actual.GetListOfStrings(key)
+			},
+			val:     []string{},
+			present: true,
+		},
+		{
+			name: "return empty list if key absence",
+			in: Metadata{
+				"random-key": []string{world},
+			},
+			call: func(actual Metadata) (interface{}, bool) {
+				return actual.GetListOfStrings(key)
+			},
+			val: []string{},
 		},
 	}
 

--- a/metadata/job_test.go
+++ b/metadata/job_test.go
@@ -109,7 +109,7 @@ func TestMeta(t *testing.T) {
 				key: []string{world, olam},
 			},
 			call: func(actual Metadata) (interface{}, bool) {
-				return actual.GetListOfStrings(key)
+				return actual.MultiString(key)
 			},
 			val:     []string{world, olam},
 			present: true,
@@ -120,7 +120,7 @@ func TestMeta(t *testing.T) {
 				key: []interface{}{world, olam},
 			},
 			call: func(actual Metadata) (interface{}, bool) {
-				return actual.GetListOfStrings(key)
+				return actual.MultiString(key)
 			},
 			val:     []string{world, olam},
 			present: true,
@@ -131,7 +131,7 @@ func TestMeta(t *testing.T) {
 				key: []interface{}{world, 1337},
 			},
 			call: func(actual Metadata) (interface{}, bool) {
-				return actual.GetListOfStrings(key)
+				return actual.MultiString(key)
 			},
 			val:     []string{},
 			present: true,
@@ -142,7 +142,7 @@ func TestMeta(t *testing.T) {
 				key: []int{42, 1337},
 			},
 			call: func(actual Metadata) (interface{}, bool) {
-				return actual.GetListOfStrings(key)
+				return actual.MultiString(key)
 			},
 			val:     []string{},
 			present: true,
@@ -153,7 +153,7 @@ func TestMeta(t *testing.T) {
 				key: []interface{}{},
 			},
 			call: func(actual Metadata) (interface{}, bool) {
-				return actual.GetListOfStrings(key)
+				return actual.MultiString(key)
 			},
 			val:     []string{},
 			present: true,
@@ -164,7 +164,7 @@ func TestMeta(t *testing.T) {
 				"random-key": []string{world},
 			},
 			call: func(actual Metadata) (interface{}, bool) {
-				return actual.GetListOfStrings(key)
+				return actual.MultiString(key)
 			},
 			val: []string{},
 		},

--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -388,7 +388,7 @@ func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, header
 		out.Column.Extra = append(out.Column.Extra, val)
 	}
 
-	emails, found := result.finished.Finished.Metadata.GetListOfStrings(EmailListKey)
+	emails, found := result.finished.Finished.Metadata.MultiString(EmailListKey)
 	if len(emails) == 0 && found {
 		log.Error("failed to extract dynamic email list, the list is empty or cannot convert to []string")
 	}

--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -418,13 +418,13 @@ func convertToListOfStrings(rawInterface interface{}) ([]string, error) {
 				break
 			default:
 				return []string{}, fmt.Errorf("one of the items in the list of the"+
-					" interfaces is not a string: %v of type %T", tt, tt)
+					" interfaces is not a string. value: '%v' type: %T", tt, tt)
 			}
 		}
 		return emails, nil
 	default:
 		return []string{}, fmt.Errorf("rawInterface type is not list of "+
-			"strings or interfaces: %v of type %T", t, t)
+			"strings or interfaces. value: '%v' type: %T", t, t)
 	}
 }
 

--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -17,7 +17,6 @@ limitations under the License.
 package updater
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -391,14 +390,9 @@ func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, header
 
 	emailAddressesInterface, ok := result.finished.Finished.Metadata[EmailListKey]
 	if ok {
-		// we do marshal and unmarshal to json to convert the result from []interface{} to []string
-		var emailAddresses []string
-		emailAddressesData, err := json.Marshal(emailAddressesInterface)
+		emailAddresses, err := metadata.ConvertToListOfStrings(emailAddressesInterface)
 		if err != nil {
-			log.WithError(err).Error("failed to marshal email addresses")
-			out.Column.EmailAddresses = []string{}
-		} else if err := json.Unmarshal(emailAddressesData, &emailAddresses); err != nil {
-			log.WithError(err).Error("failed to unmarshal email addresses")
+			log.Error(err)
 			out.Column.EmailAddresses = []string{}
 		} else {
 			out.Column.EmailAddresses = emailAddresses

--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -388,18 +388,11 @@ func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, header
 		out.Column.Extra = append(out.Column.Extra, val)
 	}
 
-	emailAddressesInterface, ok := result.finished.Finished.Metadata[EmailListKey]
-	if ok {
-		emailAddresses, err := metadata.ConvertToListOfStrings(emailAddressesInterface)
-		if err != nil {
-			log.Error(err)
-			out.Column.EmailAddresses = []string{}
-		} else {
-			out.Column.EmailAddresses = emailAddresses
-		}
-	} else {
-		out.Column.EmailAddresses = []string{}
+	emails, found := result.finished.Finished.Metadata.GetListOfStrings(EmailListKey)
+	if len(emails) == 0 && found {
+		log.Error("failed to extract dynamic email list, the list is empty or cannot convert to []string")
 	}
+	out.Column.EmailAddresses = emails
 	return out
 }
 

--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -408,12 +408,36 @@ func TestConvertResult(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid email list",
+			name: "not a list",
 			result: gcsResult{
 				finished: gcs.Finished{
 					Finished: metadata.Finished{
 						Metadata: metadata.Metadata{
 							EmailListKey: "olam",
+						},
+					},
+				},
+			},
+			expected: InflatedColumn{
+				Column: &statepb.Column{
+					EmailAddresses: []string{},
+				},
+				Cells: map[string]Cell{
+					overallRow: {
+						Result:  statuspb.TestStatus_FAIL,
+						Icon:    "T",
+						Message: "Build did not complete within 24 hours",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid email list",
+			result: gcsResult{
+				finished: gcs.Finished{
+					Finished: metadata.Finished{
+						Metadata: metadata.Metadata{
+							EmailListKey: []interface{}{1},
 						},
 					},
 				},

--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -360,6 +360,30 @@ func TestConvertResult(t *testing.T) {
 			},
 		},
 		{
+			name: "pass dynamic email list as list of interaces",
+			result: gcsResult{
+				finished: gcs.Finished{
+					Finished: metadata.Finished{
+						Metadata: metadata.Metadata{
+							EmailListKey: []interface{}{"world"},
+						},
+					},
+				},
+			},
+			expected: InflatedColumn{
+				Column: &statepb.Column{
+					EmailAddresses: []string{"world"},
+				},
+				Cells: map[string]Cell{
+					overallRow: {
+						Result:  statuspb.TestStatus_FAIL,
+						Icon:    "T",
+						Message: "Build did not complete within 24 hours",
+					},
+				},
+			},
+		},
+		{
 			name: "multiple dynamic email list",
 			result: gcsResult{
 				finished: gcs.Finished{


### PR DESCRIPTION
When reading list of strings from json go recognize it as a list of interfaces, which cause casting issues.
Added a function that deal with the case if it's a list of interfaces or list of strings. if not it's throw an error