### PR TITLE
Add implementation for these config APIs

### DIFF
--- a/pkg/api/v1/config_test.go
+++ b/pkg/api/v1/config_test.go
@@ -123,14 +123,17 @@ func TestPassQueryParameters(t *testing.T) {
 	}
 }
 
+type ConfigTestSpec struct {
+	name             string
+	config           map[string]*pb.Configuration
+	endpoint         string
+	params           string
+	expectedResponse string
+	expectedCode     int
+}
+
 func TestListDashboardGroups(t *testing.T) {
-	tests := []struct {
-		name             string
-		config           map[string]*pb.Configuration
-		params           string
-		expectedResponse string
-		expectedCode     int
-	}{
+	tests := []ConfigTestSpec{
 		{
 			name: "Returns an empty JSON when there's no groups",
 			config: map[string]*pb.Configuration{
@@ -187,47 +190,25 @@ func TestListDashboardGroups(t *testing.T) {
 		},
 		{
 			name:             "Server error with unreadable config",
-			expectedCode:     http.StatusInternalServerError,
 			params:           "?scope=gs://bad-path",
 			expectedResponse: "Could not read config at \"gs://bad-path/config\"\n",
+			expectedCode:     http.StatusInternalServerError,
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			router := Route(nil, setupTestServer(t, test.config))
-			request, err := http.NewRequest("GET", "/dashboard-groups"+test.params, nil)
-			if err != nil {
-				t.Fatalf("Can't form request: %v", err)
-			}
-			response := httptest.NewRecorder()
-			router.ServeHTTP(response, request)
-			if response.Code != test.expectedCode {
-				t.Errorf("Expected %d, but got %d", test.expectedCode, response.Code)
-			}
-			if response.Body.String() != test.expectedResponse {
-				t.Errorf("In Body, Expected %q; got %q", test.expectedResponse, response.Body.String())
-			}
-		})
-	}
+	RunTestsAgainstEndpoint(t, "/dashboard-groups", tests)
 }
 
 func TestGetDashboardGroup(t *testing.T) {
-	tests := []struct {
-		name             string
-		config           map[string]*pb.Configuration
-		endpoint         string
-		expectedResponse string
-		expectedCode     int
-	}{
+	tests := []ConfigTestSpec{
 		{
 			name: "Returns an error when there's no resource",
 			config: map[string]*pb.Configuration{
 				"gs://default/config": {},
 			},
-			endpoint:         "/dashboard-groups/missing",
-			expectedCode:     http.StatusNotFound,
+			endpoint:         "missing",
 			expectedResponse: "Dashboard group \"missing\" not found\n",
+			expectedCode:     http.StatusNotFound,
 		},
 		{
 			name: "Returns empty JSON from an empty Dashboard Group",
@@ -240,7 +221,7 @@ func TestGetDashboardGroup(t *testing.T) {
 					},
 				},
 			},
-			endpoint:         "/dashboard-groups/Group1",
+			endpoint:         "group1",
 			expectedResponse: `{}`,
 			expectedCode:     http.StatusOK,
 		},
@@ -256,7 +237,7 @@ func TestGetDashboardGroup(t *testing.T) {
 					},
 				},
 			},
-			endpoint:         "/dashboard-groups/stooges",
+			endpoint:         "stooges",
 			expectedResponse: `{"dashboards":[{"name":"larry","link":"host/dashboards/larry"},{"name":"curly","link":"host/dashboards/curly"},{"name":"moe","link":"host/dashboards/moe"}]}`,
 			expectedCode:     http.StatusOK,
 		},
@@ -280,7 +261,7 @@ func TestGetDashboardGroup(t *testing.T) {
 					},
 				},
 			},
-			endpoint:         "/dashboard-groups/right-group?scope=gs://example",
+			endpoint:         "rightgroup?scope=gs://example",
 			expectedResponse: `{"dashboards":[{"name":"yes","link":"host/dashboards/yes?scope=gs://example"}]}`,
 			expectedCode:     http.StatusOK,
 		},
@@ -304,21 +285,352 @@ func TestGetDashboardGroup(t *testing.T) {
 					},
 				},
 			},
-			endpoint:         "/dashboard-groups/wrong-group?scope=gs://example",
-			expectedResponse: "Dashboard group \"wrong-group\" not found\n",
+			endpoint:         "wronggroup?scope=gs://example",
+			expectedResponse: "Dashboard group \"wronggroup\" not found\n",
 			expectedCode:     http.StatusNotFound,
 		},
 		{
 			name:             "Server error with unreadable config",
-			expectedCode:     http.StatusInternalServerError,
-			endpoint:         "/dashboard-groups/group?scope=gs://bad-path",
+			endpoint:         "group?scope=gs://bad-path",
 			expectedResponse: "Could not read config at \"gs://bad-path/config\"\n",
+			expectedCode:     http.StatusInternalServerError,
 		},
 	}
+	RunTestsAgainstEndpoint(t, "/dashboard-groups/", tests)
+}
+
+func TestListDashboards(t *testing.T) {
+	tests := []ConfigTestSpec{
+		{
+			name: "Returns an empty JSON when there is no dashboards",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {},
+			},
+			expectedResponse: `{}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name: "Returns a Dashboard",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "Dashboard1",
+						},
+					},
+				},
+			},
+			expectedResponse: `{"dashboards":[{"name":"Dashboard1","link":"host/dashboards/dashboard1"}]}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name: "Returns multiple Dashboards",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "Dashboard1",
+						},
+						{
+							Name: "Dashboard2",
+						},
+					},
+				},
+			},
+			expectedResponse: `{"dashboards":[{"name":"Dashboard1","link":"host/dashboards/dashboard1"},{"name":"Dashboard2","link":"host/dashboards/dashboard2"}]}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name: "Reads from other config/scope",
+			config: map[string]*pb.Configuration{
+				"gs://example/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "Dashboard1",
+						},
+					},
+				},
+			},
+			params:           "?scope=gs://example",
+			expectedResponse: `{"dashboards":[{"name":"Dashboard1","link":"host/dashboards/dashboard1?scope=gs://example"}]}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name:             "Server error with unreadable config",
+			params:           "?scope=gs://bad-path",
+			expectedResponse: "Could not read config at \"gs://bad-path/config\"\n",
+			expectedCode:     http.StatusInternalServerError,
+		},
+	}
+
+	RunTestsAgainstEndpoint(t, "/dashboards", tests)
+}
+
+func TestGetDashboard(t *testing.T) {
+	tests := []ConfigTestSpec{
+		{
+			name: "Returns an error when there's no resource",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {},
+			},
+			endpoint:         "missing",
+			expectedResponse: "Dashboard \"missing\" not found\n",
+			expectedCode:     http.StatusNotFound,
+		},
+		{
+			name: "Returns empty JSON from an empty Dashboard",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "Dashboard1",
+						},
+					},
+				},
+			},
+			endpoint:         "dashboard1",
+			expectedResponse: `{}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name: "Returns dashboard info from dashboard",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name:                "Dashboard1",
+							DefaultTab:          "defaultTab",
+							HighlightToday:      true,
+							DownplayFailingTabs: true,
+							Notifications: []*pb.Notification{
+								{
+									Summary:     "Notification summary",
+									ContextLink: "Notification context link",
+								},
+							},
+						},
+					},
+				},
+			},
+			endpoint:         "dashboard1",
+			expectedResponse: `{"notifications":[{"summary":"Notification summary","context_link":"Notification context link"}],"default_tab":"defaultTab","suppress_failing_tabs":true,"highlight_today":true}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name: "Reads specified configs",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name:                "wrong-dashboard",
+							DefaultTab:          "wrong-dashboard defaultTab",
+							HighlightToday:      true,
+							DownplayFailingTabs: true,
+							Notifications: []*pb.Notification{
+								{
+									Summary:     "Notification summary",
+									ContextLink: "Notification context link",
+								},
+							},
+						},
+					},
+				},
+				"gs://example/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name:                "correct-dashboard",
+							DefaultTab:          "correct-dashboard defaultTab",
+							HighlightToday:      true,
+							DownplayFailingTabs: true,
+							Notifications:       []*pb.Notification{},
+						},
+					},
+				},
+			},
+			endpoint:         "correctdashboard",
+			params:           "?scope=gs://example",
+			expectedResponse: `{"default_tab":"correct-dashboard defaultTab","suppress_failing_tabs":true,"highlight_today":true}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name: "Specified configs never reads default config",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name:                "wrong-dashboard",
+							DefaultTab:          "wrong-dashboard defaultTab",
+							HighlightToday:      true,
+							DownplayFailingTabs: true,
+							Notifications: []*pb.Notification{
+								{
+									Summary:     "Notification summary",
+									ContextLink: "Notification context link",
+								},
+							},
+						},
+					},
+				},
+				"gs://example/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name:                "correct-dashboard",
+							DefaultTab:          "correct-dashboard defaultTab",
+							HighlightToday:      true,
+							DownplayFailingTabs: true,
+							Notifications:       []*pb.Notification{},
+						},
+					},
+				},
+			},
+			endpoint:         "wrongdashboard",
+			params:           "?scope=gs://example",
+			expectedResponse: "Dashboard \"wrongdashboard\" not found\n",
+			expectedCode:     http.StatusNotFound,
+		},
+		{
+			name:             "Server error with unreadable config",
+			endpoint:         "dashboard",
+			params:           "?scope=gs://bad-path",
+			expectedResponse: "Could not read config at \"gs://bad-path/config\"\n",
+			expectedCode:     http.StatusInternalServerError,
+		},
+	}
+	RunTestsAgainstEndpoint(t, "/dashboards/", tests)
+}
+
+func TestGetDashboardTabs(t *testing.T) {
+	tests := []ConfigTestSpec{
+		{
+			name: "Returns an error when there's no resource",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {},
+			},
+			endpoint:         "missingdashboard/tabs",
+			expectedResponse: "Dashboard \"missingdashboard\" not found\n",
+			expectedCode:     http.StatusNotFound,
+		},
+		{
+			name: "Returns empty JSON from an empty Dashboard",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name:         "Dashboard1",
+							DashboardTab: []*pb.DashboardTab{},
+						},
+					},
+				},
+			},
+			endpoint:         "dashboard1/tabs",
+			expectedResponse: `{}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name: "Returns tabs list from a Dashboard",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "Dashboard1",
+							DashboardTab: []*pb.DashboardTab{
+								{
+									Name: "tab 1",
+								},
+								{
+									Name: "tab 2",
+								},
+							},
+						},
+					},
+				},
+			},
+			endpoint:         "dashboard1/tabs",
+			expectedResponse: `{"dashboard_tabs":[{"name":"tab 1","link":"host/dashboards/dashboard1/tabs/tab1"},{"name":"tab 2","link":"host/dashboards/dashboard1/tabs/tab2"}]}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name: "Reads specified configs",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "wrong-dashboard",
+							DashboardTab: []*pb.DashboardTab{
+								{
+									Name: "wrong-dashboard tab 1",
+								},
+							},
+						},
+					},
+				},
+				"gs://example/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "correct-dashboard",
+							DashboardTab: []*pb.DashboardTab{
+								{
+									Name: "correct-dashboard tab 1",
+								},
+							},
+						},
+					},
+				},
+			},
+			endpoint:         "correctdashboard/tabs",
+			params:           "?scope=gs://example",
+			expectedResponse: `{"dashboard_tabs":[{"name":"correct-dashboard tab 1","link":"host/dashboards/correctdashboard/tabs/correctdashboardtab1?scope=gs://example"}]}`,
+			expectedCode:     http.StatusOK,
+		},
+		{
+			name: "Specified configs never reads default config",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "wrong-dashboard",
+							DashboardTab: []*pb.DashboardTab{
+								{
+									Name: "wrong-dashboard tab 1",
+								},
+							},
+						},
+					},
+				},
+				"gs://example/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "correct-dashboard",
+							DashboardTab: []*pb.DashboardTab{
+								{
+									Name: "correct-dashboard tab 1",
+								},
+							},
+						},
+					},
+				},
+			},
+			endpoint:         "wrongdashboard/tabs",
+			params:           "?scope=gs://example",
+			expectedResponse: "Dashboard \"wrongdashboard\" not found\n",
+			expectedCode:     http.StatusNotFound,
+		},
+		{
+			name:             "Server error with unreadable config",
+			endpoint:         "dashboard1/tabs",
+			params:           "?scope=gs://bad-path",
+			expectedResponse: "Could not read config at \"gs://bad-path/config\"\n",
+			expectedCode:     http.StatusInternalServerError,
+		},
+	}
+	RunTestsAgainstEndpoint(t, "/dashboards/", tests)
+}
+
+func RunTestsAgainstEndpoint(t *testing.T, baseEndpoint string, tests []ConfigTestSpec) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			router := Route(nil, setupTestServer(t, test.config))
-			request, err := http.NewRequest("GET", test.endpoint, nil)
+			request, err := http.NewRequest("GET", baseEndpoint+test.endpoint+test.params, nil)
 			if err != nil {
 				t.Fatalf("Can't form request: %v", err)
 			}

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -37,5 +37,8 @@ func Route(r *mux.Router, s Server) *mux.Router {
 	}
 	r.HandleFunc("/dashboard-groups", s.ListDashboardGroups).Methods("GET")
 	r.HandleFunc("/dashboard-groups/{dashboard-group}", s.GetDashboardGroup).Methods("GET")
+	r.HandleFunc("/dashboards", s.ListDashboards).Methods("GET")
+	r.HandleFunc("/dashboards/{dashboard}/tabs", s.ListDashboardTabs).Methods("GET")
+	r.HandleFunc("/dashboards/{dashboard}", s.GetDashboard).Methods("GET")
 	return r
 }


### PR DESCRIPTION
Add implementation for these config APIs:
* /dashboards -> Lists dashboard names
* /dashboards/{dashboard}/tabs -> Lists the dashboard tab names
* /dashboards/{dashboard} -> Returns a Dashboard config's metadata

+ Unit tests added
+ Fix 404 not found issue for dashboard groups locating (missing Normalize comparison)