### PR TITLE
Correct flag to enable race detction during testing.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@ build --workspace_status_command=./hack/print-workspace-status.sh
 run --workspace_status_command=./hack/print-workspace-status.sh
 
 # enable data race detection
-test --features=race --test_output=errors
+test --@io_bazel_rules_go//go/config:race --test_output=errors
 
 # only build tests when testing
 test --build_tests_only


### PR DESCRIPTION
This is now `--@io_bazel_rules_go//go/config:race`

```
DEBUG: /root/.cache/bazel/_bazel_root/38c3d4864ff292290a1ecc94a9fefad6/external/io_bazel_rules_go/go/private/context.bzl:497:14: WARNING: --features=race is no longer supported. Use --@io_bazel_rules_go//go/config:race instead.
```