### PR TITLE
Ensure offset has a trailing /.

### DIFF
--- a/util/gcs/read.go
+++ b/util/gcs/read.go
@@ -204,6 +204,9 @@ func ListBuilds(parent context.Context, lister Lister, gcsPath Path, after *Path
 		offset = after.Object()
 	}
 	offsetBaseName := hackOffset(&offset)
+	if !strings.HasSuffix(offset, "/") {
+		offset += "/"
+	}
 	it := lister.Objects(ctx, gcsPath, "/", offset)
 	var all []Build
 	for {


### PR DESCRIPTION
Already robust to this because of:

https://github.com/GoogleCloudPlatform/testgrid/blob/8cb1f6faf07480e12288879b53e81438e05bb030/util/gcs/read.go#L259-L269 

But we shouldn't rely on it.