### PR TITLE
Refactor pubsub package for easier unit testing.

### DIFF
--- a/pkg/pubsub/pubsub_test.go
+++ b/pkg/pubsub/pubsub_test.go
@@ -54,7 +54,7 @@ func TestSendToReceivers(t *testing.T) {
 	cases := []struct {
 		name     string
 		ctx      context.Context
-		send     sender
+		send     Sender
 		want     []*Notification
 		wantAcks fakeAcker
 		err      error


### PR DESCRIPTION
Create a wrapped client type, which implements a Susbscriber interface that will Subscribe and returns a Sender.