### PR TITLE
Update canary updater flags.

### DIFF
--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -39,15 +39,15 @@ spec:
         - --group-concurrency=4
         - --group-timeout=10m
         - --json-logs
-        - --subscribe=kubernetes-jenkins=kubernetes-jenkins/testgrid
+        - --subscribe=kubernetes-jenkins=kubernetes-jenkins/testgrid-canary
         - --subscribe=oss-prow=k8s-testgrid/testgrid-canary
         - --subscribe=istio-prow=k8s-testgrid/testgrid-canary
-        - --wait=3h
+        - --wait=4h
         resources:
           requests:
-            cpu: "1"
-            memory: "50G"
+            cpu: "5"
+            memory: "20G"
           limits:
-            cpu: "4"
-            memory: "100G"
+            cpu: "10"
+            memory: "50G"
 ---

--- a/config/queue.go
+++ b/config/queue.go
@@ -159,9 +159,9 @@ func (q *TestGroupQueue) Fix(name string, when time.Time, later bool) error {
 		"when":  when,
 	})
 	if when.Before(it.when) {
-		log = log.WithField("reduced", it.when.Sub(when))
+		log = log.WithField("reduced minutes", it.when.Sub(when).Round(time.Second).Minutes())
 	} else if later && !when.Equal(it.when) {
-		log = log.WithField("delayed", when.Sub(it.when))
+		log = log.WithField("delayed minutes", when.Sub(it.when).Round(time.Second).Minutes())
 	} else {
 		return nil
 	}


### PR DESCRIPTION
* Fix requests to more closely match autopilot's usage-based values.
* Increase periodic cycle to 4h
* Correct kubernetes-jenkins subscription ID for canary.

/cc @cjwagner 
/cc @chaodaiG 

(also includes the https://github.com/GoogleCloudPlatform/testgrid/pull/644 bump)