### PR TITLE
Match PR directory links.

### DIFF
--- a/pkg/updater/pubsub.go
+++ b/pkg/updater/pubsub.go
@@ -213,11 +213,15 @@ func processNotification(paths map[gcs.Path][]string, n *pubsub.Notification) ([
 	b, obj := n.Path.Bucket(), n.Path.Object()
 	base := path.Base(obj)
 	dur, ok := namedDurations[base]
-	if !ok { // Maybe it is a junit file, should finish soon
-		if !strings.HasPrefix(base, "junit") || !strings.HasSuffix(base, ".xml") {
+	if !ok { // Maybe it is an interesting file
+		switch {
+		case strings.HasPrefix(base, "junit") && strings.HasSuffix(base, ".xml"): // row data
+			dur = 5 * time.Minute
+		case strings.HasSuffix(base, ".txt") && strings.Contains(obj, "directory/"): // symlink to actual data
+			dur = 5 * time.Minute
+		default:
 			return nil, 0
 		}
-		dur = 5 * time.Minute
 	}
 
 	for path, groups := range paths {

--- a/pkg/updater/pubsub_test.go
+++ b/pkg/updater/pubsub_test.go
@@ -581,6 +581,26 @@ func TestProcessNotification(t *testing.T) {
 			wantDur: 5 * time.Minute,
 		},
 		{
+			name: "normal txt",
+			paths: map[gcs.Path][]string{
+				mustPath("gs://foo/bar"): {"yes"},
+			},
+			n: &pubsub.Notification{
+				Path: mustPath("gs://foo/bar/something.txt"),
+			},
+		},
+		{
+			name: "directory txt",
+			paths: map[gcs.Path][]string{
+				mustPath("gs://foo/bar/directory"): {"yes"},
+			},
+			n: &pubsub.Notification{
+				Path: mustPath("gs://foo/bar/directory/something.txt"),
+			},
+			want:    []string{"yes"},
+			wantDur: 5 * time.Minute,
+		},
+		{
 			name: "complex junit",
 			paths: map[gcs.Path][]string{
 				mustPath("gs://foo/bar"): {"hello", "world"},


### PR DESCRIPTION
Presubmits tend to get uploaded in a `gs://prefix/directory/job/1234.txt` with a link to `gs://prefix/pull/123/job/1234`