### PR TITLE
Allow time to collect podinfo.

### DIFF
--- a/pkg/updater/pubsub.go
+++ b/pkg/updater/pubsub.go
@@ -195,10 +195,10 @@ func processGCSNotifications(ctx context.Context, log logrus.FieldLogger, q *con
 }
 
 var namedDurations = map[string]time.Duration{
-	"podinfo.json":  time.Second,     // Done
-	"finished.json": time.Minute,     // Container done, wait for prowjob to finish
-	"metadata.json": 5 * time.Minute, // Should finish soon
-	"started.json":  time.Second,     // Running
+	"podinfo.json":  30 * time.Second, // Done
+	"finished.json": 5 * time.Minute,  // Container done, wait for prowjob to finish
+	"metadata.json": 5 * time.Minute,  // Should finish soon
+	"started.json":  30 * time.Second, // Running
 }
 
 // Try to balance providing up-to-date info with minimal redundant processing.

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -486,7 +486,7 @@ var (
 	podInfoSuccess     = jsonPodInfo(podInfoSuccessPodInfo)
 	podInfoPassCell    = cell{Result: statuspb.TestStatus_PASS}
 	podInfoMissingCell = cell{
-		Result:  statuspb.TestStatus_FAIL,
+		Result:  statuspb.TestStatus_RUNNING,
 		Icon:    "!",
 		Message: gcs.MissingPodInfo,
 	}


### PR DESCRIPTION
The podinfo.json is updated by crier, some time after the sidecar uploads finished.json.
Detect this scenario and flag a missing podinfo.json as RUNNING until the result has reached its deadline:
* An hour after finished.json is uploaded or 24 hours after it started.

Also allow a larger buffer between when we receive a pubsub notification and when reprocess the tab.

/cc @chaodaiG 
ref #656