### PR TITLE
Reduce updater replicas to 1

### DIFF
--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -16,7 +16,7 @@ metadata:
     component: updater
     app: testgrid
 spec:
-  replicas: 2
+  replicas: 1 # https://github.com/GoogleCloudPlatform/testgrid/issues/663
   selector:
     matchLabels:
       app: testgrid

--- a/cluster/prod/updater.yaml
+++ b/cluster/prod/updater.yaml
@@ -16,7 +16,7 @@ metadata:
     component: updater
     app: testgrid
 spec:
-  replicas: 2
+  replicas: 1 # https://github.com/GoogleCloudPlatform/testgrid/issues/663
   selector:
     matchLabels:
       app: testgrid


### PR DESCRIPTION
ref https://github.com/GoogleCloudPlatform/testgrid/issues/663

We can do everything we need within a single replicas, so multiple-replicas support is not critical at the moment. This was mostly just to prove it can work, but currently prod will work better without it.