### PR TITLE
Stop touching the grid before download, tracking generation.

### DIFF
--- a/util/gcs/gcs.go
+++ b/util/gcs/gcs.go
@@ -199,7 +199,7 @@ func UploadHandle(ctx context.Context, handle *storage.ObjectHandle, buf []byte,
 func DownloadGrid(ctx context.Context, opener Opener, path Path) (*statepb.Grid, *storage.ReaderObjectAttrs, error) {
 	var g statepb.Grid
 	r, attrs, err := opener.Open(ctx, path)
-	if err != nil && err == storage.ErrObjectNotExist {
+	if err != nil && errors.Is(err, storage.ErrObjectNotExist) {
 		return &g, nil, nil
 	}
 	if err != nil {


### PR DESCRIPTION
Download and Upload now returns the generation. We can use this in InflateDropAppend to determine what version we downloaded
and ensure when we try and replace it that no one else has changed it.

This is faster and also simplifies Update since it no longer needs to try and lock the object and/or track the generation.

We can just determine the generation when we download the object and ensure that our upload replaces this version.