### PR TITLE
Fix timestamp assignment from columns

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -1293,11 +1293,12 @@ func buildID(col *statepb.Column) string {
 const billion = 1e9
 
 // stamp converts seconds into a timestamp proto
+// TODO(#683): col.Started should be a timestamp instead of a float
 func stamp(col *statepb.Column) *timestamp.Timestamp {
 	if col == nil {
 		return nil
 	}
-	seconds := col.Started
+	seconds := col.Started / 1000
 	floor := math.Floor(seconds)
 	remain := seconds - floor
 	return &timestamp.Timestamp{

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -4168,7 +4168,7 @@ func TestStamp(t *testing.T) {
 		{
 			name: "no nanos",
 			col: &statepb.Column{
-				Started: 2,
+				Started: 2000,
 			},
 			expected: &timestamp.Timestamp{
 				Seconds: 2,
@@ -4176,13 +4176,23 @@ func TestStamp(t *testing.T) {
 			},
 		},
 		{
-			name: "has nanos",
+			name: "milli to nano",
+			col: &statepb.Column{
+				Started: 1234,
+			},
+			expected: &timestamp.Timestamp{
+				Seconds: 1,
+				Nanos:   234000000,
+			},
+		},
+		{
+			name: "double to nanos",
 			col: &statepb.Column{
 				Started: 1.1,
 			},
 			expected: &timestamp.Timestamp{
-				Seconds: 1,
-				Nanos:   1e8,
+				Seconds: 0,
+				Nanos:   1100000,
 			},
 		},
 	}


### PR DESCRIPTION
This float -> timestamp conversion is causing the displayed start times to be wrong when displayed, without (it seems) affecting the business logic of the updater. The rest of the updater seems to treat this field as milliseconds correctly.

It would be great if this proto field was simply a "timestamp", so it doesn't need to be converted to (and later from) a timestamp. (#683)