### PR TITLE
Add field metrics to config merger

### DIFF
--- a/cmd/config_merger/BUILD.bazel
+++ b/cmd/config_merger/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/testgrid/cmd/config_merger",
     visibility = ["//visibility:public"],
     deps = [
+        "//config:go_default_library",
         "//pkg/merger:go_default_library",
         "//util/gcs:go_default_library",
         "//util/metrics:go_default_library",

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config.go",
         "converge.go",
+        "fields.go",
         "queue.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/config",
@@ -17,6 +18,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@org_bitbucket_creachadair_stringset//:go_default_library",
+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
     ],
 )
 
@@ -43,6 +45,7 @@ go_test(
     srcs = [
         "config_test.go",
         "converge_test.go",
+        "fields_test.go",
         "queue_test.go",
     ],
     embed = [":go_default_library"],

--- a/config/fields.go
+++ b/config/fields.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+type protoPath struct {
+	name  string
+	count map[string]int64
+}
+
+func (pp protoPath) countRecursive(fd protoreflect.FieldDescriptor, val protoreflect.Value) bool {
+	if pp.name != "" {
+		pp.name = fmt.Sprintf("%s.%s", pp.name, fd.Name())
+	} else {
+		pp.name = string(fd.Name())
+	}
+
+	if fd.Kind() == protoreflect.MessageKind {
+		if fd.IsList() {
+			for i := 0; i < val.List().Len(); i++ {
+				val.List().Get(i).Message().Range(pp.countRecursive)
+			}
+			return true
+		}
+		// Does not support maps of messages; there aren't any in config.proto
+		val.Message().Range(pp.countRecursive)
+		return true
+	}
+	pp.count[pp.name]++
+	return true
+}
+
+// Fields returns counts of all of the primitive fields in this configuration
+//
+// Field names in the map are qualified with where they are nested; this is not the same as a message's "FullName"
+// Ex: A dashboard tab's name is "dashboards.dashboard_tab.name"
+func Fields(cfg *configpb.Configuration) map[string]int64 {
+	pp := protoPath{
+		count: map[string]int64{},
+	}
+
+	cfg.ProtoReflect().Range(pp.countRecursive)
+	return pp.count
+}

--- a/config/fields_test.go
+++ b/config/fields_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFields(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   *configpb.Configuration
+		expected map[string]int64
+	}{
+		{
+			name:     "Nil config",
+			expected: map[string]int64{},
+		},
+		{
+			name:     "Empty config",
+			config:   &configpb.Configuration{},
+			expected: map[string]int64{},
+		},
+		{
+			name: "Simple config",
+			config: &configpb.Configuration{
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "dash_1",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "tab_1",
+								TestGroupName: "test_group_1",
+							},
+						},
+					},
+				},
+				TestGroups: []*configpb.TestGroup{
+					{
+						Name:             "test_group_1",
+						GcsPrefix:        "tests_live_here",
+						DaysOfResults:    1,
+						NumColumnsRecent: 1,
+					},
+				},
+			},
+			expected: map[string]int64{
+				"dashboards.name":                          1,
+				"dashboards.dashboard_tab.name":            1,
+				"dashboards.dashboard_tab.test_group_name": 1,
+				"test_groups.name":                         1,
+				"test_groups.gcs_prefix":                   1,
+				"test_groups.days_of_results":              1,
+				"test_groups.num_columns_recent":           1,
+			},
+		},
+		{
+			name: "Multiple configs",
+			config: &configpb.Configuration{
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name: "dash_1",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "tab_1",
+								TestGroupName: "test_group_1",
+							},
+						},
+					},
+					{
+						Name: "dash_2",
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:          "tab_2",
+								TestGroupName: "test_group_2",
+							},
+							{
+								Name:         "tab_3",
+								BugComponent: 1,
+							},
+						},
+						HighlightToday: true,
+					},
+				},
+			},
+			expected: map[string]int64{
+				"dashboards.name":                          2,
+				"dashboards.dashboard_tab.name":            3,
+				"dashboards.dashboard_tab.test_group_name": 2,
+				"dashboards.dashboard_tab.bug_component":   1,
+				"dashboards.highlight_today":               1,
+			},
+		},
+		{
+			name: "Ignore default values",
+			config: &configpb.Configuration{
+				Dashboards: []*configpb.Dashboard{
+					{
+						Name:           "",
+						HighlightToday: false,
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name:         "DashTab",
+								BugComponent: 0,
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]int64{
+				"dashboards.dashboard_tab.name": 1,
+			},
+		},
+		{
+			name: "Nested messages and one-ofs",
+			config: &configpb.Configuration{
+				Dashboards: []*configpb.Dashboard{
+					{
+						DashboardTab: []*configpb.DashboardTab{
+							{
+								Name: "t",
+								BetaAutobugOptions: &configpb.AutoBugOptions{
+									BetaAutobugComponent: 1,
+									HotlistIdsFromSource: []*configpb.HotlistIdFromSource{
+										{
+											HotlistIdSource: &configpb.HotlistIdFromSource_Label{"foo"},
+										},
+										{
+											HotlistIdSource: &configpb.HotlistIdFromSource_Value{1},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TestGroups: []*configpb.TestGroup{
+					{
+						AutoBugOptions: &configpb.AutoBugOptions{
+							BetaAutobugComponent: 1,
+							HotlistIdsFromSource: []*configpb.HotlistIdFromSource{
+								{
+									HotlistIdSource: &configpb.HotlistIdFromSource_Value{2},
+								},
+								{
+									HotlistIdSource: &configpb.HotlistIdFromSource_Value{3},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]int64{
+				"dashboards.dashboard_tab.name":                                               1,
+				"dashboards.dashboard_tab.beta_autobug_options.beta_autobug_component":        1,
+				"dashboards.dashboard_tab.beta_autobug_options.hotlist_ids_from_source.label": 1,
+				"dashboards.dashboard_tab.beta_autobug_options.hotlist_ids_from_source.value": 1,
+				"test_groups.auto_bug_options.beta_autobug_component":                         1,
+				"test_groups.auto_bug_options.hotlist_ids_from_source.value":                  2,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := Fields(tc.config)
+			if diff := cmp.Diff(tc.expected, result); diff != "" {
+				t.Errorf("Incorrect fields (-want +got): %s", diff)
+			}
+		})
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
@@ -234,6 +235,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/merger/merger_test.go
+++ b/pkg/merger/merger_test.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"io"
 	"io/ioutil"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
@@ -387,7 +388,7 @@ func Test_MergeAndUpdate(t *testing.T) {
 				})
 			}
 
-			resultErr := MergeAndUpdate(context.Background(), &client, mergeList, tc.skipValidate, tc.confirm)
+			_, resultErr := MergeAndUpdate(context.Background(), &client, mergeList, tc.skipValidate, tc.confirm)
 
 			if tc.expectUpload && !client.uploaded {
 				t.Errorf("Expected upload, but there was none")


### PR DESCRIPTION
Config Merger now counts and logs usage of particular config options as merging takes place.