### PR TITLE
Don't store properties on group-delimiter rows.

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -1121,11 +1121,12 @@ func appendCell(row *statepb.Row, cell Cell, start, count int) {
 			continue
 		}
 		if addCellID {
+			// These values can be derived from the parent row and don't need to be repeated here.
 			row.CellIds = append(row.CellIds, cell.CellID)
+			row.Properties = append(row.Properties, &statepb.Property{
+				Property: cell.Properties,
+			})
 		}
-		row.Properties = append(row.Properties, &statepb.Property{
-			Property: cell.Properties,
-		})
 		// Javascript client expects no result cells to skip icons/messages
 		row.Messages = append(row.Messages, cell.Message)
 		row.Icons = append(row.Icons, cell.Icon)

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -3693,6 +3693,36 @@ func TestAppendCell(t *testing.T) {
 				Issues:  []string{"problematic", "state"},
 			},
 		},
+		{
+			name: "append to group delimiter",
+			row: &statepb.Row{
+				Name: "test1@TESTGRID@something",
+				Results: []int32{
+					int32(statuspb.TestStatus_PASS), 1,
+				},
+				Messages:     []string{""},
+				Icons:        []string{""},
+				UserProperty: []string{""},
+			},
+			cell: cell{
+				Result: statuspb.TestStatus_PASS,
+				CellID: "cell-id-1",
+				Properties: map[string]string{
+					"workflow-id":   "run-1",
+					"workflow-name": "//workflow-a",
+				},
+			},
+			count: 1,
+			expected: &statepb.Row{
+				Name: "test1@TESTGRID@something",
+				Results: []int32{
+					int32(statuspb.TestStatus_PASS), 2,
+				},
+				Messages:     []string{"", ""},
+				Icons:        []string{"", ""},
+				UserProperty: []string{"", ""},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Properties will generally be the same on the parent row for rows with a group delimiter, so save time/space by not storing additional info on them.