### PR TITLE
Always include job name on Overall row.

### DIFF
--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -348,7 +348,6 @@ func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, header
 			overall.Message = "Build failed outside of test results"
 		}
 	}
-
 	injectedCells := map[string]Cell{
 		overallRow: overall,
 	}
@@ -361,11 +360,11 @@ func convertResult(log logrus.FieldLogger, nameCfg nameConfig, id string, header
 
 	for name, c := range injectedCells {
 		c.CellID = cellID
+		jobName := result.job + "." + name
+		cells[jobName] = append([]Cell{c}, cells[jobName]...)
 		if nameCfg.multiJob {
-			jobName := result.job + "." + name
-			cells[jobName] = append([]Cell{c}, cells[jobName]...)
+			cells[name] = append([]Cell{c}, cells[name]...)
 		}
-		cells[name] = append([]Cell{c}, cells[name]...)
 	}
 
 	out := InflatedColumn{

--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -327,7 +327,7 @@ func TestConvertResult(t *testing.T) {
 			expected: InflatedColumn{
 				Column: &statepb.Column{},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "T",
 						Message: "Build did not complete within 24 hours",
@@ -351,7 +351,7 @@ func TestConvertResult(t *testing.T) {
 					EmailAddresses: []string{"world"},
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "T",
 						Message: "Build did not complete within 24 hours",
@@ -375,7 +375,7 @@ func TestConvertResult(t *testing.T) {
 					EmailAddresses: []string{"world"},
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "T",
 						Message: "Build did not complete within 24 hours",
@@ -399,7 +399,7 @@ func TestConvertResult(t *testing.T) {
 					EmailAddresses: []string{"world", "olam"},
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "T",
 						Message: "Build did not complete within 24 hours",
@@ -423,7 +423,7 @@ func TestConvertResult(t *testing.T) {
 					EmailAddresses: []string{},
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "T",
 						Message: "Build did not complete within 24 hours",
@@ -447,7 +447,7 @@ func TestConvertResult(t *testing.T) {
 					EmailAddresses: []string{},
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "T",
 						Message: "Build did not complete within 24 hours",
@@ -488,7 +488,7 @@ func TestConvertResult(t *testing.T) {
 					},
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "T",
 						Message: "Build did not complete within 24 hours",
@@ -529,7 +529,7 @@ func TestConvertResult(t *testing.T) {
 					},
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_RUNNING,
 						Icon:    "R",
 						Message: "Build still running...",
@@ -538,7 +538,7 @@ func TestConvertResult(t *testing.T) {
 			},
 		},
 		{
-			name: "add job overall when multiJob",
+			name: "add overall when multiJob",
 			id:   "build",
 			nameCfg: nameConfig{
 				format:   "%s.%s",
@@ -603,7 +603,7 @@ func TestConvertResult(t *testing.T) {
 			},
 		},
 		{
-			name: "inclue job name upon request",
+			name: "include job name upon request",
 			nameCfg: nameConfig{
 				format: "%s.%s",
 				parts:  []string{jobName, testsName},
@@ -642,7 +642,7 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"job-name." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "F",
 						Message: "Build failed outside of test results",
@@ -693,7 +693,7 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Icon:    "F",
 						Message: "Build failed outside of test results",
@@ -781,7 +781,7 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Metrics: setElapsed(nil, 1),
 					},
@@ -937,7 +937,7 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_FAIL,
 						Metrics: setElapsed(nil, 1),
 					},
@@ -1064,7 +1064,7 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_PASS,
 						Metrics: setElapsed(nil, 1),
 					},
@@ -1157,7 +1157,7 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_PASS,
 						Metrics: setElapsed(nil, 1),
 					},
@@ -1238,7 +1238,7 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_PASS,
 						Metrics: setElapsed(nil, 1),
 					},
@@ -1315,7 +1315,7 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_PASS,
 						Metrics: setElapsed(nil, 1),
 					},
@@ -1390,7 +1390,7 @@ func TestConvertResult(t *testing.T) {
 				},
 				Cells: func() map[string]Cell {
 					out := map[string]Cell{
-						overallRow: {
+						"." + overallRow: {
 							Result:  statuspb.TestStatus_PASS,
 							Metrics: setElapsed(nil, 1),
 						},
@@ -1440,11 +1440,11 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_PASS,
 						Metrics: setElapsed(nil, 1),
 					},
-					podInfoRow: podInfoMissingCell,
+					"." + podInfoRow: podInfoMissingCell,
 				},
 			},
 		},
@@ -1476,11 +1476,11 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_PASS,
 						Metrics: setElapsed(nil, 1),
 					},
-					podInfoRow: podInfoPassCell,
+					"." + podInfoRow: podInfoPassCell,
 				},
 			},
 		},
@@ -1501,7 +1501,7 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_RUNNING,
 						Icon:    "R",
 						Message: "Build still running...",
@@ -1531,12 +1531,12 @@ func TestConvertResult(t *testing.T) {
 					Started: float64(now * 1000),
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_RUNNING,
 						Icon:    "R",
 						Message: "Build still running...",
 					},
-					podInfoRow: podInfoPassCell,
+					"." + podInfoRow: podInfoPassCell,
 				},
 			},
 		},
@@ -1586,7 +1586,7 @@ func TestConvertResult(t *testing.T) {
 					Hint:    "McLovin",
 				},
 				Cells: map[string]Cell{
-					overallRow: {
+					"." + overallRow: {
 						Result:  statuspb.TestStatus_PASS,
 						Metrics: setElapsed(nil, 1),
 						CellID:  "McLovin",

--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -252,13 +252,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+10) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 10 / 60.0,
 							},
 						},
-						podInfoRow: podInfoMissingCell,
+						"build." + podInfoRow: podInfoMissingCell,
 					},
 				},
 				{
@@ -268,7 +268,7 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+11) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result:  statuspb.TestStatus_FAIL,
 							Icon:    "F",
 							Message: "Build failed outside of test results",
@@ -276,7 +276,7 @@ func TestReadColumns(t *testing.T) {
 								"test-duration-minutes": 11 / 60.0,
 							},
 						},
-						podInfoRow: podInfoPassCell,
+						"build." + podInfoRow: podInfoPassCell,
 					},
 				},
 			},
@@ -341,13 +341,13 @@ func TestReadColumns(t *testing.T) {
 						},
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 10 / 60.0,
 							},
 						},
-						podInfoRow: podInfoMissingCell,
+						"build." + podInfoRow: podInfoMissingCell,
 					},
 				},
 				{
@@ -361,7 +361,7 @@ func TestReadColumns(t *testing.T) {
 						},
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result:  statuspb.TestStatus_FAIL,
 							Icon:    "F",
 							Message: "Build failed outside of test results",
@@ -369,7 +369,7 @@ func TestReadColumns(t *testing.T) {
 								"test-duration-minutes": 11 / 60.0,
 							},
 						},
-						podInfoRow: podInfoPassCell,
+						"build." + podInfoRow: podInfoPassCell,
 					},
 				},
 			},
@@ -424,13 +424,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+10) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 10 / 60.0,
 							},
 						},
-						podInfoRow: podInfoPassCell,
+						"build." + podInfoRow: podInfoPassCell,
 						"name good - context context-a - thread 33": {
 							Result: statuspb.TestStatus_PASS,
 						},
@@ -532,13 +532,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+13) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 13 / 60.0,
 							},
 						},
-						podInfoRow: podInfoPassCell,
+						"build." + podInfoRow: podInfoPassCell,
 					},
 				},
 				{
@@ -548,13 +548,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+14) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 14 / 60.0,
 							},
 						},
-						podInfoRow: podInfoPassCell,
+						"build." + podInfoRow: podInfoPassCell,
 					},
 				},
 			},
@@ -625,13 +625,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+13) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 13 / 60.0,
 							},
 						},
-						podInfoRow: podInfoPassCell,
+						"build." + podInfoRow: podInfoPassCell,
 					},
 				},
 				{
@@ -641,13 +641,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+12) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 12 / 60.0,
 							},
 						},
-						podInfoRow: podInfoMissingCell,
+						"build." + podInfoRow: podInfoMissingCell,
 					},
 				},
 				{
@@ -657,13 +657,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+11) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 11 / 60.0,
 							},
 						},
-						podInfoRow: podInfoPassCell,
+						"build." + podInfoRow: podInfoPassCell,
 					},
 				},
 				{
@@ -673,13 +673,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+10) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 10 / 60.0,
 							},
 						},
-						podInfoRow: podInfoMissingCell,
+						"build." + podInfoRow: podInfoMissingCell,
 					},
 				},
 			},
@@ -750,13 +750,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+13) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 13 / 60.0,
 							},
 						},
-						podInfoRow: podInfoMissingCell,
+						"build." + podInfoRow: podInfoMissingCell,
 					},
 				},
 				{
@@ -766,13 +766,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+12) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 12 / 60.0,
 							},
 						},
-						podInfoRow: podInfoPassCell,
+						"build." + podInfoRow: podInfoPassCell,
 					},
 				},
 				// drop 11 and 10
@@ -867,13 +867,13 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+9) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result: statuspb.TestStatus_PASS,
 							Metrics: map[string]float64{
 								"test-duration-minutes": 9 / 60.0,
 							},
 						},
-						podInfoRow: podInfoMissingCell,
+						"build." + podInfoRow: podInfoMissingCell,
 					},
 				},
 				{
@@ -909,7 +909,7 @@ func TestReadColumns(t *testing.T) {
 						Started: float64(now+13) * 1000,
 					},
 					Cells: map[string]cell{
-						overallRow: {
+						"build." + overallRow: {
 							Result:  statuspb.TestStatus_FAIL,
 							Icon:    "F",
 							Message: "Build failed outside of test results",
@@ -917,7 +917,7 @@ func TestReadColumns(t *testing.T) {
 								"test-duration-minutes": 13 / 60.0,
 							},
 						},
-						podInfoRow: podInfoPassCell,
+						"build." + podInfoRow: podInfoPassCell,
 					},
 				},
 				{

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -1330,8 +1330,8 @@ func TestInflateDropAppend(t *testing.T) {
 					Rows: []*statepb.Row{
 						setupRow(
 							&statepb.Row{
-								Name: overallRow,
-								Id:   overallRow,
+								Name: "build." + overallRow,
+								Id:   "build." + overallRow,
 							},
 							cell{
 								Result:  statuspb.TestStatus_RUNNING,
@@ -1353,8 +1353,8 @@ func TestInflateDropAppend(t *testing.T) {
 						),
 						setupRow(
 							&statepb.Row{
-								Name: podInfoRow,
-								Id:   podInfoRow,
+								Name: "build." + podInfoRow,
+								Id:   "build." + podInfoRow,
 							},
 							cell{Result: statuspb.TestStatus_NO_RESULT},
 							podInfoPassCell,
@@ -1493,8 +1493,8 @@ func TestInflateDropAppend(t *testing.T) {
 					Rows: []*statepb.Row{
 						setupRow(
 							&statepb.Row{
-								Name: overallRow,
-								Id:   overallRow,
+								Name: "build." + overallRow,
+								Id:   "build." + overallRow,
 							},
 							cell{
 								Result:  statuspb.TestStatus_PASS,
@@ -1516,8 +1516,8 @@ func TestInflateDropAppend(t *testing.T) {
 						),
 						setupRow(
 							&statepb.Row{
-								Name: podInfoRow,
-								Id:   podInfoRow,
+								Name: "build." + podInfoRow,
+								Id:   "build." + podInfoRow,
 							},
 							podInfoPassCell,
 							podInfoPassCell,
@@ -1650,8 +1650,8 @@ func TestInflateDropAppend(t *testing.T) {
 					Rows: []*statepb.Row{
 						setupRow(
 							&statepb.Row{
-								Name: overallRow,
-								Id:   overallRow,
+								Name: "build." + overallRow,
+								Id:   "build." + overallRow,
 							},
 							cell{
 								Result:  statuspb.TestStatus_PASS,
@@ -1691,8 +1691,8 @@ func TestInflateDropAppend(t *testing.T) {
 					Rows: []*statepb.Row{
 						setupRow(
 							&statepb.Row{
-								Name: overallRow,
-								Id:   overallRow,
+								Name: "build." + overallRow,
+								Id:   "build." + overallRow,
 							},
 							cell{
 								Result:  statuspb.TestStatus_RUNNING,
@@ -1767,8 +1767,8 @@ func TestInflateDropAppend(t *testing.T) {
 					Rows: []*statepb.Row{
 						setupRow(
 							&statepb.Row{
-								Name: overallRow,
-								Id:   overallRow,
+								Name: "build." + overallRow,
+								Id:   "build." + overallRow,
 							},
 							cell{
 								Result:  statuspb.TestStatus_PASS,
@@ -1818,8 +1818,8 @@ func TestInflateDropAppend(t *testing.T) {
 					Rows: []*statepb.Row{
 						setupRow(
 							&statepb.Row{
-								Name: overallRow,
-								Id:   overallRow,
+								Name: "build." + overallRow,
+								Id:   "build." + overallRow,
 							},
 							cell{
 								Result:  statuspb.TestStatus_RUNNING,


### PR DESCRIPTION
We already do this for multi-job configurations, do it for single-job as well for consistency and better interaction with some features.