### PR TITLE
Refactor TestGroup out of base Queue

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -12,10 +12,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pb/config:go_default_library",
+        "//util:go_default_library",
         "//util/gcs:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
     ],

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
-        "@org_bitbucket_creachadair_stringset//:go_default_library",
         "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
     ],
 )

--- a/config/queue.go
+++ b/config/queue.go
@@ -17,15 +17,12 @@ limitations under the License.
 package config
 
 import (
-	"container/heap"
 	"context"
-	"errors"
-	"fmt"
 	"sync"
 	"time"
 
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	"github.com/sirupsen/logrus"
+	"github.com/GoogleCloudPlatform/testgrid/util"
 )
 
 // TestGroupQueue can send test groups to receivers at a specific frequency.
@@ -34,140 +31,27 @@ import (
 // First call must be to Init().
 // Exported methods are safe to call concurrently.
 type TestGroupQueue struct {
-	queue  priorityQueue
-	items  map[string]*item
+	util.Queue
 	groups map[string]*configpb.TestGroup
 	lock   sync.RWMutex
-	signal chan struct{}
 }
 
 // Init (or reinit) the queue with the specified groups, which should be updated at frequency.
 func (q *TestGroupQueue) Init(testGroups []*configpb.TestGroup, when time.Time) {
 	n := len(testGroups)
 	groups := make(map[string]*configpb.TestGroup, n)
+	names := make([]string, n)
 
-	q.lock.Lock()
-	defer q.lock.Unlock()
-	defer q.rouse()
-	q.groups = groups
-
-	if q.signal == nil {
-		q.signal = make(chan struct{})
-	}
-
-	if q.items == nil {
-		q.items = make(map[string]*item, n)
-	}
-	if q.queue == nil {
-		q.queue = make(priorityQueue, 0, n)
-	}
-	items := q.items
-
-	for _, tg := range testGroups {
+	for i, tg := range testGroups {
 		name := tg.Name
+		names[i] = name
 		groups[name] = tg
-		it, ok := items[name]
-		if !ok {
-			it = &item{
-				name:  name,
-				when:  when,
-				index: len(q.queue),
-			}
-			heap.Push(&q.queue, it)
-			items[name] = it
-			logrus.WithFields(logrus.Fields{
-				"when":  when,
-				"group": name,
-			}).Info("Adding group to queue")
-		}
 	}
 
-	for name, it := range items {
-		if _, ok := groups[name]; ok {
-			continue
-		}
-		logrus.WithField("group", name).Info("Removing group from queue")
-		heap.Remove(&q.queue, it.index)
-		delete(q.items, name)
-	}
-}
-
-// FixAll will fix multiple groups inside a single critical section.
-//
-// If later is set then it will move out the next update time, otherwise
-// it will only reduce it.
-func (q *TestGroupQueue) FixAll(whens map[string]time.Time, later bool) error {
+	q.Queue.Init(names, when)
 	q.lock.Lock()
-	defer q.lock.Unlock()
-	var missing []string
-	defer q.rouse()
-
-	reduced := map[string]time.Time{}
-	fixed := map[string]time.Time{}
-
-	for name, when := range whens {
-		it, ok := q.items[name]
-		if !ok {
-			missing = append(missing, name)
-			continue
-		}
-		if when.Before(it.when) {
-			reduced[name] = when
-		} else if later && !when.Equal(it.when) {
-			fixed[name] = when
-		} else {
-			continue
-		}
-		it.when = when
-	}
-	var log logrus.FieldLogger = logrus.New()
-	var any bool
-	if n := len(reduced); n > 0 {
-		log = log.WithField("reduced", n)
-		any = true
-	}
-	if n := len(fixed); n > 0 {
-		log = log.WithField("fixed", n)
-		any = true
-	}
-	heap.Init(&q.queue)
-	if len(missing) > 0 {
-		return fmt.Errorf("not found: %v", missing)
-	}
-	if any {
-		log.Info("Fixed all groups")
-	}
-	return nil
-}
-
-// Fix the next time to send the group to receivers.
-//
-// If later is set then it will move out the next update time, otherwise
-// it will only reduce it.
-func (q *TestGroupQueue) Fix(name string, when time.Time, later bool) error {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-	defer q.rouse()
-
-	it, ok := q.items[name]
-	if !ok {
-		return errors.New("not found")
-	}
-	log := logrus.WithFields(logrus.Fields{
-		"group": name,
-		"when":  when,
-	})
-	if when.Before(it.when) {
-		log = log.WithField("reduced minutes", it.when.Sub(when).Round(time.Second).Minutes())
-	} else if later && !when.Equal(it.when) {
-		log = log.WithField("delayed minutes", when.Sub(it.when).Round(time.Second).Minutes())
-	} else {
-		return nil
-	}
-	it.when = when
-	heap.Fix(&q.queue, it.index)
-	log.Info("Fixed group")
-	return nil
+	q.groups = groups
+	q.lock.Unlock()
 }
 
 // Status of the queue: depth, next item and when the next item is ready.
@@ -176,48 +60,11 @@ func (q *TestGroupQueue) Status() (int, *configpb.TestGroup, time.Time) {
 	defer q.lock.RUnlock()
 	var tg *configpb.TestGroup
 	var when time.Time
-	if it := q.queue.peek(); it != nil {
-		tg = q.groups[it.name]
-		when = it.when
+	n, who, when := q.Queue.Status()
+	if who != nil {
+		tg = q.groups[*who]
 	}
-	return len(q.queue), tg, when
-}
-
-func (q *TestGroupQueue) rouse() {
-	select {
-	case q.signal <- struct{}{}: // wake up early
-	default: // not sleeping
-	}
-}
-
-func (q *TestGroupQueue) sleep(d time.Duration) {
-	log := logrus.WithFields(logrus.Fields{
-		"seconds": d.Round(100 * time.Millisecond).Seconds(),
-	})
-	if d > 5*time.Second {
-		log.Info("Sleeping...")
-	} else {
-		log.Debug("Sleeping...")
-	}
-	sleep := time.NewTimer(d)
-	start := time.Now()
-	select {
-	case <-q.signal:
-		if !sleep.Stop() {
-			<-sleep.C
-		}
-		dur := time.Now().Sub(start)
-		log := log.WithField("after", dur.Round(time.Millisecond))
-		switch {
-		case dur > 10*time.Second:
-			log.Info("Roused")
-		case dur > time.Second:
-			log.Debug("Roused")
-		default:
-			log.Trace("Roused")
-		}
-	case <-sleep.C:
-	}
+	return n, tg, when
 }
 
 // Send test groups to receivers until the context expires.
@@ -225,95 +72,25 @@ func (q *TestGroupQueue) sleep(d time.Duration) {
 // Pops items off the queue when frequency is zero.
 // Otherwise reschedules the item after the specified frequency has elapsed.
 func (q *TestGroupQueue) Send(ctx context.Context, receivers chan<- *configpb.TestGroup, frequency time.Duration) error {
-	var next func() (*configpb.TestGroup, time.Time)
-	if frequency == 0 {
-		next = func() (*configpb.TestGroup, time.Time) {
-			if len(q.queue) == 0 {
-				return nil, time.Time{}
-			}
-			it := heap.Pop(&q.queue).(*item)
-			return q.groups[it.name], it.when
-		}
-	} else {
-		next = func() (*configpb.TestGroup, time.Time) {
-			it := q.queue.peek()
-			if it == nil {
-				return nil, time.Time{}
-			}
-			when := it.when
-			it.when = time.Now().Add(frequency)
-			heap.Fix(&q.queue, it.index)
-			return q.groups[it.name], when
-		}
-	}
+	ch := make(chan string)
+	var err error
+	go func() {
+		err = q.Queue.Send(ctx, ch, frequency)
+		close(ch)
+	}()
 
-	for {
-		q.lock.Lock()
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		tg, when := next()
-		q.lock.Unlock()
-
+	for who := range ch {
+		q.lock.RLock()
+		tg := q.groups[who]
+		q.lock.RUnlock()
 		if tg == nil {
-			if frequency == 0 {
-				return nil
-			}
-			q.sleep(time.Second)
 			continue
 		}
-
-		if dur := when.Sub(time.Now()); dur > 0 {
-			q.sleep(dur)
-		}
 		select {
-		case receivers <- tg:
 		case <-ctx.Done():
 			return ctx.Err()
+		case receivers <- tg:
 		}
 	}
-}
-
-type priorityQueue []*item
-
-func (pq priorityQueue) Len() int { return len(pq) }
-func (pq priorityQueue) Less(i, j int) bool {
-	return pq[i].when.Before(pq[j].when)
-}
-func (pq priorityQueue) Swap(i, j int) {
-	pq[i], pq[j] = pq[j], pq[i]
-	pq[i].index = i
-	pq[j].index = j
-}
-
-func (pq *priorityQueue) Push(something interface{}) {
-	it := something.(*item)
-	it.index = len(*pq)
-	*pq = append(*pq, it)
-}
-
-func (pq *priorityQueue) Pop() interface{} {
-	old := *pq
-	n := len(old)
-	it := old[n-1]
-	it.index = -1
-	old[n-1] = nil
-	*pq = old[0 : n-1]
-	return it
-}
-
-func (pq priorityQueue) peek() *item {
-	n := len(pq)
-	if n == 0 {
-		return nil
-	}
-	return pq[0]
-}
-
-type item struct {
-	name  string
-	when  time.Time
-	index int
+	return err
 }

--- a/config/queue_test.go
+++ b/config/queue_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"container/heap"
 	"context"
 	"sync"
 	"testing"
@@ -27,285 +26,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 )
-
-func TestInit(t *testing.T) {
-	now := time.Now()
-	cases := []struct {
-		name   string
-		q      *TestGroupQueue
-		groups []*configpb.TestGroup
-		when   time.Time
-
-		next []string
-	}{
-		{
-			name: "add",
-			q:    &TestGroupQueue{},
-			groups: []*configpb.TestGroup{
-				{
-					Name: "hi",
-				},
-			},
-			when: now,
-
-			next: []string{"hi"},
-		},
-		{
-			name: "remove",
-			q: func() *TestGroupQueue {
-				var q TestGroupQueue
-				q.Init([]*configpb.TestGroup{
-					{
-						Name: "drop",
-					},
-					{
-						Name: "keep",
-					},
-				}, now)
-				return &q
-			}(),
-			groups: []*configpb.TestGroup{
-				{
-					Name: "keep",
-				},
-				{
-					Name: "add",
-				},
-			},
-			when: now.Add(-time.Minute),
-			next: []string{
-				"add",
-				"keep",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			tc.q.Init(tc.groups, tc.when)
-
-			var got []string
-			for range tc.next {
-				got = append(got, heap.Pop(&tc.q.queue).(*item).name)
-			}
-			if diff := cmp.Diff(tc.next, got, protocmp.Transform()); diff != "" {
-				t.Errorf("FixAll() got unexpected diff (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestFixAll(t *testing.T) {
-	now := time.Now()
-	cases := []struct {
-		name  string
-		q     *TestGroupQueue
-		fixes map[string]time.Time
-		later bool
-
-		next []string
-		err  bool
-	}{
-		{
-			name: "empty",
-			q:    &TestGroupQueue{},
-		},
-		{
-			name: "later",
-			q: func() *TestGroupQueue {
-				var q TestGroupQueue
-				q.Init([]*configpb.TestGroup{
-					{
-						Name: "first-now-second",
-					},
-					{
-						Name: "second-now-fifth",
-					},
-					{
-						Name: "third",
-					},
-					{
-						Name: "fourth-now-first",
-					},
-					{
-						Name: "fifth-now-fourth",
-					},
-				}, now)
-				return &q
-			}(),
-			fixes: map[string]time.Time{
-				"fourth-now-first": now.Add(-2 * time.Minute),
-				"first-now-second": now.Add(-time.Minute),
-				"second-now-fifth": now.Add(2 * time.Minute),
-				"fifth-now-fourth": now.Add(time.Minute),
-			},
-			later: true,
-
-			next: []string{
-				"fourth-now-first",
-				"first-now-second",
-				"third",
-				"fifth-now-fourth",
-				"second-now-fifth",
-			},
-		},
-		{
-			name: "reduce",
-			q: func() *TestGroupQueue {
-				var q TestGroupQueue
-				q.Init([]*configpb.TestGroup{
-					{
-						Name: "first-now-second",
-					},
-					{
-						Name: "second-ignored-becomes-fifth",
-					},
-					{
-						Name: "third-becomes-fourth",
-					},
-					{
-						Name: "fourth-now-first",
-					},
-					{
-						Name: "fifth-ignored-becomes-fourth",
-					},
-				}, now)
-				return &q
-			}(),
-			fixes: map[string]time.Time{
-				"fourth-now-first":             now.Add(-2 * time.Minute),
-				"first-now-second":             now.Add(-time.Minute),
-				"second-ignored-becomes-fifth": now.Add(2 * time.Minute), // noop
-				"fifth-ignored-becomes-fourth": now.Add(time.Minute),     // noop
-			},
-			later: true,
-
-			next: []string{
-				"fourth-now-first",
-				"first-now-second",
-				"third-becomes-fourth",
-				"fifth-ignored-becomes-fourth",
-				"second-ignored-becomes-fifth",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.q.FixAll(tc.fixes, tc.later); (err != nil) != tc.err {
-				t.Errorf("FixAll() got unexpected error %v, wanted err=%t", err, tc.err)
-			}
-			var got []string
-			for range tc.next {
-				got = append(got, heap.Pop(&tc.q.queue).(*item).name)
-			}
-			if diff := cmp.Diff(tc.next, got, protocmp.Transform()); diff != "" {
-				t.Errorf("FixAll() got unexpected diff (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestFix(t *testing.T) {
-	now := time.Now()
-	cases := []struct {
-		name string
-
-		q     *TestGroupQueue
-		fix   string
-		when  time.Time
-		later bool
-
-		next []string
-		err  bool
-	}{
-		{
-			name: "missing",
-			fix:  "missing",
-			q:    &TestGroupQueue{},
-			err:  true,
-		},
-		{
-			name: "later",
-			fix:  "basic",
-			q: func() *TestGroupQueue {
-				var q TestGroupQueue
-				q.Init([]*configpb.TestGroup{
-					{
-						Name: "basic",
-					},
-					{
-						Name: "was-later-now-first",
-					},
-				}, now)
-				return &q
-			}(),
-			when:  now.Add(time.Minute),
-			later: true,
-			next: []string{
-				"was-later-now-first",
-				"basic",
-			},
-		},
-		{
-			name: "ignore later",
-			fix:  "basic",
-			q: func() *TestGroupQueue {
-				var q TestGroupQueue
-				q.Init([]*configpb.TestGroup{
-					{
-						Name: "basic",
-					},
-					{
-						Name: "was-later-still-later",
-					},
-				}, now)
-				return &q
-			}(),
-			when: now.Add(time.Minute),
-			next: []string{
-				"basic",
-				"was-later-still-later",
-			},
-		},
-		{
-			name: "reduce",
-			fix:  "basic",
-			q: func() *TestGroupQueue {
-				var q TestGroupQueue
-				q.Init([]*configpb.TestGroup{
-					{
-						Name: "was-earlier-now-later",
-					},
-					{
-						Name: "basic",
-					},
-				}, now)
-				return &q
-			}(),
-			when: now.Add(-time.Minute),
-			next: []string{
-				"basic",
-				"was-earlier-now-later",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.q.Fix(tc.fix, tc.when, tc.later); (err != nil) != tc.err {
-				t.Errorf("Fix() got unexpected error %v, wanted err=%t", err, tc.err)
-			}
-			var got []string
-			for range tc.next {
-				got = append(got, heap.Pop(&tc.q.queue).(*item).name)
-			}
-			if diff := cmp.Diff(tc.next, got, protocmp.Transform()); diff != "" {
-				t.Errorf("Fix() got unexpected diff (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
 
 func TestStatus(t *testing.T) {
 	now := time.Now()
@@ -448,16 +168,14 @@ func TestSend(t *testing.T) {
 				var wg sync.WaitGroup
 				wg.Add(1)
 				var got []*configpb.TestGroup
-				ctx, cancel := context.WithCancel(ctx)
 				go func() {
 					defer wg.Done()
 					for {
 						select {
 						case tg := <-ch:
 							got = append(got, tg)
-							cancel()
+							return
 						case <-ctx.Done():
-							cancel()
 							return
 						}
 					}
@@ -544,7 +262,6 @@ func TestSend(t *testing.T) {
 				var wg sync.WaitGroup
 				wg.Add(1)
 				var got []*configpb.TestGroup
-				ctx, cancel := context.WithCancel(ctx)
 				go func() {
 					defer wg.Done()
 					for {
@@ -552,10 +269,9 @@ func TestSend(t *testing.T) {
 						case tg := <-ch:
 							got = append(got, tg)
 							if len(got) == 2 {
-								cancel()
+								return
 							}
 						case <-ctx.Done():
-							cancel()
 							return
 						}
 					}
@@ -653,73 +369,6 @@ func TestSend(t *testing.T) {
 			got := get()
 			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
 				t.Errorf("Send() got unexpected diff (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestPriorityQueue(t *testing.T) {
-	cases := []struct {
-		name  string
-		items []*item
-		want  []string
-	}{
-		{
-			name: "basic",
-		},
-		{
-			name: "single",
-			items: []*item{
-				{
-					name: "hi",
-				},
-			},
-			want: []string{"hi"},
-		},
-		{
-			name: "desc",
-			items: []*item{
-				{
-					name: "young",
-					when: time.Now(),
-				},
-				{
-					name: "old",
-					when: time.Now().Add(-time.Hour),
-				},
-			},
-			want: []string{"old", "young"},
-		},
-		{
-			name: "asc",
-			items: []*item{
-				{
-					name: "old",
-					when: time.Now().Add(-time.Hour),
-				},
-				{
-					name: "young",
-					when: time.Now(),
-				},
-			},
-			want: []string{"old", "young"},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			pq := priorityQueue(tc.items)
-			heap.Init(&pq)
-			var got []string
-			for i, w := range tc.want {
-				g := pq.peek().name
-				if diff := cmp.Diff(w, g, protocmp.Transform()); diff != "" {
-					t.Errorf("%d peek() got unexpected diff (-want +got):\n%s", i, diff)
-				}
-				got = append(got, heap.Pop(&pq).(*item).name)
-			}
-			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
-				t.Errorf("priorityQueue() got unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -1,8 +1,11 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["log.go"],
+    srcs = [
+        "log.go",
+        "queue.go",
+    ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/util",
     visibility = ["//visibility:public"],
     deps = ["@com_github_sirupsen_logrus//:go_default_library"],
@@ -24,4 +27,14 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["queue_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
+    ],
 )

--- a/util/queue.go
+++ b/util/queue.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"container/heap"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Queue can send names to receivers at a specific frequency.
+//
+// Also contains the ability to modify the next time to send names.
+// First call must be to Init().
+// Exported methods are safe to call concurrently.
+type Queue struct {
+	queue  priorityQueue
+	items  map[string]*item
+	lock   sync.RWMutex
+	signal chan struct{}
+}
+
+// Init (or reinit) the queue with the specified groups, which should be updated at frequency.
+func (q *Queue) Init(names []string, when time.Time) {
+	n := len(names)
+	found := make(map[string]bool, n)
+
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	defer q.rouse()
+
+	if q.signal == nil {
+		q.signal = make(chan struct{})
+	}
+
+	if q.items == nil {
+		q.items = make(map[string]*item, n)
+	}
+	if q.queue == nil {
+		q.queue = make(priorityQueue, 0, n)
+	}
+	items := q.items
+
+	for _, name := range names {
+		found[name] = true
+		it, ok := items[name]
+		if !ok {
+			it = &item{
+				name:  name,
+				when:  when,
+				index: len(q.queue),
+			}
+			heap.Push(&q.queue, it)
+			items[name] = it
+			logrus.WithFields(logrus.Fields{
+				"when": when,
+				"name": name,
+			}).Info("Adding name to queue")
+		}
+	}
+
+	for name, it := range items {
+		if found[name] {
+			continue
+		}
+		logrus.WithField("name", name).Info("Removing name from queue")
+		heap.Remove(&q.queue, it.index)
+		delete(q.items, name)
+	}
+}
+
+// FixAll will fix multiple groups inside a single critical section.
+//
+// If later is set then it will move out the next update time, otherwise
+// it will only reduce it.
+func (q *Queue) FixAll(whens map[string]time.Time, later bool) error {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	var missing []string
+	defer q.rouse()
+
+	reduced := map[string]time.Time{}
+	fixed := map[string]time.Time{}
+
+	for name, when := range whens {
+		it, ok := q.items[name]
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		if when.Before(it.when) {
+			reduced[name] = when
+		} else if later && !when.Equal(it.when) {
+			fixed[name] = when
+		} else {
+			continue
+		}
+		it.when = when
+	}
+	var log logrus.FieldLogger = logrus.New()
+	var any bool
+	if n := len(reduced); n > 0 {
+		log = log.WithField("reduced", n)
+		any = true
+	}
+	if n := len(fixed); n > 0 {
+		log = log.WithField("fixed", n)
+		any = true
+	}
+	heap.Init(&q.queue)
+	if len(missing) > 0 {
+		return fmt.Errorf("not found: %v", missing)
+	}
+	if any {
+		log.Info("Fixed all names")
+	}
+	return nil
+}
+
+// Fix the next time to send the group to receivers.
+//
+// If later is set then it will move out the next update time, otherwise
+// it will only reduce it.
+func (q *Queue) Fix(name string, when time.Time, later bool) error {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	defer q.rouse()
+
+	it, ok := q.items[name]
+	if !ok {
+		return errors.New("not found")
+	}
+	log := logrus.WithFields(logrus.Fields{
+		"group": name,
+		"when":  when,
+	})
+	if when.Before(it.when) {
+		log = log.WithField("reduced minutes", it.when.Sub(when).Round(time.Second).Minutes())
+	} else if later && !when.Equal(it.when) {
+		log = log.WithField("delayed minutes", when.Sub(it.when).Round(time.Second).Minutes())
+	} else {
+		return nil
+	}
+	it.when = when
+	heap.Fix(&q.queue, it.index)
+	log.Info("Fixed names")
+	return nil
+}
+
+// Status of the queue: depth, next item and when the next item is ready.
+func (q *Queue) Status() (int, *string, time.Time) {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	var who *string
+	var when time.Time
+	if it := q.queue.peek(); it != nil {
+		who = &it.name
+		when = it.when
+	}
+	return len(q.queue), who, when
+}
+
+func (q *Queue) rouse() {
+	select {
+	case q.signal <- struct{}{}: // wake up early
+	default: // not sleeping
+	}
+}
+
+func (q *Queue) sleep(d time.Duration) {
+	log := logrus.WithFields(logrus.Fields{
+		"seconds": d.Round(100 * time.Millisecond).Seconds(),
+	})
+	if d > 5*time.Second {
+		log.Info("Sleeping...")
+	} else {
+		log.Debug("Sleeping...")
+	}
+	sleep := time.NewTimer(d)
+	start := time.Now()
+	select {
+	case <-q.signal:
+		if !sleep.Stop() {
+			<-sleep.C
+		}
+		dur := time.Now().Sub(start)
+		log := log.WithField("after", dur.Round(time.Millisecond))
+		switch {
+		case dur > 10*time.Second:
+			log.Info("Roused")
+		case dur > time.Second:
+			log.Debug("Roused")
+		default:
+			log.Trace("Roused")
+		}
+	case <-sleep.C:
+	}
+}
+
+// Send test groups to receivers until the context expires.
+//
+// Pops items off the queue when frequency is zero.
+// Otherwise reschedules the item after the specified frequency has elapsed.
+func (q *Queue) Send(ctx context.Context, receivers chan<- string, frequency time.Duration) error {
+	var next func() (*string, time.Time)
+	if frequency == 0 {
+		next = func() (*string, time.Time) {
+			if len(q.queue) == 0 {
+				return nil, time.Time{}
+			}
+			it := heap.Pop(&q.queue).(*item)
+			return &it.name, it.when
+		}
+	} else {
+		next = func() (*string, time.Time) {
+			it := q.queue.peek()
+			if it == nil {
+				return nil, time.Time{}
+			}
+			when := it.when
+			it.when = time.Now().Add(frequency)
+			heap.Fix(&q.queue, it.index)
+			return &it.name, when
+		}
+	}
+
+	for {
+		q.lock.Lock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		who, when := next()
+		q.lock.Unlock()
+
+		if who == nil {
+			if frequency == 0 {
+				return nil
+			}
+			q.sleep(time.Second)
+			continue
+		}
+
+		if dur := when.Sub(time.Now()); dur > 0 {
+			q.sleep(dur)
+		}
+		select {
+		case receivers <- *who:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+type priorityQueue []*item
+
+func (pq priorityQueue) Len() int { return len(pq) }
+func (pq priorityQueue) Less(i, j int) bool {
+	return pq[i].when.Before(pq[j].when)
+}
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *priorityQueue) Push(something interface{}) {
+	it := something.(*item)
+	it.index = len(*pq)
+	*pq = append(*pq, it)
+}
+
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	it.index = -1
+	old[n-1] = nil
+	*pq = old[0 : n-1]
+	return it
+}
+
+func (pq priorityQueue) peek() *item {
+	n := len(pq)
+	if n == 0 {
+		return nil
+	}
+	return pq[0]
+}
+
+type item struct {
+	name  string
+	when  time.Time
+	index int
+}

--- a/util/queue_test.go
+++ b/util/queue_test.go
@@ -1,0 +1,617 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"container/heap"
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestInit(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name  string
+		q     *Queue
+		names []string
+		when  time.Time
+
+		next []string
+	}{
+		{
+			name: "add",
+			q:    &Queue{},
+			names: []string{
+				"hi",
+			},
+			when: now,
+
+			next: []string{"hi"},
+		},
+		{
+			name: "remove",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{"drop", "keep"}, now)
+				return &q
+			}(),
+			names: []string{
+				"keep",
+				"add",
+			},
+			when: now.Add(-time.Minute),
+			next: []string{
+				"add",
+				"keep",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.q.Init(tc.names, tc.when)
+
+			var got []string
+			for range tc.next {
+				got = append(got, heap.Pop(&tc.q.queue).(*item).name)
+			}
+			if diff := cmp.Diff(tc.next, got, protocmp.Transform()); diff != "" {
+				t.Errorf("FixAll() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFixAll(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name  string
+		q     *Queue
+		fixes map[string]time.Time
+		later bool
+
+		next []string
+		err  bool
+	}{
+		{
+			name: "empty",
+			q:    &Queue{},
+		},
+		{
+			name: "later",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{
+					"first-now-second",
+					"second-now-fifth",
+					"third",
+					"fourth-now-first",
+					"fifth-now-fourth",
+				}, now)
+				return &q
+			}(),
+			fixes: map[string]time.Time{
+				"fourth-now-first": now.Add(-2 * time.Minute),
+				"first-now-second": now.Add(-time.Minute),
+				"second-now-fifth": now.Add(2 * time.Minute),
+				"fifth-now-fourth": now.Add(time.Minute),
+			},
+			later: true,
+
+			next: []string{
+				"fourth-now-first",
+				"first-now-second",
+				"third",
+				"fifth-now-fourth",
+				"second-now-fifth",
+			},
+		},
+		{
+			name: "reduce",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{
+					"first-now-second",
+					"second-ignored-becomes-fifth",
+					"third-becomes-fourth",
+					"fourth-now-first",
+					"fifth-ignored-becomes-fourth",
+				}, now)
+				return &q
+			}(),
+			fixes: map[string]time.Time{
+				"fourth-now-first":             now.Add(-2 * time.Minute),
+				"first-now-second":             now.Add(-time.Minute),
+				"second-ignored-becomes-fifth": now.Add(2 * time.Minute), // noop
+				"fifth-ignored-becomes-fourth": now.Add(time.Minute),     // noop
+			},
+			later: true,
+
+			next: []string{
+				"fourth-now-first",
+				"first-now-second",
+				"third-becomes-fourth",
+				"fifth-ignored-becomes-fourth",
+				"second-ignored-becomes-fifth",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.q.FixAll(tc.fixes, tc.later); (err != nil) != tc.err {
+				t.Errorf("FixAll() got unexpected error %v, wanted err=%t", err, tc.err)
+			}
+			var got []string
+			for range tc.next {
+				got = append(got, heap.Pop(&tc.q.queue).(*item).name)
+			}
+			if diff := cmp.Diff(tc.next, got, protocmp.Transform()); diff != "" {
+				t.Errorf("FixAll() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFix(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+
+		q     *Queue
+		fix   string
+		when  time.Time
+		later bool
+
+		next []string
+		err  bool
+	}{
+		{
+			name: "missing",
+			fix:  "missing",
+			q:    &Queue{},
+			err:  true,
+		},
+		{
+			name: "later",
+			fix:  "basic",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{
+					"basic",
+					"was-later-now-first",
+				}, now)
+				return &q
+			}(),
+			when:  now.Add(time.Minute),
+			later: true,
+			next: []string{
+				"was-later-now-first",
+				"basic",
+			},
+		},
+		{
+			name: "ignore later",
+			fix:  "basic",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{
+					"basic",
+					"was-later-still-later",
+				}, now)
+				return &q
+			}(),
+			when: now.Add(time.Minute),
+			next: []string{
+				"basic",
+				"was-later-still-later",
+			},
+		},
+		{
+			name: "reduce",
+			fix:  "basic",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{
+					"was-earlier-now-later",
+					"basic",
+				}, now)
+				return &q
+			}(),
+			when: now.Add(-time.Minute),
+			next: []string{
+				"basic",
+				"was-earlier-now-later",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.q.Fix(tc.fix, tc.when, tc.later); (err != nil) != tc.err {
+				t.Errorf("Fix() got unexpected error %v, wanted err=%t", err, tc.err)
+			}
+			var got []string
+			for range tc.next {
+				got = append(got, heap.Pop(&tc.q.queue).(*item).name)
+			}
+			if diff := cmp.Diff(tc.next, got, protocmp.Transform()); diff != "" {
+				t.Errorf("Fix() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	pstr := func(s string) *string { return &s }
+	now := time.Now()
+	cases := []struct {
+		name string
+		q    *Queue
+
+		depth int
+		next  *string
+		when  time.Time
+	}{
+		{
+			name: "empty",
+			q:    &Queue{},
+		},
+		{
+			name: "single",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{"hi"}, now)
+				return &q
+			}(),
+			depth: 1,
+			next:  pstr("hi"),
+			when:  now,
+		},
+		{
+			name: "multi",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{
+					"hi",
+					"middle",
+					"there",
+				}, now)
+				q.Fix("middle", now.Add(-time.Minute), true)
+				return &q
+			}(),
+			depth: 3,
+			next:  pstr("middle"),
+			when:  now.Add(-time.Minute),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			depth, next, when := tc.q.Status()
+			if want, got := tc.depth, depth; want != got {
+				t.Errorf("Status() wanted depth %d, got %d", want, got)
+			}
+			if diff := cmp.Diff(tc.next, next, protocmp.Transform()); diff != "" {
+				t.Errorf("Status() got unexpected next diff (-want +got):\n%s", diff)
+			}
+			if !when.Equal(tc.when) {
+				t.Errorf("Status() wanted when %v, got %v", tc.when, when)
+			}
+		})
+	}
+}
+
+func TestSend(t *testing.T) {
+	cases := []struct {
+		name      string
+		q         *Queue
+		receivers func(context.Context, *testing.T) (context.Context, chan<- string, func() []string)
+		freq      time.Duration
+
+		want []string
+	}{
+		{
+			name: "empty",
+			q:    &Queue{},
+			receivers: func(ctx context.Context, t *testing.T) (context.Context, chan<- string, func() []string) {
+				ch := make(chan string)
+				go func() {
+					for {
+						select {
+						case name := <-ch:
+							t.Errorf("Send() receiver got unexpected group: %v", name)
+							return
+						case <-ctx.Done():
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []string { return nil }
+			},
+		},
+		{
+			name: "empty loop",
+			q:    &Queue{},
+			receivers: func(ctx context.Context, t *testing.T) (context.Context, chan<- string, func() []string) {
+				ch := make(chan string)
+				ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+				go func() {
+					for {
+						select {
+						case name := <-ch:
+							t.Errorf("Send() receiver got unexpected name: %q", name)
+							return
+						case <-ctx.Done():
+							cancel()
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []string { return nil }
+			},
+			freq: time.Microsecond,
+		},
+		{
+			name: "single",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{"hi"}, time.Now())
+				return &q
+			}(),
+			receivers: func(ctx context.Context, t *testing.T) (context.Context, chan<- string, func() []string) {
+				ch := make(chan string)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				var got []string
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case name := <-ch:
+							got = append(got, name)
+							return
+						case <-ctx.Done():
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []string {
+					wg.Wait()
+					return got
+				}
+			},
+			want: []string{"hi"},
+		},
+		{
+			name: "single loop",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{"hi"}, time.Now())
+				return &q
+			}(),
+			receivers: func(ctx context.Context, _ *testing.T) (context.Context, chan<- string, func() []string) {
+				ch := make(chan string)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				var got []string
+				ctx, cancel := context.WithCancel(ctx)
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case name := <-ch:
+							got = append(got, name)
+							if len(got) == 3 {
+								cancel()
+							}
+						case <-ctx.Done():
+							cancel()
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []string {
+					wg.Wait()
+					return got
+				}
+			},
+			freq: time.Microsecond,
+			want: []string{
+				"hi",
+				"hi",
+				"hi",
+			},
+		},
+		{
+			name: "multi",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{
+					"hi",
+					"there",
+				}, time.Now())
+				return &q
+			}(),
+			receivers: func(ctx context.Context, _ *testing.T) (context.Context, chan<- string, func() []string) {
+				ch := make(chan string)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				var got []string
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case name := <-ch:
+							got = append(got, name)
+							if len(got) == 2 {
+								return
+							}
+						case <-ctx.Done():
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []string {
+					wg.Wait()
+					return got
+				}
+			},
+			want: []string{
+				"hi",
+				"there",
+			},
+		},
+		{
+			name: "multi loop",
+			q: func() *Queue {
+				var q Queue
+				q.Init([]string{"hi", "there"}, time.Now())
+				return &q
+			}(),
+			receivers: func(ctx context.Context, _ *testing.T) (context.Context, chan<- string, func() []string) {
+				ch := make(chan string)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				var got []string
+				ctx, cancel := context.WithCancel(ctx)
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case name := <-ch:
+							got = append(got, name)
+							if len(got) == 6 {
+								cancel()
+							}
+						case <-ctx.Done():
+							cancel()
+							return
+						}
+					}
+				}()
+
+				return ctx, ch, func() []string {
+					wg.Wait()
+					return got
+				}
+			},
+			freq: time.Microsecond,
+			want: []string{
+				"hi",
+				"there",
+				"hi",
+				"there",
+				"hi",
+				"there",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ctx, channel, get := tc.receivers(ctx, t)
+			if err := tc.q.Send(ctx, channel, tc.freq); err != ctx.Err() {
+				t.Errorf("Send() returned unexpected error: want %v, got %v", ctx.Err(), err)
+			}
+			got := get()
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("Send() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPriorityQueue(t *testing.T) {
+	cases := []struct {
+		name  string
+		items []*item
+		want  []string
+	}{
+		{
+			name: "basic",
+		},
+		{
+			name: "single",
+			items: []*item{
+				{
+					name: "hi",
+				},
+			},
+			want: []string{"hi"},
+		},
+		{
+			name: "desc",
+			items: []*item{
+				{
+					name: "young",
+					when: time.Now(),
+				},
+				{
+					name: "old",
+					when: time.Now().Add(-time.Hour),
+				},
+			},
+			want: []string{"old", "young"},
+		},
+		{
+			name: "asc",
+			items: []*item{
+				{
+					name: "old",
+					when: time.Now().Add(-time.Hour),
+				},
+				{
+					name: "young",
+					when: time.Now(),
+				},
+			},
+			want: []string{"old", "young"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pq := priorityQueue(tc.items)
+			heap.Init(&pq)
+			var got []string
+			for i, w := range tc.want {
+				g := pq.peek().name
+				if diff := cmp.Diff(w, g, protocmp.Transform()); diff != "" {
+					t.Errorf("%d peek() got unexpected diff (-want +got):\n%s", i, diff)
+				}
+				got = append(got, heap.Pop(&pq).(*item).name)
+			}
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("priorityQueue() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The core logic of updating something at a specific time is more general than test groups. 

For example, the summarizer will want to use this on a per-dashboard basis (not test group). This moves most of the logic into util/queue.go, with specific TestGroup functionality in config/queue.go.