### PR TITLE
Store hostname as URL

### DIFF
--- a/pkg/api/v1/config.go
+++ b/pkg/api/v1/config.go
@@ -89,7 +89,7 @@ func (s Server) ListDashboardGroups(w http.ResponseWriter, r *http.Request) {
 	for _, group := range cfg.DashboardGroups {
 		rsc := apipb.Resource{
 			Name: group.Name,
-			Link: fmt.Sprintf("%s/dashboard-groups/%s%s", s.Host, config.Normalize(group.Name), passQueryParameters(r)),
+			Link: fmt.Sprintf("%s/dashboard-groups/%s%s", s.Host.String(), config.Normalize(group.Name), passQueryParameters(r)),
 		}
 		groups.DashboardGroups = append(groups.DashboardGroups, &rsc)
 	}
@@ -113,7 +113,7 @@ func (s Server) GetDashboardGroup(w http.ResponseWriter, r *http.Request) {
 			for _, dash := range group.DashboardNames {
 				rsc := apipb.Resource{
 					Name: dash,
-					Link: fmt.Sprintf("%s/dashboards/%s%s", s.Host, config.Normalize(dash), passQueryParameters(r)),
+					Link: fmt.Sprintf("%s/dashboards/%s%s", s.Host.String(), config.Normalize(dash), passQueryParameters(r)),
 				}
 				result.Dashboards = append(result.Dashboards, &rsc)
 			}
@@ -136,7 +136,7 @@ func (s Server) ListDashboards(w http.ResponseWriter, r *http.Request) {
 	for _, dashboard := range cfg.Dashboards {
 		rsc := apipb.Resource{
 			Name: dashboard.Name,
-			Link: fmt.Sprintf("%s/dashboards/%s%s", s.Host, config.Normalize(dashboard.Name), passQueryParameters(r)),
+			Link: fmt.Sprintf("%s/dashboards/%s%s", s.Host.String(), config.Normalize(dashboard.Name), passQueryParameters(r)),
 		}
 		dashboardResponse.Dashboards = append(dashboardResponse.Dashboards, &rsc)
 	}
@@ -185,7 +185,7 @@ func (s Server) ListDashboardTabs(w http.ResponseWriter, r *http.Request) {
 			for _, tab := range dashboard.DashboardTab {
 				rsc := apipb.Resource{
 					Name: tab.Name,
-					Link: fmt.Sprintf("%s/dashboards/%s/tabs/%s%s", s.Host, config.Normalize(dashboard.Name), config.Normalize(tab.Name), passQueryParameters(r)),
+					Link: fmt.Sprintf("%s/dashboards/%s/tabs/%s%s", s.Host.String(), config.Normalize(dashboard.Name), config.Normalize(tab.Name), passQueryParameters(r)),
 				}
 				dashboardTabsResponse.DashboardTabs = append(dashboardTabsResponse.DashboardTabs, &rsc)
 			}

--- a/pkg/api/v1/config_test.go
+++ b/pkg/api/v1/config_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -683,9 +684,14 @@ func setupTestServer(t *testing.T, configurations map[string]*pb.Configuration, 
 		}
 	}
 
+	host, err := url.Parse("host")
+	if err != nil {
+		t.Fatalf("Could not form host: %v", err)
+	}
+
 	return Server{
 		Client:         fc,
-		Host:           "host",
+		Host:           host,
 		DefaultBucket:  "gs://default",
 		GridPathPrefix: "grid",
 		Timeout:        10 * time.Minute,

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"net/url"
 	"time"
 
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
@@ -26,7 +27,7 @@ import (
 // Server contains the necessary settings and i/o objects needed to serve this api
 type Server struct {
 	Client         gcs.Client
-	Host           string
+	Host           *url.URL
 	DefaultBucket  string
 	GridPathPrefix string
 	Timeout        time.Duration


### PR DESCRIPTION
Using path.Join on a URL results in its protocol getting mangled, ex: https://stackoverflow.com/questions/34668012/combine-url-paths-with-path-join/34668130

Instead, store the hostname as a *URL and convert to string at the last moment to allow correct URL manipulation