### PR TITLE
Log when we successfully summarize a dashboard.

### DIFF
--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -329,6 +329,7 @@ func Update(ctx context.Context, client gcs.ConditionalClient, mets *Metrics, co
 					log.WithError(err).Error("Failed to summarize dashboard")
 				} else {
 					mets.Success()
+					log.Info("Summarized dashboard")
 				}
 			}
 		}()


### PR DESCRIPTION
Right now all the logs are debug level, and default logging only notes when a dashboard errors, not when it succeeds.