### PR TITLE
Standardize cycle metrics across controllers

### DIFF
--- a/cmd/config_merger/BUILD.bazel
+++ b/cmd/config_merger/BUILD.bazel
@@ -20,9 +20,9 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/testgrid/cmd/config_merger",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
         "//pkg/merger:go_default_library",
         "//util/gcs:go_default_library",
+        "//util/metrics:go_default_library",
         "//util/metrics/prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/cmd/summarizer/BUILD.bazel
+++ b/cmd/summarizer/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/summarizer:go_default_library",
         "//util:go_default_library",
         "//util/gcs:go_default_library",
+        "//util/metrics:go_default_library",
         "//util/metrics/prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_pubsub//:go_default_library",

--- a/cmd/updater/BUILD.bazel
+++ b/cmd/updater/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/updater:go_default_library",
         "//util:go_default_library",
         "//util/gcs:go_default_library",
+        "//util/metrics:go_default_library",
         "//util/metrics/prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_pubsub//:go_default_library",

--- a/pkg/merger/BUILD.bazel
+++ b/pkg/merger/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
         "//config:go_default_library",
         "//pb/config:go_default_library",
         "//util/gcs:go_default_library",
+        "//util/metrics:go_default_library",
+        "//util/metrics/prometheus:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",

--- a/pkg/merger/merger_test.go
+++ b/pkg/merger/merger_test.go
@@ -388,7 +388,7 @@ func Test_MergeAndUpdate(t *testing.T) {
 				})
 			}
 
-			_, resultErr := MergeAndUpdate(context.Background(), &client, mergeList, tc.skipValidate, tc.confirm)
+			_, resultErr := MergeAndUpdate(context.Background(), &client, nil, mergeList, tc.skipValidate, tc.confirm)
 
 			if tc.expectUpload && !client.uploaded {
 				t.Errorf("Expected upload, but there was none")

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -417,17 +417,10 @@ func TestUpdate(t *testing.T) {
 			if tc.groupUpdater == nil {
 				tc.groupUpdater = GCS(client, *tc.groupTimeout, *tc.buildTimeout, tc.buildConcurrency, !tc.skipConfirm, SortStarted)
 			}
-			mets := &Metrics{
-				Successes:    &fakeCounter{},
-				Errors:       &fakeCounter{},
-				Skips:        &fakeCounter{},
-				DelaySeconds: &fakeInt64{},
-				CycleSeconds: &fakeInt64{},
-			}
 			err := Update(
 				ctx,
 				client,
-				mets,
+				nil, // metric
 				configPath,
 				tc.gridPrefix,
 				tc.groupConcurrency,
@@ -449,39 +442,8 @@ func TestUpdate(t *testing.T) {
 					t.Errorf("Update() uploaded files got unexpected diff (-want, +got):\n%s", diff)
 				}
 			}
-
-			// Check that metrics also report.
-			if want, got := int64(tc.successes), mets.Successes.(*fakeCounter).total; want != got {
-				t.Errorf("Update() has wrong number of successful updates; want %d, got %d", want, got)
-			}
-			if want, got := int64(tc.errors), mets.Errors.(*fakeCounter).total; want != got {
-				t.Errorf("Update() has wrong number of failed updates; want %d, got %d", want, got)
-			}
-			if want, got := int64(tc.skips), mets.Skips.(*fakeCounter).total; want != got {
-				t.Errorf("Update() has wrong number of skipped updates; want %d, got %d", want, got)
-			}
 		})
 	}
-}
-
-type fakeInt64 struct {
-	values []int64
-}
-
-func (fi *fakeInt64) Name() string { return "fake-int64" }
-
-func (fi *fakeInt64) Set(n int64, _ ...string) {
-	fi.values = append(fi.values, n)
-}
-
-type fakeCounter struct {
-	total int64
-}
-
-func (fc *fakeCounter) Name() string { return "fake-counter" }
-
-func (fc *fakeCounter) Add(n int64, _ ...string) {
-	fc.total += n
 }
 
 func TestTestGroupPath(t *testing.T) {

--- a/util/metrics/BUILD.bazel
+++ b/util/metrics/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -23,4 +23,10 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["metrics_test.go"],
+    embed = [":go_default_library"],
 )

--- a/util/metrics/metrics_test.go
+++ b/util/metrics/metrics_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCyclic(t *testing.T) {
+	testcases := []struct {
+		name          string
+		method        func(Cyclic)
+		expectSeconds int64
+		expectFails   int64
+		expectSuccess int64
+		expectSkips   int64
+	}{
+		{
+			name: "success",
+			method: func(c Cyclic) {
+				fin := c.Start()
+				time.Sleep(1 * time.Second)
+				fin.Success()
+			},
+			expectSeconds: 1,
+			expectSuccess: 1,
+		},
+		{
+			name: "error",
+			method: func(c Cyclic) {
+				fin := c.Start()
+				time.Sleep(2 * time.Second)
+				fin.Fail()
+			},
+			expectSeconds: 2,
+			expectFails:   1,
+		},
+		{
+			name: "skips",
+			method: func(c Cyclic) {
+				fin := c.Start()
+				fin.Skip()
+			},
+			expectSkips: 1,
+		},
+		{
+			name: "counting",
+			method: func(c Cyclic) {
+				for i := 0; i < 5; i++ {
+					ok := c.Start()
+					ok.Success()
+					no := c.Start()
+					no.Fail()
+				}
+			},
+			expectSuccess: 5,
+			expectFails:   5,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			var errorCounter, skipCounter, successCounter FakeCounter
+			cycleInt64 := FakeInt64{read: true}
+
+			cyclic := Cyclic{
+				errors:       &errorCounter,
+				skips:        &skipCounter,
+				successes:    &successCounter,
+				cycleSeconds: &cycleInt64,
+			}
+
+			test.method(cyclic)
+
+			if test.expectFails != errorCounter.count {
+				t.Errorf("Want %d errors, got %d", test.expectFails, errorCounter.count)
+			}
+			if test.expectSkips != skipCounter.count {
+				t.Errorf("Want %d skips, got %d", test.expectSkips, skipCounter.count)
+			}
+			if test.expectSuccess != successCounter.count {
+				t.Errorf("Want %d successes, got %d", test.expectSuccess, successCounter.count)
+			}
+			if test.expectSeconds != cycleInt64.last {
+				t.Errorf("Expected %d seconds, got %d", test.expectSeconds, cycleInt64.last)
+			}
+		})
+	}
+
+}
+
+func TestCyclic_TolerateNilCounters(t *testing.T) {
+	for a, errorCounter := range []Counter{nil, &FakeCounter{}} {
+		for b, skipCounter := range []Counter{nil, &FakeCounter{}} {
+			for c, successCounter := range []Counter{nil, &FakeCounter{}} {
+				for d, cycleInt64 := range []Int64{nil, &FakeInt64{}} {
+					t.Run(fmt.Sprintf("Error-%d Skip-%d Success-%d Cycle-%d", a, b, c, d), func(t *testing.T) {
+						cyclic := Cyclic{
+							errors:       errorCounter,
+							skips:        skipCounter,
+							successes:    successCounter,
+							cycleSeconds: cycleInt64,
+						}
+						var wg sync.WaitGroup
+						wg.Add(3)
+						go func() {
+							f := cyclic.Start()
+							f.Success()
+							wg.Done()
+						}()
+						go func() {
+							f := cyclic.Start()
+							f.Skip()
+							wg.Done()
+						}()
+						go func() {
+							f := cyclic.Start()
+							f.Fail()
+							wg.Done()
+						}()
+						wg.Wait()
+					})
+				}
+			}
+		}
+	}
+}
+
+type FakeCounter struct {
+	count int64
+}
+
+func (f *FakeCounter) Name() string {
+	return "FakeCounter"
+}
+
+func (f *FakeCounter) Add(n int64, _ ...string) {
+	f.count += n
+}
+
+type FakeInt64 struct {
+	read bool // Fake implementation not concurrent-safe
+	last int64
+}
+
+func (f *FakeInt64) Name() string {
+	return "FakeCounter"
+}
+
+func (f *FakeInt64) Set(n int64, _ ...string) {
+	if f.read {
+		f.last = n
+	}
+}


### PR DESCRIPTION
Adds duration controller to summarizer
Adds success/failure metrics to config_merger
Moves cycle timer to util/
Creates factory to standardize metric creation in main.go

/lint