### PR TITLE
Testgrid autobump PR not assigned to oncall

### DIFF
--- a/cluster/testgrid-canary-autobump-config.yaml
+++ b/cluster/testgrid-canary-autobump-config.yaml
@@ -3,6 +3,7 @@ gitHubLogin: "google-oss-robot"
 gitHubToken: "/etc/github-token/oauth"
 onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
 skipPullRequest: false
+skipOncallAssignment: true
 gitHubOrg: "GoogleCloudPlatform"
 gitHubRepo: "testgrid"
 remoteName: "testgrid"

--- a/cluster/testgrid-prod-autobump-config.yaml
+++ b/cluster/testgrid-prod-autobump-config.yaml
@@ -3,6 +3,7 @@ gitHubLogin: "google-oss-robot"
 gitHubToken: "/etc/github-token/oauth"
 onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
 skipPullRequest: false
+skipOncallAssignment: true
 gitHubOrg: "GoogleCloudPlatform"
 gitHubRepo: "testgrid"
 remoteName: "testgrid"


### PR DESCRIPTION
Testgrid bumping PRs are not monitored/approved by oncall members, there is no need assigning to them, let blunderbuss do the job if configured