### PR TITLE
Create Duration metric

### DIFF
--- a/cmd/config_merger/BUILD.bazel
+++ b/cmd/config_merger/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
     deps = [
         "//pkg/merger:go_default_library",
         "//util/gcs:go_default_library",
-        "//util/metrics:go_default_library",
         "//util/metrics/prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/cmd/config_merger/main.go
+++ b/cmd/config_merger/main.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/testgrid/pkg/merger"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
-	"github.com/GoogleCloudPlatform/testgrid/util/metrics"
 	"github.com/GoogleCloudPlatform/testgrid/util/metrics/prometheus"
 
 	"github.com/sirupsen/logrus"
@@ -109,10 +108,7 @@ func main() {
 
 	client := gcs.NewClient(storageClient)
 
-	mets := merger.CreateMetrics(metrics.Factory{
-		NewInt64:   prometheus.NewInt64,
-		NewCounter: prometheus.NewCounter,
-	})
+	mets := merger.CreateMetrics(prometheus.NewFactory())
 
 	updateOnce := func(ctx context.Context) {
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)

--- a/cmd/summarizer/BUILD.bazel
+++ b/cmd/summarizer/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/summarizer:go_default_library",
         "//util:go_default_library",
         "//util/gcs:go_default_library",
-        "//util/metrics:go_default_library",
         "//util/metrics/prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_pubsub//:go_default_library",

--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/GoogleCloudPlatform/testgrid/pkg/summarizer"
 	"github.com/GoogleCloudPlatform/testgrid/util"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
-	"github.com/GoogleCloudPlatform/testgrid/util/metrics"
 	"github.com/GoogleCloudPlatform/testgrid/util/metrics/prometheus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
@@ -128,10 +127,7 @@ func main() {
 	}
 
 	client := gcs.NewClient(storageClient)
-	metrics := summarizer.CreateMetrics(metrics.Factory{
-		NewInt64:   prometheus.NewInt64,
-		NewCounter: prometheus.NewCounter,
-	})
+	metrics := summarizer.CreateMetrics(prometheus.NewFactory())
 	fixer, err := gcsFixer(ctx, opt.pubsub, opt.config, opt.gridPathPrefix, opt.creds)
 	if err != nil {
 		logrus.WithError(err).WithField("subscription", opt.pubsub).Fatal("Failed to configure pubsub")

--- a/cmd/updater/BUILD.bazel
+++ b/cmd/updater/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//pkg/updater:go_default_library",
         "//util:go_default_library",
         "//util/gcs:go_default_library",
-        "//util/metrics:go_default_library",
         "//util/metrics/prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_pubsub//:go_default_library",

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/GoogleCloudPlatform/testgrid/pkg/updater"
 	"github.com/GoogleCloudPlatform/testgrid/util"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
-	"github.com/GoogleCloudPlatform/testgrid/util/metrics"
 	"github.com/GoogleCloudPlatform/testgrid/util/metrics/prometheus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
@@ -161,10 +160,7 @@ func main() {
 
 	groupUpdater := updater.GCS(client, opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm, updater.SortStarted)
 
-	mets := updater.CreateMetrics(metrics.Factory{
-		NewInt64:   prometheus.NewInt64,
-		NewCounter: prometheus.NewCounter,
-	})
+	mets := updater.CreateMetrics(prometheus.NewFactory())
 
 	pubsubClient, err := gpubsub.NewClient(ctx, "", option.WithCredentialsFile(opt.creds))
 	if err != nil {

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -50,14 +50,14 @@ const componentName = "updater"
 // Metrics holds metrics relevant to the Updater.
 type Metrics struct {
 	UpdateState  metrics.Cyclic
-	DelaySeconds metrics.Int64
+	DelaySeconds metrics.Duration
 }
 
 // CreateMetrics creates metrics for this controller
 func CreateMetrics(factory metrics.Factory) *Metrics {
 	return &Metrics{
 		UpdateState:  factory.NewCyclic(componentName),
-		DelaySeconds: factory.NewInt64("delay", "Seconds updater is behind schedule", "component"),
+		DelaySeconds: factory.NewDuration("delay", "Seconds updater is behind schedule", "component"),
 	}
 }
 
@@ -65,9 +65,7 @@ func (mets *Metrics) delay(dur time.Duration) {
 	if mets == nil {
 		return
 	}
-
-	seconds := int64(dur.Seconds())
-	mets.DelaySeconds.Set(seconds, componentName)
+	mets.DelaySeconds.Clock(dur, componentName)
 }
 
 func (mets *Metrics) start() *metrics.CycleReporter {

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -65,7 +65,7 @@ func (mets *Metrics) delay(dur time.Duration) {
 	if mets == nil {
 		return
 	}
-	mets.DelaySeconds.Clock(dur, componentName)
+	mets.DelaySeconds.Set(dur, componentName)
 }
 
 func (mets *Metrics) start() *metrics.CycleReporter {

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -39,7 +39,7 @@ type Counter interface {
 // Duration is a metric describing a length of time
 type Duration interface {
 	Metric
-	Clock(time.Duration, ...string)
+	Set(time.Duration, ...string)
 }
 
 // Factory is a collection of functions that create metrics
@@ -88,7 +88,7 @@ func (pr *CycleReporter) done() {
 	if pr == nil || pr.metric.cycleSeconds == nil {
 		return
 	}
-	pr.metric.cycleSeconds.Clock(time.Since(pr.when), pr.metric.fields...)
+	pr.metric.cycleSeconds.Set(time.Since(pr.when), pr.metric.fields...)
 }
 
 // Success reports success

--- a/util/metrics/metrics_test.go
+++ b/util/metrics/metrics_test.go
@@ -184,7 +184,7 @@ func (f *FakeDuration) Name() string {
 	return "FakeDuration"
 }
 
-func (f *FakeDuration) Clock(n time.Duration, _ ...string) {
+func (f *FakeDuration) Set(n time.Duration, _ ...string) {
 	if f.read {
 		f.last = n
 	}

--- a/util/metrics/prometheus/prometheus_test.go
+++ b/util/metrics/prometheus/prometheus_test.go
@@ -287,7 +287,7 @@ func TestDurationSet(t *testing.T) {
 				for n, fields := range set {
 					wg.Add(1)
 					go func(n time.Duration, fields []string) {
-						m.Clock(n, fields...)
+						m.Set(n, fields...)
 						m.(Valuer).Values() // Set and Values must be able to run concurrently
 						wg.Done()
 					}(n, fields)

--- a/util/metrics/prometheus/prometheus_test.go
+++ b/util/metrics/prometheus/prometheus_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -208,6 +209,94 @@ func TestCounterAdd(t *testing.T) {
 			got := m.(Valuer).Values()
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Add() got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDurationSet(t *testing.T) {
+	cases := []struct {
+		name   string
+		fields []string
+		sets   []map[time.Duration][]string
+		want   map[string]float64
+	}{
+		{
+			name: "zero",
+			want: map[string]float64{},
+		},
+		{
+			name:   "basic",
+			fields: []string{"component"},
+			sets: []map[time.Duration][]string{
+				{(1100 * time.Millisecond): {"updater"}},
+			},
+			want: map[string]float64{
+				"updater": float64(1.1),
+			},
+		},
+		{
+			name:   "fields",
+			fields: []string{"component", "source"},
+			sets: []map[time.Duration][]string{
+				{time.Second: {"updater", "prow"}},
+			},
+			want: map[string]float64{
+				"updater|prow": float64(1),
+			},
+		},
+		{
+			name:   "serial values",
+			fields: []string{"component"},
+			sets: []map[time.Duration][]string{
+				{time.Second: {"updater"}},
+				{time.Minute: {"updater"}},
+			},
+			want: map[string]float64{
+				"updater": float64(60),
+			},
+		},
+		{
+			name:   "complex",
+			fields: []string{"component", "source"},
+			sets: []map[time.Duration][]string{
+				{
+					time.Second:      {"updater", "prow"},
+					time.Minute:      {"updater", "google"},
+					time.Millisecond: {"summarizer", "google"},
+				},
+				{
+					time.Second:       {"updater", "prow"},
+					(2 * time.Second): {"summarizer", "google"},
+				},
+			},
+			want: map[string]float64{
+				"updater|prow":      float64(1),
+				"updater|google":    float64(60),
+				"summarizer|google": float64(2),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mName := strings.Replace(tc.name, " ", "_", -1) + "_duration"
+			m := NewDuration(mName, "fake desc", tc.fields...)
+			var wg sync.WaitGroup
+			for _, set := range tc.sets {
+				for n, fields := range set {
+					wg.Add(1)
+					go func(n time.Duration, fields []string) {
+						m.Clock(n, fields...)
+						m.(Valuer).Values() // Set and Values must be able to run concurrently
+						wg.Done()
+					}(n, fields)
+				}
+				wg.Wait()
+			}
+			got := m.(Valuer).Values()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Set() got unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
A common TestGrid metric is a duration, which is currently being stored as an Int64 number of seconds. This rendered anything that happens in less than one second (ex: most Config Mergers) invisible.

This change adds a metric type that measures elapsed time with the standard "duration" type.