### PR TITLE
Add cache backing ReadGCS

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "cache.go",
         "config.go",
         "converge.go",
         "fields.go",
@@ -44,6 +45,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cache_test.go",
         "config_test.go",
         "converge_test.go",
         "fields_test.go",
@@ -52,10 +54,13 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pb/config:go_default_library",
+        "//util/gcs:go_default_library",
+        "//util/gcs/fake:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
         "@org_golang_google_protobuf//testing/protocmp:go_default_library",
     ],
 )

--- a/config/cache.go
+++ b/config/cache.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/storage"
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+)
+
+var (
+	cache     map[string]Config
+	cacheLock sync.RWMutex
+)
+
+const cacheRefreshInterval = 5 * time.Minute
+
+type Config struct {
+	proto     *configpb.Configuration
+	lastFetch time.Time
+}
+
+func init() {
+	cache = map[string]Config{}
+}
+
+// InitCache clears the cache of configs, forcing the next ReadGCS call to fetch fresh from GCS.
+//
+// Used primarily for testing
+func InitCache() {
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	cache = map[string]Config{}
+}
+
+// ReadGCS opens the config at path and unmarshals it into a Configuration proto.
+//
+// If it has been read recently, a cached version will be served.
+func ReadGCS(ctx context.Context, opener gcs.Opener, path gcs.Path) (*configpb.Configuration, error) {
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	cfg, ok := cache[path.String()]
+	if ok && time.Since(cfg.lastFetch) < cacheRefreshInterval {
+		return cfg.proto, nil
+	}
+
+	r, _, err := opener.Open(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open config: %w", err)
+	}
+	p, err := Unmarshal(r)
+	defer r.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+	cache[path.String()] = Config{
+		proto:     p,
+		lastFetch: time.Now(),
+	}
+	return p, nil
+}
+
+// ReadPath reads the config from the specified local file path.
+func ReadPath(path string) (*configpb.Configuration, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open: %v", err)
+	}
+	return Unmarshal(f)
+}
+
+// Read will read the Configuration proto message from a local or gs:// path.
+//
+// The ctx and client are only relevant when path refers to GCS.
+func Read(ctx context.Context, path string, client *storage.Client) (*configpb.Configuration, error) {
+	if strings.HasPrefix(path, "gs://") {
+		gcsPath, err := gcs.NewPath(path)
+		if err != nil {
+			return nil, fmt.Errorf("bad path: %v", err)
+		}
+		return ReadGCS(ctx, gcs.NewClient(client), *gcsPath)
+	}
+	return ReadPath(path)
+}

--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2021 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/golang/protobuf/proto"
+
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs/fake"
+)
+
+func Test_ReadGCS(t *testing.T) {
+	expectedConfig := &configpb.Configuration{
+		Dashboards: []*configpb.Dashboard{
+			{
+				Name: "Example",
+			},
+		},
+	}
+	expectedBytes, err := proto.Marshal(expectedConfig)
+	if err != nil {
+		t.Fatalf("Can't marshal expectations: %v", err)
+	}
+
+	now := time.Now()
+
+	cases := []struct {
+		name               string
+		currentCache       map[string]Config
+		remoteData         []byte
+		remoteLastModified time.Time
+		remoteGeneration   int64
+	}{
+		{
+			name:               "read on fresh cache",
+			currentCache:       map[string]Config{},
+			remoteData:         expectedBytes,
+			remoteLastModified: now,
+			remoteGeneration:   1,
+		},
+		{
+			name: "don't read if too recent",
+			currentCache: map[string]Config{
+				"gs://example": {
+					proto:     expectedConfig,
+					lastFetch: now,
+				},
+			},
+			remoteData:         []byte{1, 2, 3},
+			remoteLastModified: now,
+			remoteGeneration:   1,
+		},
+		{
+			name: "read on stale cache",
+			currentCache: map[string]Config{
+				"gs://example": {
+					proto: &configpb.Configuration{
+						Dashboards: []*configpb.Dashboard{
+							{
+								Name: "stale",
+							},
+						},
+					},
+					lastFetch: now.Add(-1 * time.Hour),
+				},
+			},
+			remoteData:         expectedBytes,
+			remoteLastModified: now,
+			remoteGeneration:   1,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			cache = test.currentCache
+			client := fake.Client{
+				Opener: fake.Opener{},
+			}
+
+			client.Opener[mustPath("gs://example")] = fake.Object{
+				Data: string(test.remoteData),
+				Attrs: &storage.ReaderObjectAttrs{
+					LastModified: test.remoteLastModified,
+					Generation:   test.remoteGeneration,
+				},
+			}
+			result, err := ReadGCS(context.Background(), &client, mustPath("gs://example"))
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
+			if !proto.Equal(expectedConfig, result) {
+				t.Errorf("Expected %v, got %v", expectedConfig, result)
+			}
+		})
+	}
+}
+
+func mustPath(s string) gcs.Path {
+	p, err := gcs.NewPath(s)
+	if err != nil {
+		panic(err)
+	}
+	return *p
+}

--- a/config/config.go
+++ b/config/config.go
@@ -17,21 +17,17 @@ limitations under the License.
 package config
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"regexp"
 	"strings"
 	"unicode/utf8"
 
-	"cloud.google.com/go/storage"
 	"github.com/golang/protobuf/proto"
 
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 	multierror "github.com/hashicorp/go-multierror"
 )
 
@@ -518,38 +514,6 @@ func MarshalBytes(c *configpb.Configuration) ([]byte, error) {
 		return nil, err
 	}
 	return proto.Marshal(c)
-}
-
-// ReadGCS opens the config at path and unmarshals it into a Configuration proto.
-func ReadGCS(ctx context.Context, opener gcs.Opener, path gcs.Path) (*configpb.Configuration, error) {
-	r, _, err := opener.Open(ctx, path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open config: %v", err)
-	}
-	return Unmarshal(r)
-}
-
-// ReadPath reads the config from the specified local file path.
-func ReadPath(path string) (*configpb.Configuration, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("open: %v", err)
-	}
-	return Unmarshal(f)
-}
-
-// Read will read the Configuration proto message from a local or gs:// path.
-//
-// The ctx and client are only relevant when path refers to GCS.
-func Read(ctx context.Context, path string, client *storage.Client) (*configpb.Configuration, error) {
-	if strings.HasPrefix(path, "gs://") {
-		gcsPath, err := gcs.NewPath(path)
-		if err != nil {
-			return nil, fmt.Errorf("bad path: %v", err)
-		}
-		return ReadGCS(ctx, gcs.NewClient(client), *gcsPath)
-	}
-	return ReadPath(path)
 }
 
 // FindTestGroup returns the configpb.TestGroup proto for a given TestGroup name.

--- a/pkg/api/v1/BUILD.bazel
+++ b/pkg/api/v1/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//config:go_default_library",
         "//pb/config:go_default_library",
         "//pb/state:go_default_library",
         "//util/gcs:go_default_library",

--- a/pkg/api/v1/config_test.go
+++ b/pkg/api/v1/config_test.go
@@ -31,6 +31,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/golang/protobuf/proto"
 
+	"github.com/GoogleCloudPlatform/testgrid/config"
 	pb "github.com/GoogleCloudPlatform/testgrid/pb/config"
 	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
@@ -660,6 +661,7 @@ func setupTestServer(t *testing.T, configurations map[string]*pb.Configuration, 
 	var fc fakeClient
 	fc.Datastore = map[gcs.Path][]byte{}
 
+	config.InitCache()
 	for p, cfg := range configurations {
 		path, err := gcs.NewPath(p)
 		if err != nil {
@@ -716,7 +718,7 @@ func (f fakeClient) Open(ctx context.Context, path gcs.Path) (io.ReadCloser, *st
 	if !exists {
 		return nil, nil, fmt.Errorf("fake file %s does not exist", path.String())
 	}
-	return ioutil.NopCloser(bytes.NewReader(data)), nil, nil
+	return ioutil.NopCloser(bytes.NewReader(data)), &storage.ReaderObjectAttrs{}, nil
 }
 
 func (f fakeClient) Upload(ctx context.Context, path gcs.Path, bytes []byte, b bool, s string) (*storage.ObjectAttrs, error) {

--- a/pkg/merger/merger_test.go
+++ b/pkg/merger/merger_test.go
@@ -424,7 +424,7 @@ func (fo fakeOpener) Open(_ context.Context, path gcs.Path) (io.ReadCloser, *sto
 	if o.err != nil {
 		return nil, nil, fmt.Errorf("injected open error: %w", o.err)
 	}
-	return ioutil.NopCloser(bytes.NewReader(o.buf)), nil, nil
+	return ioutil.NopCloser(bytes.NewReader(o.buf)), &storage.ReaderObjectAttrs{}, nil
 }
 
 type fakeObject struct {


### PR DESCRIPTION
Modifies the Read GCS function to keep a cache of recently-requested configs. Mostly serves to speed up the API.

Controllers and commands using these functions:
`ReadGCS`: Config Merger, API
`Read`: Config Print, State Comparer

The Summarizer and Updater have their own logic to periodically recheck the configuration (not just as-needed); all of these could be collapsed into a config file subscription.