### PR TITLE
Document update-protos requiring python2

### DIFF
--- a/build_test_update.md
+++ b/build_test_update.md
@@ -38,7 +38,7 @@ If you modify a .proto file, you'll also need to generate and check in the
 .pb.go files.
 
 Run `bazel run //hack:update-protos` to generate, and `bazel run //hack:verify-protos.sh`
-to verify.
+to verify. This command requires `python` to be installed.
 
 ## Testing
 


### PR DESCRIPTION
Not actually sure if it strictly requires Python 2 or what, but that's what fixed it for me.
There may be other requirements that aren't obvious to me (e.g., is the Go compiler
needed?).