### PR TITLE
Minor go vet changes

### DIFF
--- a/config/snapshot/config_snapshot_test.go
+++ b/config/snapshot/config_snapshot_test.go
@@ -115,7 +115,7 @@ func TestObserve(t *testing.T) {
 func TestTick(t *testing.T) {
 	tests := []struct {
 		name             string
-		cs               Config
+		cs               *Config
 		config           *configpb.Configuration
 		configGeneration int64
 		readErr          error
@@ -125,6 +125,7 @@ func TestTick(t *testing.T) {
 	}{
 		{
 			name: "Reads configs",
+			cs:   &Config{},
 			config: &configpb.Configuration{
 				Dashboards: []*configpb.Dashboard{
 					{
@@ -140,7 +141,7 @@ func TestTick(t *testing.T) {
 		},
 		{
 			name: "Updates configs",
-			cs: Config{
+			cs: &Config{
 				dashboards: map[string]*configpb.Dashboard{
 					"stale": {
 						Name: "stale",
@@ -165,7 +166,7 @@ func TestTick(t *testing.T) {
 		},
 		{
 			name: "Does not update same config",
-			cs: Config{
+			cs: &Config{
 				dashboards: map[string]*configpb.Dashboard{
 					"dashboard": {
 						Name: "dashboard",
@@ -189,7 +190,7 @@ func TestTick(t *testing.T) {
 		},
 		{
 			name: "Doesn't update on read error",
-			cs: Config{
+			cs: &Config{
 				dashboards: map[string]*configpb.Dashboard{
 					"dashboard": {
 						Name: "dashboard",

--- a/pkg/tabulator/tabstate.go
+++ b/pkg/tabulator/tabstate.go
@@ -52,6 +52,8 @@ func CreateMetrics(factory metrics.Factory) *Metrics {
 // Fixer should adjust the dashboard queue until the context expires.
 type Fixer func(context.Context, *config.DashboardQueue) error
 
+// Update tab state with the given frequency continuously. If freq == 0, runs only once.
+//
 // For each dashboard/tab in the config, copy the testgroup state into the tab state.
 func Update(ctx context.Context, client gcs.ConditionalClient, mets *Metrics, configPath gcs.Path, concurrency int, gridPathPrefix, tabsPathPrefix string, confirm bool, freq time.Duration, fix Fixer) error {
 	ctx, cancel := context.WithCancel(ctx)
@@ -197,7 +199,7 @@ func tabStatePath(g gcs.Path, tabPrefix, dashboardName, tabName string) (*gcs.Pa
 	if err != nil {
 		return nil, fmt.Errorf("resolve reference: %w", err)
 	}
-	if err == nil && np.Bucket() != g.Bucket() {
+	if np.Bucket() != g.Bucket() {
 		return nil, fmt.Errorf("tabState %s should not change bucket", name)
 	}
 	return np, nil

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -416,7 +416,7 @@ func TestGroupPath(g gcs.Path, gridPrefix, groupName string) (*gcs.Path, error) 
 	if err != nil {
 		return nil, fmt.Errorf("resolve reference: %w", err)
 	}
-	if err == nil && np.Bucket() != g.Bucket() {
+	if np.Bucket() != g.Bucket() {
 		return nil, fmt.Errorf("testGroup %s should not change bucket", name)
 	}
 	return np, nil


### PR DESCRIPTION
Test no longer copies RWMutex
Removes redundant nil check
/lint