### PR TITLE
Initialize summarizer queue

### DIFF
--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -173,6 +173,8 @@ func Update(ctx context.Context, client gcs.ConditionalClient, mets *Metrics, co
 		return fmt.Errorf("observe config: %w", err)
 	}
 
+	q.Init(log, cfg.AllDashboards(), time.Now().Add(freq))
+
 	if fix != nil {
 		go func() {
 			fix(ctx, &q)


### PR DESCRIPTION
Fix to a panic caused after #790 was merged due to the queue not being initialized the first time the loop runs.

Lesson learned: test with --wait flag; the bug doesn't manifest if you run a summary only once.