### PR TITLE
Support persisting test group queue across processes.

### DIFF
--- a/pkg/summarizer/pubsub.go
+++ b/pkg/summarizer/pubsub.go
@@ -32,9 +32,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Fixer should adjust the dashboard queue until the context expires.
-type Fixer func(context.Context, *config.DashboardQueue) error
-
 // FixGCS listens for GCS changes to test groups and schedules another update of its dashboards ~immediately.
 //
 // Returns when the context is canceled or a processing error occurs.

--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -111,6 +111,9 @@ func lockDashboard(ctx context.Context, client gcs.ConditionalClient, path gcs.P
 	return gcs.Touch(ctx, client, path, generation, buf)
 }
 
+// Fixer should adjust the dashboard queue until the context expires.
+type Fixer func(context.Context, *config.DashboardQueue) error
+
 // Update summary protos by reading the state protos defined in the config.
 //
 // Will use concurrency go routines to update dashboards in parallel.

--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "gcs.go",
         "inflate.go",
+        "persist.go",
         "pubsub.go",
         "read.go",
         "updater.go",
@@ -34,6 +35,7 @@ go_test(
     srcs = [
         "gcs_test.go",
         "inflate_test.go",
+        "persist_test.go",
         "pubsub_test.go",
         "read_test.go",
         "updater_test.go",

--- a/pkg/updater/persist.go
+++ b/pkg/updater/persist.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package updater reads the latest test results and saves updated state.
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/testgrid/config"
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"github.com/sirupsen/logrus"
+)
+
+// PersistClient contains interfaces for reading from and writing to a Path.
+type PersistClient interface {
+	gcs.Uploader
+	gcs.Opener
+}
+
+// FixPersistent persists the queue to the remote path every tick.
+//
+// The first time it will load the state. Thereafter it will save the state.
+// This includes restarts due to expiring contexts -- it will just load once.
+func FixPersistent(client PersistClient, path gcs.Path, tick <-chan time.Time) Fixer {
+	var shouldSave bool
+	return func(ctx context.Context, logr logrus.FieldLogger, q *config.TestGroupQueue, _ []*configpb.TestGroup) error {
+		log := logr.WithField("path", path)
+
+		log.Debug("Using persistent state")
+
+		tryLoad := func() error {
+			reader, attrs, err := client.Open(ctx, path)
+			if errors.Is(err, storage.ErrObjectNotExist) {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("open: %w", err)
+			}
+
+			defer reader.Close()
+			dec := json.NewDecoder(reader)
+			var whens map[string]time.Time
+			if err := dec.Decode(&whens); err != nil {
+				return fmt.Errorf("decode: %v", err)
+			}
+
+			current := q.Current()
+
+			for name := range whens {
+				if _, ok := current[name]; ok {
+					continue
+				}
+				delete(whens, name)
+			}
+
+			log.WithField("from", attrs.LastModified).Info("Fixing queue with persistent state.")
+			if err := q.FixAll(whens, false); err != nil {
+				return fmt.Errorf("fix all: %v", err)
+			}
+			return nil
+		}
+
+		trySave := func() error {
+			currently := q.Current()
+			buf, err := json.MarshalIndent(currently, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshal: %v", err)
+			}
+			_, err = client.Upload(ctx, path, buf, false, "")
+			return err
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-tick:
+			}
+
+			if shouldSave {
+				log.Trace("Saving persistent state...")
+				if err := trySave(); err != nil {
+					log.WithError(err).Error("Failed to save persistent state.")
+					continue
+				}
+				log.Debug("Saved persistent state.")
+			} else {
+				log.Trace("Loading persistent state...")
+				if err := tryLoad(); err != nil {
+					log.WithError(err).Error("Failed to load persistent state.")
+					continue
+				}
+				shouldSave = true
+				log.Debug("Loaded persistent state.")
+			}
+		}
+	}
+}

--- a/pkg/updater/persist_test.go
+++ b/pkg/updater/persist_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/testgrid/config"
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs/fake"
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+)
+
+func TestFixPersistent(t *testing.T) {
+	now := time.Now().Round(time.Second)
+	next := now.Add(time.Minute)
+	later := now.Add(time.Hour)
+	cases := []struct {
+		name        string
+		q           *config.TestGroupQueue
+		currently   fake.Object
+		ticks       []time.Time
+		fixes       map[string]time.Time
+		wantCurrent map[string]time.Time
+		wantBuf     string
+	}{
+		{
+			name:        "basic",
+			q:           &config.TestGroupQueue{},
+			wantCurrent: map[string]time.Time{},
+		},
+		{
+			name: "no load",
+			q: func() *config.TestGroupQueue {
+				var q config.TestGroupQueue
+				groups := []*configpb.TestGroup{
+					{
+						Name: "foo",
+					},
+					{
+						Name: "bar",
+					},
+				}
+				q.Init(logrus.New(), groups, next)
+				return &q
+			}(),
+			wantCurrent: map[string]time.Time{
+				"foo": next,
+				"bar": next,
+			},
+		},
+		{
+			name: "load empty",
+			q: func() *config.TestGroupQueue {
+				var q config.TestGroupQueue
+				groups := []*configpb.TestGroup{
+					{
+						Name: "foo",
+					},
+					{
+						Name: "bar",
+					},
+				}
+				q.Init(logrus.New(), groups, next)
+				return &q
+			}(),
+			ticks: []time.Time{now},
+			wantCurrent: map[string]time.Time{
+				"foo": next,
+				"bar": next,
+			},
+		},
+		{
+			name: "load",
+			q: func() *config.TestGroupQueue {
+				var q config.TestGroupQueue
+				groups := []*configpb.TestGroup{
+					{
+						Name: "keep-next",
+					},
+					{
+						Name: "bump-to-now",
+					},
+				}
+				q.Init(logrus.New(), groups, next)
+				return &q
+			}(),
+			ticks: []time.Time{now},
+			currently: fake.Object{
+				Data: func() string {
+					saved := map[string]time.Time{
+						"keep-next":   later,
+						"bump-to-now": now,
+						"ignore-old":  now,
+					}
+					buf, err := json.Marshal(saved)
+					if err != nil {
+						t.Fatalf("Failed to marshal: %v", err)
+					}
+					return string(buf)
+				}(),
+				Attrs: &storage.ReaderObjectAttrs{},
+			},
+			wantCurrent: map[string]time.Time{
+				"keep-next":   next,
+				"bump-to-now": now,
+			},
+		},
+		{
+			name: "load err",
+			q: func() *config.TestGroupQueue {
+				var q config.TestGroupQueue
+				groups := []*configpb.TestGroup{
+					{
+						Name: "keep-next",
+					},
+					{
+						Name: "would-bump-to-now-if-read",
+					},
+				}
+				q.Init(logrus.New(), groups, next)
+				return &q
+			}(),
+			ticks: []time.Time{now},
+			currently: fake.Object{
+				Data: func() string {
+					saved := map[string]time.Time{
+						"keep-next":                 later,
+						"would-bump-to-now-if-read": now,
+					}
+					buf, err := json.Marshal(saved)
+					if err != nil {
+						t.Fatalf("Failed to marshal: %v", err)
+					}
+					return string(buf)
+				}(),
+				Attrs:   &storage.ReaderObjectAttrs{},
+				OpenErr: errors.New("fake open error"),
+			},
+			wantCurrent: map[string]time.Time{
+				"keep-next":                 next,
+				"would-bump-to-now-if-read": next,
+			},
+		},
+		{
+			name: "load and save",
+			q: func() *config.TestGroupQueue {
+				var q config.TestGroupQueue
+				groups := []*configpb.TestGroup{
+					{
+						Name: "keep-next",
+					},
+					{
+						Name: "bump-to-now",
+					},
+				}
+				q.Init(logrus.New(), groups, next)
+				return &q
+			}(),
+			ticks: []time.Time{now, now, now},
+			currently: fake.Object{
+				Data: func() string {
+					saved := map[string]time.Time{
+						"keep-next":   later,
+						"bump-to-now": now,
+						"ignore-old":  now,
+					}
+					buf, err := json.Marshal(saved)
+					if err != nil {
+						t.Fatalf("Failed to marshal: %v", err)
+					}
+					return string(buf)
+				}(),
+				Attrs: &storage.ReaderObjectAttrs{},
+			},
+			wantCurrent: map[string]time.Time{
+				"keep-next":   next,
+				"bump-to-now": now,
+			},
+			wantBuf: func() string {
+				saved := map[string]time.Time{
+					"keep-next":   next,
+					"bump-to-now": now,
+				}
+				buf, err := json.MarshalIndent(saved, "", "  ")
+				if err != nil {
+					t.Fatalf("Failed to marshal: %v", err)
+				}
+				return string(buf)
+			}(),
+		},
+	}
+
+	path, err := gcs.NewPath("gs://fake-bucket/path/to/whatever")
+	if err != nil {
+		t.Fatalf("NewPath(): %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.UploadClient{
+				Uploader: fake.Uploader{},
+				Client: fake.Client{
+					Opener: fake.Opener{
+						*path: tc.currently,
+					},
+				},
+			}
+			ch := make(chan time.Time)
+			fix := FixPersistent(client, *path, ch)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			go func() {
+				for _, tick := range tc.ticks {
+					ch <- tick
+				}
+				cancel()
+			}()
+			if err := fix(ctx, logrus.WithField("name", tc.name), tc.q, nil); !errors.Is(err, context.Canceled) {
+				t.Errorf("fix() returned unexpected error: %v", err)
+			} else {
+				got := tc.q.Current()
+				if diff := cmp.Diff(tc.wantCurrent, got); diff != "" {
+					t.Errorf("fix() got unexpected current diff (-want +got):\n%s", diff)
+				}
+				gotBytes := string(client.Uploader[*path].Buf)
+				if diff := cmp.Diff(tc.wantBuf, gotBytes); diff != "" {
+					t.Errorf("fix() got unexpected byte diff (-want +got):\n%s", diff)
+				}
+
+			}
+		})
+	}
+}

--- a/util/gcs/client.go
+++ b/util/gcs/client.go
@@ -25,7 +25,7 @@ import (
 
 // Uploader adds upload capabilities to a GCS client.
 type Uploader interface {
-	Upload(context.Context, Path, []byte, bool, string) (*storage.ObjectAttrs, error)
+	Upload(ctx context.Context, path Path, buf []byte, public bool, cacheControl string) (*storage.ObjectAttrs, error)
 }
 
 // Downloader can list files and open them for reading.

--- a/util/queue.go
+++ b/util/queue.go
@@ -168,6 +168,17 @@ func (q *Queue) Fix(name string, when time.Time, later bool) error {
 	return nil
 }
 
+// Current status for each item in the queue.
+func (q *Queue) Current() map[string]time.Time {
+	currently := make(map[string]time.Time, len(q.queue))
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	for _, item := range q.queue {
+		currently[item.name] = item.when
+	}
+	return currently
+}
+
 // Status of the queue: depth, next item and when the next item is ready.
 func (q *Queue) Status() (int, *string, time.Time) {
 	q.lock.RLock()


### PR DESCRIPTION
* First try and load the state from GCS
* Thereafter save it to GCS every minute
* Discard any loaded names that are no longer in the queue
* Unit test