### PR TITLE
Add persistent queue to summarizer.

### DIFF
--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -36,6 +36,7 @@ import (
 
 type options struct {
 	config            gcs.Path // gcs://path/to/config/proto
+	persistQueue      gcs.Path
 	creds             string
 	confirm           bool
 	dashboards        util.Strings
@@ -63,6 +64,7 @@ func (o *options) validate() error {
 func gatherOptions() options {
 	var o options
 	flag.Var(&o.config, "config", "gs://path/to/config.pb")
+	flag.Var(&o.persistQueue, "persist-queue", "Load previous queue state from gs://path/to/queue-state.json and regularly save to it thereafter")
 	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
 	flag.BoolVar(&o.confirm, "confirm", false, "Upload data if set")
 	flag.Var(&o.dashboards, "dashboard", "Only update named dashboards if set (repeateable)")
@@ -132,7 +134,19 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).WithField("subscription", opt.pubsub).Fatal("Failed to configure pubsub")
 	}
-	if err := summarizer.Update(ctx, client, metrics, opt.config, opt.concurrency, opt.gridPathPrefix, opt.summaryPathPrefix, opt.dashboards.Strings(), opt.confirm, opt.wait, fixer); err != nil {
+
+	fixers := []summarizer.Fixer{
+		fixer,
+	}
+
+	if path := opt.persistQueue; path.String() != "" {
+		const freq = time.Minute
+		ticker := time.NewTicker(freq)
+		log := logrus.WithField("frequency", freq)
+		fixers = append(fixers, summarizer.FixPersistent(log, client, path, ticker.C))
+	}
+
+	if err := summarizer.Update(ctx, client, metrics, opt.config, opt.concurrency, opt.gridPathPrefix, opt.summaryPathPrefix, opt.dashboards.Strings(), opt.confirm, opt.wait, fixers...); err != nil {
 		logrus.WithError(err).Error("Could not summarize")
 	}
 }

--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -135,10 +135,10 @@ func main() {
 		logrus.WithError(err).WithField("subscription", opt.pubsub).Fatal("Failed to configure pubsub")
 	}
 
-	fixers := []summarizer.Fixer{
-		fixer,
+	fixers := make([]summarizer.Fixer, 0, 2)
+	if fixer != nil {
+		fixers = append(fixers, fixer)
 	}
-
 	if path := opt.persistQueue; path.String() != "" {
 		const freq = time.Minute
 		ticker := time.NewTicker(freq)

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -174,8 +174,10 @@ func main() {
 	}
 
 	if path := opt.persistQueue; path.String() != "" {
-		ticker := time.NewTicker(time.Minute)
-		fixers = append(fixers, updater.FixPersistent(client, path, ticker.C))
+		const freq = time.Minute
+		ticker := time.NewTicker(freq)
+		log := logrus.WithField("frequency", freq)
+		fixers = append(fixers, updater.FixPersistent(log, client, path, ticker.C))
 	}
 
 	if err := updater.Update(ctx, client, mets, opt.config, opt.gridPrefix, opt.groupConcurrency, opt.groups.Strings(), groupUpdater, opt.confirm, opt.wait, fixers...); err != nil {

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -13,8 +13,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pb/config:go_default_library",
-        "//util:go_default_library",
         "//util/gcs:go_default_library",
+        "//util/queue:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/config/queue.go
+++ b/config/queue.go
@@ -23,13 +23,13 @@ import (
 
 	"bitbucket.org/creachadair/stringset"
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	"github.com/GoogleCloudPlatform/testgrid/util"
+	"github.com/GoogleCloudPlatform/testgrid/util/queue"
 	"github.com/sirupsen/logrus"
 )
 
 // DashboardQueue sends dashboard names at a specific frequency.
 type DashboardQueue struct {
-	util.Queue
+	queue.Queue
 	dashboards map[string]*configpb.Dashboard
 	groups     map[string]*stringset.Set
 
@@ -83,7 +83,7 @@ func (q *DashboardQueue) FixTestGroups(when time.Time, later bool, groups ...str
 // First call must be to Init().
 // Exported methods are safe to call concurrently.
 type TestGroupQueue struct {
-	util.Queue
+	queue.Queue
 	groups map[string]*configpb.TestGroup
 	lock   sync.RWMutex
 }

--- a/pkg/summarizer/BUILD.bazel
+++ b/pkg/summarizer/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "flakiness.go",
+        "persist.go",
         "pubsub.go",
         "summary.go",
     ],
@@ -22,6 +23,7 @@ go_library(
         "//pkg/summarizer/common:go_default_library",
         "//util/gcs:go_default_library",
         "//util/metrics:go_default_library",
+        "//util/queue:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",

--- a/pkg/summarizer/persist.go
+++ b/pkg/summarizer/persist.go
@@ -1,0 +1,19 @@
+package summarizer
+
+import (
+	"context"
+	"time"
+
+	"github.com/GoogleCloudPlatform/testgrid/config"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"github.com/GoogleCloudPlatform/testgrid/util/queue"
+	"github.com/sirupsen/logrus"
+)
+
+// FixPersistent persists the updater queue using queue.FixPersistent.
+func FixPersistent(log logrus.FieldLogger, client queue.PersistClient, path gcs.Path, tick <-chan time.Time) Fixer {
+	fix := queue.FixPersistent(log, client, path, tick)
+	return func(ctx context.Context, iq *config.DashboardQueue) error {
+		return fix(ctx, &iq.Queue)
+	}
+}

--- a/pkg/summarizer/persist.go
+++ b/pkg/summarizer/persist.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package summarizer
 
 import (

--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -221,6 +221,7 @@ func Update(ctx context.Context, client gcs.ConditionalClient, mets *Metrics, co
 		}
 
 		ticker := time.NewTicker(time.Minute) // TODO(fejta): subscribe to notifications
+		fixAll()
 		for {
 			lock.Lock()
 			activeDashboards := active.Elements()

--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/pubsub:go_default_library",
         "//util/gcs:go_default_library",
         "//util/metrics:go_default_library",
+        "//util/queue:go_default_library",
         "@com_github_fvbommel_sortorder//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -1,10 +1,9 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
     srcs = [
         "log.go",
-        "queue.go",
         "strings.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/util",
@@ -25,18 +24,8 @@ filegroup(
         ":package-srcs",
         "//util/gcs:all-srcs",
         "//util/metrics:all-srcs",
+        "//util/queue:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["queue_test.go"],
-    embed = [":go_default_library"],
-    deps = [
-        "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
-        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
-    ],
 )

--- a/util/queue/BUILD.bazel
+++ b/util/queue/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "persist.go",
+        "queue.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/testgrid/util/queue",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//util/gcs:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "persist_test.go",
+        "queue_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//util/gcs:go_default_library",
+        "//util/gcs/fake:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
+        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/util/queue/persist.go
+++ b/util/queue/persist.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"github.com/sirupsen/logrus"
+)
+
+// PersistClient contains interfaces for reading from and writing to a Path.
+type PersistClient interface {
+	gcs.Uploader
+	gcs.Opener
+}
+
+// Fixer will adjust the queue until the context expires.
+type Fixer func(context.Context, *Queue) error
+
+// FixPersistent persists the queue to the remote path every tick.
+//
+// The first time it will load the state. Thereafter it will save the state.
+// This includes restarts due to expiring contexts -- it will just load once.
+func FixPersistent(logr logrus.FieldLogger, client PersistClient, path gcs.Path, tick <-chan time.Time) Fixer {
+	var shouldSave bool
+	log := logr.WithField("path", path)
+	return func(ctx context.Context, q *Queue) error {
+		log.Debug("Using persistent state")
+
+		tryLoad := func() error {
+			reader, attrs, err := client.Open(ctx, path)
+			if errors.Is(err, storage.ErrObjectNotExist) {
+				log.Info("Previous persistent queue state does not exist.")
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("open: %w", err)
+			}
+
+			defer reader.Close()
+			dec := json.NewDecoder(reader)
+			var whens map[string]time.Time
+			if err := dec.Decode(&whens); err != nil {
+				return fmt.Errorf("decode: %v", err)
+			}
+
+			current := q.Current()
+
+			for name := range whens {
+				if _, ok := current[name]; ok {
+					continue
+				}
+				delete(whens, name)
+			}
+
+			log.WithField("from", attrs.LastModified).Info("Fixing queue with persistent state.")
+			if err := q.FixAll(whens, false); err != nil {
+				return fmt.Errorf("fix all: %v", err)
+			}
+			return nil
+		}
+
+		trySave := func() error {
+			currently := q.Current()
+			buf, err := json.MarshalIndent(currently, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshal: %v", err)
+			}
+			_, err = client.Upload(ctx, path, buf, false, "")
+			return err
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-tick:
+			}
+
+			if shouldSave {
+				log.Trace("Saving persistent state...")
+				if err := trySave(); err != nil {
+					log.WithError(err).Error("Failed to save persistent state.")
+					continue
+				}
+				log.Debug("Saved persistent state.")
+			} else {
+				log.Trace("Loading persistent state...")
+				if err := tryLoad(); err != nil {
+					log.WithError(err).Error("Failed to load persistent state.")
+					continue
+				}
+				shouldSave = true
+				log.Debug("Loaded persistent state.")
+			}
+		}
+	}
+}

--- a/util/queue/persist_test.go
+++ b/util/queue/persist_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package queue
 
 import (

--- a/util/queue/persist_test.go
+++ b/util/queue/persist_test.go
@@ -1,20 +1,4 @@
-/*
-Copyright 2022 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-package updater
+package queue
 
 import (
 	"context"
@@ -24,8 +8,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/testgrid/config"
-	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs/fake"
 	"github.com/google/go-cmp/cmp"
@@ -38,7 +20,7 @@ func TestFixPersistent(t *testing.T) {
 	later := now.Add(time.Hour)
 	cases := []struct {
 		name        string
-		q           *config.TestGroupQueue
+		q           *Queue
 		currently   fake.Object
 		ticks       []time.Time
 		fixes       map[string]time.Time
@@ -47,22 +29,14 @@ func TestFixPersistent(t *testing.T) {
 	}{
 		{
 			name:        "basic",
-			q:           &config.TestGroupQueue{},
+			q:           &Queue{},
 			wantCurrent: map[string]time.Time{},
 		},
 		{
 			name: "no load",
-			q: func() *config.TestGroupQueue {
-				var q config.TestGroupQueue
-				groups := []*configpb.TestGroup{
-					{
-						Name: "foo",
-					},
-					{
-						Name: "bar",
-					},
-				}
-				q.Init(logrus.New(), groups, next)
+			q: func() *Queue {
+				var q Queue
+				q.Init(logrus.New(), []string{"foo", "bar"}, next)
 				return &q
 			}(),
 			wantCurrent: map[string]time.Time{
@@ -72,17 +46,9 @@ func TestFixPersistent(t *testing.T) {
 		},
 		{
 			name: "load empty",
-			q: func() *config.TestGroupQueue {
-				var q config.TestGroupQueue
-				groups := []*configpb.TestGroup{
-					{
-						Name: "foo",
-					},
-					{
-						Name: "bar",
-					},
-				}
-				q.Init(logrus.New(), groups, next)
+			q: func() *Queue {
+				var q Queue
+				q.Init(logrus.New(), []string{"foo", "bar"}, next)
 				return &q
 			}(),
 			ticks: []time.Time{now},
@@ -93,17 +59,9 @@ func TestFixPersistent(t *testing.T) {
 		},
 		{
 			name: "load",
-			q: func() *config.TestGroupQueue {
-				var q config.TestGroupQueue
-				groups := []*configpb.TestGroup{
-					{
-						Name: "keep-next",
-					},
-					{
-						Name: "bump-to-now",
-					},
-				}
-				q.Init(logrus.New(), groups, next)
+			q: func() *Queue {
+				var q Queue
+				q.Init(logrus.New(), []string{"keep-next", "bump-to-now"}, next)
 				return &q
 			}(),
 			ticks: []time.Time{now},
@@ -129,17 +87,9 @@ func TestFixPersistent(t *testing.T) {
 		},
 		{
 			name: "load err",
-			q: func() *config.TestGroupQueue {
-				var q config.TestGroupQueue
-				groups := []*configpb.TestGroup{
-					{
-						Name: "keep-next",
-					},
-					{
-						Name: "would-bump-to-now-if-read",
-					},
-				}
-				q.Init(logrus.New(), groups, next)
+			q: func() *Queue {
+				var q Queue
+				q.Init(logrus.New(), []string{"keep-next", "would-bump-to-now-if-read"}, next)
 				return &q
 			}(),
 			ticks: []time.Time{now},
@@ -165,17 +115,9 @@ func TestFixPersistent(t *testing.T) {
 		},
 		{
 			name: "load and save",
-			q: func() *config.TestGroupQueue {
-				var q config.TestGroupQueue
-				groups := []*configpb.TestGroup{
-					{
-						Name: "keep-next",
-					},
-					{
-						Name: "bump-to-now",
-					},
-				}
-				q.Init(logrus.New(), groups, next)
+			q: func() *Queue {
+				var q Queue
+				q.Init(logrus.New(), []string{"keep-next", "bump-to-now"}, next)
 				return &q
 			}(),
 			ticks: []time.Time{now, now, now},
@@ -237,7 +179,7 @@ func TestFixPersistent(t *testing.T) {
 				}
 				cancel()
 			}()
-			if err := fix(ctx, nil, tc.q, nil); !errors.Is(err, context.Canceled) {
+			if err := fix(ctx, tc.q); !errors.Is(err, context.Canceled) {
 				t.Errorf("fix() returned unexpected error: %v", err)
 			} else {
 				got := tc.q.Current()

--- a/util/queue/queue.go
+++ b/util/queue/queue.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package queue
 
 import (
 	"container/heap"

--- a/util/queue/queue_test.go
+++ b/util/queue/queue_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package queue
 
 import (
 	"container/heap"


### PR DESCRIPTION
* Allow summarizer to accept multiple fixers
* Move util.Queue to util.queue.Queue
* Factor most FixPersistent logic into util.queue package
* Restart summary fixers when the configuration changes.
* Protect summarizer from a dashboard that no longer exists