### PR TITLE
Config snapshot adjustments

### DIFF
--- a/config/snapshot/config_snapshot_test.go
+++ b/config/snapshot/config_snapshot_test.go
@@ -212,14 +212,14 @@ func TestObserve_OnTick(t *testing.T) {
 					if result := cs.Dashboards["dashboard"]; !proto.Equal(result, test.expectDashboard) {
 						t.Errorf("got dashboard %v, expected %v", result, test.expectDashboard)
 					}
-				case <-time.After(5 * time.Hour):
+				case <-time.After(3 * time.Second):
 					t.Error("expected a snapshot after tick, but got none")
 				}
 			} else {
 				select {
 				case cs := <-snaps:
 					t.Errorf("did not expect a snapshot, but got %v", cs)
-				default:
+				case <-time.After(3 * time.Second):
 				}
 			}
 		})

--- a/pkg/updater/BUILD.bazel
+++ b/pkg/updater/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//config:go_default_library",
+        "//config/snapshot:go_default_library",
         "//internal/result:go_default_library",
         "//metadata:go_default_library",
         "//metadata/junit:go_default_library",


### PR DESCRIPTION
- Config Snapshot test now detects if it "does not snapshot when generation match" correctly 
- Deletes unused/duplicate code. This wound up being shockingly little cut, since the "configSnapshot" has already been removed.

/assign @fejta 