### PR TITLE
Move the test-group-updates subscription over to the tabulator.

### DIFF
--- a/cluster/prod/knative/summarizer.yaml
+++ b/cluster/prod/knative/summarizer.yaml
@@ -27,10 +27,10 @@ spec:
         - --config=gs://knative-own-testgrid/config
         - --confirm
         - --json-logs
-        - --wait=5m
-        - --persist-queue=gs://knative-own-testgrid/queue/summarizer.json
-        - --pubsub=knative-tests/test-group-updates
+        # --persist-queue=gs://knative-own-testgrid/queue/summarizer.json
+        # --pubsub=knative-tests/test-group-updates
         - --summary-path=summary-old
+        - --wait=24h
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cluster/prod/knative/tabulator.yaml
+++ b/cluster/prod/knative/tabulator.yaml
@@ -33,6 +33,8 @@ spec:
         - --config=gs://knative-own-testgrid/config
         - --wait=15m
         - --confirm
+        - --pubsub=knative-tests/test-group-updates
+        # --persist-queue=gs://knative-own-testgrid/queue/tabulator.json
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/cluster/prod/summarizer.yaml
+++ b/cluster/prod/summarizer.yaml
@@ -40,10 +40,10 @@ spec:
         - --confirm
         - --grid-path=grid
         - --json-logs
-        - --pubsub=k8s-testgrid/test-group-updates
-        - --persist-queue=gs://k8s-testgrid/queue/summarizer.json
+        # --pubsub=k8s-testgrid/test-group-updates
+        # --persist-queue=gs://k8s-testgrid/queue/summarizer.json
         - --summary-path=summary-old
-        - --wait=5m
+        - --wait=24h
         resources:
           requests:
             cpu: "1"

--- a/cluster/prod/tabulator.yaml
+++ b/cluster/prod/tabulator.yaml
@@ -33,6 +33,8 @@ spec:
         - --config=gs://k8s-testgrid/config
         - --confirm
         - --wait=15m
+        - --pubsub=k8s-testgrid/test-group-updates
+        # --persist-queue=gs://k8s-testgrid/queue/tabulator.json
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
The summarizer now consumes tab data and uses a different subscription