### PR TITLE
Bump the max size of junit xml(s)

### DIFF
--- a/util/gcs/read.go
+++ b/util/gcs/read.go
@@ -413,7 +413,7 @@ type SuitesMeta struct {
 }
 
 const (
-	maxSize int64 = 100e6 // 100 million, coarce to int not float
+	maxSize int64 = 200e6 // 200 million, coarce to int not float
 )
 
 func readSuites(ctx context.Context, opener Opener, p Path) (*junit.Suites, error) {


### PR DESCRIPTION
With the json output switch, we end up with larger output for each line,
which in turn has bumped up the size of the junit xml(s). Please see for
example:

https://testgrid.k8s.io/sig-release-master-blocking#integration-master&width=20

We end up with a message in test grid that xml file is too large.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>