### PR TITLE
Restore --dashboard functionality.

### DIFF
--- a/pkg/summarizer/BUILD.bazel
+++ b/pkg/summarizer/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+        "@org_bitbucket_creachadair_stringset//:go_default_library",
         "@org_golang_google_protobuf//testing/protocmp:go_default_library",
     ],
 )


### PR DESCRIPTION
The logic to filter down the list of dashboard to those
specified by the `--dashboard` flag has been refactored away.
This adds back the functionality.