### PR TITLE
Receive all statuses from the column.

### DIFF
--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -1011,7 +1011,6 @@ func latestGreen(grid *statepb.Grid, useFirstExtra bool) string {
 			}
 			if result == statuspb.TestStatus_FLAKY || result == statuspb.TestStatus_FAIL || result == statuspb.TestStatus_UNKNOWN {
 				failures = true
-				break
 			}
 		}
 		if failures || !passes {

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -2369,6 +2369,35 @@ func TestLatestGreen(t *testing.T) {
 			first:    true,
 			expected: "accept second-after-failure",
 		},
+		{
+			name: "multiple failing columns fixed",
+			rows: []*statepb.Row{
+				{
+					Name: "fail then pass",
+					Results: []int32{
+						int32(statuspb.TestStatus_FAIL), 1,
+						int32(statuspb.TestStatus_PASS), 1,
+					},
+				},
+				{
+					Name: "also fail then pass",
+					Results: []int32{
+						int32(statuspb.TestStatus_FAIL), 1,
+						int32(statuspb.TestStatus_PASS), 2,
+					},
+				},
+			},
+			cols: []*statepb.Column{
+				{
+					Extra: []string{"skip-first-col-with-fail"},
+				},
+				{
+					Extra: []string{"accept second-after-failure"},
+				},
+			},
+			first:    true,
+			expected: "accept second-after-failure",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Breaking as soon as we find a failure will corrupt the next column's
statuses