### PR TITLE
Add processing to tabulator

### DIFF
--- a/cmd/tabulator/main.go
+++ b/cmd/tabulator/main.go
@@ -39,6 +39,7 @@ type options struct {
 	persistQueue       gcs.Path
 	creds              string
 	confirm            bool
+	filter             bool
 	concurrency        int
 	wait               time.Duration
 	gridPathPrefix     string
@@ -70,6 +71,7 @@ func gatherOptions() options {
 	flag.Var(&o.persistQueue, "persist-queue", "Load previous queue state from gs://path/to/queue-state.json and regularly save to it thereafter")
 	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
 	flag.BoolVar(&o.confirm, "confirm", false, "Upload data if set")
+	flag.BoolVar(&o.filter, "filter", false, "Filters out data according to the tab's configuration")
 	flag.IntVar(&o.concurrency, "concurrency", 0, "Manually define the number of groups to concurrently update if non-zero")
 	flag.DurationVar(&o.wait, "wait", 0, "Ensure at least this much time has passed since the last loop (exit if zero).")
 
@@ -138,7 +140,7 @@ func main() {
 
 	mets := tabulator.CreateMetrics(prometheus.NewFactory())
 
-	if err := tabulator.Update(ctx, client, mets, opt.config, opt.concurrency, opt.gridPathPrefix, opt.tabStatePathPrefix, opt.confirm, opt.wait, fixers...); err != nil {
+	if err := tabulator.Update(ctx, client, mets, opt.config, opt.concurrency, opt.gridPathPrefix, opt.tabStatePathPrefix, opt.confirm, opt.filter, opt.wait, fixers...); err != nil {
 		logrus.WithError(err).Error("Could not tabulate")
 	}
 }

--- a/pkg/tabulator/BUILD.bazel
+++ b/pkg/tabulator/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//config:go_default_library",
         "//config/snapshot:go_default_library",
         "//pb/config:go_default_library",
+        "//pb/state:go_default_library",
         "//pkg/pubsub:go_default_library",
         "//pkg/updater:go_default_library",
         "//util/gcs:go_default_library",
@@ -21,6 +22,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@org_bitbucket_creachadair_stringset//:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )
 
@@ -32,9 +34,13 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pb/state:go_default_library",
         "//pkg/pubsub:go_default_library",
         "//util/gcs:go_default_library",
+        "//util/gcs/fake:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Allows processing to be done between tab states. Actually useful processing to be implemented.

Adds a `copy-only` flag to suppress this behavior.