### PR TITLE
Add filtering to tabulator

### DIFF
--- a/pkg/tabulator/BUILD.bazel
+++ b/pkg/tabulator/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "filter.go",
         "persist.go",
         "pubsub.go",
         "tabstate.go",
@@ -29,18 +30,20 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "filter_test.go",
         "pubsub_test.go",
         "tabstate_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pb/config:go_default_library",
         "//pb/state:go_default_library",
+        "//pb/test_status:go_default_library",
         "//pkg/pubsub:go_default_library",
         "//util/gcs:go_default_library",
         "//util/gcs/fake:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )
 

--- a/pkg/tabulator/filter.go
+++ b/pkg/tabulator/filter.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tabulator processes test group state into tab state.
+package tabulator
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+
+	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
+)
+
+const (
+	includeFilter = "include-filter-by-regex"
+	excludeFilter = "exclude-filter-by-regex"
+)
+
+// filterGrid filters the grid to rows matching the include/exclude list in the base options
+func filterGrid(baseOptions string, rows []*statepb.Row) ([]*statepb.Row, error) {
+
+	vals, err := url.ParseQuery(baseOptions)
+	if err != nil {
+		return nil, fmt.Errorf("parse %q: %v", baseOptions, err)
+	}
+
+	for _, include := range vals[includeFilter] {
+		if rows, err = includeRows(rows, include); err != nil {
+			return nil, fmt.Errorf("bad %s=%s: %v", includeFilter, include, err)
+		}
+	}
+
+	for _, exclude := range vals[excludeFilter] {
+		if rows, err = excludeRows(rows, exclude); err != nil {
+			return nil, fmt.Errorf("bad %s=%s: %v", excludeFilter, exclude, err)
+		}
+	}
+
+	// TODO(chases2): drop columns that are now empty due to filters
+	// TODO(fejta): grouping, which is not used by testgrid.k8s.io
+	// TODO(fejta): sorting, unused by testgrid.k8s.io
+	// TODO(fejta): graph, unused by testgrid.k8s.io
+	// TODO(fejta): tabuluar, unused by testgrid.k8s.io
+	return rows, nil
+}
+
+// includeRows returns the subset of rows that match the regex
+func includeRows(in []*statepb.Row, include string) ([]*statepb.Row, error) {
+	re, err := regexp.Compile(include)
+	if err != nil {
+		return nil, err
+	}
+	var rows []*statepb.Row
+	for _, r := range in {
+		if !re.MatchString(r.Name) {
+			continue
+		}
+		rows = append(rows, r)
+	}
+	return rows, nil
+}
+
+// excludeRows returns the subset of rows that do not match the regex
+func excludeRows(in []*statepb.Row, exclude string) ([]*statepb.Row, error) {
+	re, err := regexp.Compile(exclude)
+	if err != nil {
+		return nil, err
+	}
+	var rows []*statepb.Row
+	for _, r := range in {
+		if re.MatchString(r.Name) {
+			continue
+		}
+		rows = append(rows, r)
+	}
+	return rows, nil
+}

--- a/pkg/tabulator/filter_test.go
+++ b/pkg/tabulator/filter_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2022 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tabulator processes test group state into tab state.
+package tabulator
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
+	statuspb "github.com/GoogleCloudPlatform/testgrid/pb/test_status"
+)
+
+func TestFilterGrid(t *testing.T) {
+	cases := []struct {
+		name        string
+		baseOptions string
+		rows        []*statepb.Row
+		expected    []*statepb.Row
+		err         bool
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:        "bad options returns error",
+			baseOptions: "%z",
+			err:         true,
+		},
+		{
+			name: "everything works",
+			baseOptions: url.Values{
+				includeFilter: []string{"foo"},
+				excludeFilter: []string{"bar"},
+			}.Encode(),
+			rows: []*statepb.Row{
+				{
+					Name:    "include-food",
+					Results: []int32{int32(statuspb.TestStatus_PASS), 10},
+				},
+				{
+					Name:    "exclude-included-bart",
+					Results: []int32{int32(statuspb.TestStatus_PASS), 10},
+				},
+				{
+					Name: "ignore-included-stale",
+					Results: []int32{
+						int32(statuspb.TestStatus_NO_RESULT), 5,
+						int32(statuspb.TestStatus_PASS_WITH_SKIPS), 10,
+					},
+				},
+			},
+			expected: []*statepb.Row{
+				{
+					Name:    "include-food",
+					Results: []int32{int32(statuspb.TestStatus_PASS), 10},
+				},
+			},
+		},
+		{
+			name: "must match all includes",
+			baseOptions: url.Values{
+				includeFilter: []string{"foo", "spam"},
+			}.Encode(),
+			rows: []*statepb.Row{
+				{
+					Name: "spam-is-food",
+				},
+				{
+					Name: "spam-musubi",
+				},
+				{
+					Name: "unagi-food",
+				},
+				{
+					Name: "email-spam-is-not-food",
+				},
+			},
+			expected: []*statepb.Row{
+				{
+					Name: "spam-is-food",
+				},
+				{
+					Name: "email-spam-is-not-food",
+				},
+			},
+		},
+		{
+			name: "exclude any exclusions",
+			baseOptions: url.Values{
+				excludeFilter: []string{"not", "nope"},
+			}.Encode(),
+			rows: []*statepb.Row{
+				{
+					Name: "yes please",
+				},
+				{
+					Name: "leslie knope",
+				},
+				{
+					Name: "not eating",
+				},
+				{
+					Name: "fluffy waffles",
+				},
+			},
+			expected: []*statepb.Row{
+				{
+					Name: "yes please",
+				},
+				{
+					Name: "fluffy waffles",
+				},
+			},
+		},
+		{
+			name: "bad inclusion regexp errors",
+			baseOptions: url.Values{
+				includeFilter: []string{"this.("},
+			}.Encode(),
+			err: true,
+		},
+		{
+			name: "bad exclude regexp errors",
+			baseOptions: url.Values{
+				excludeFilter: []string{"this.("},
+			}.Encode(),
+			err: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, r := range tc.rows {
+				if r.Results == nil {
+					r.Results = []int32{int32(statuspb.TestStatus_PASS), 100}
+				}
+			}
+			for _, r := range tc.expected {
+				if r.Results == nil {
+					r.Results = []int32{int32(statuspb.TestStatus_PASS), 100}
+				}
+			}
+			actual, err := filterGrid(tc.baseOptions, tc.rows)
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Error("failed to return an error")
+			case !reflect.DeepEqual(actual, tc.expected):
+				t.Errorf("%s != expected %s", actual, tc.expected)
+			}
+
+		})
+	}
+}
+
+func TestIncludeRows(t *testing.T) {
+	cases := []struct {
+		name     string
+		names    []string
+		include  string
+		expected []string
+		err      bool
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:    "bad regex errors",
+			include: "^[a-z",
+			err:     true,
+		},
+		{
+			name:    "return nothing rows when nothing matches",
+			names:   []string{"hello", "world"},
+			include: "dog",
+		},
+		{
+			name:     "include only matching rows",
+			include:  "fun",
+			names:    []string{"apply", "function", "to", "funny", "bone"},
+			expected: []string{"function", "funny"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rows []*statepb.Row
+			for _, n := range tc.names {
+				rows = append(rows, &statepb.Row{Name: n})
+			}
+			actualRows, err := includeRows(rows, tc.include)
+			var actual []string
+			for _, r := range actualRows {
+				actual = append(actual, r.Name)
+			}
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Error("failed to return expected error")
+			case !reflect.DeepEqual(actual, tc.expected):
+				t.Errorf("actual %s != expected %s", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestExcludeRows(t *testing.T) {
+	cases := []struct {
+		name     string
+		names    []string
+		exclude  string
+		expected []string
+		err      bool
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:    "bad regex errors",
+			exclude: "^[a-z",
+			err:     true,
+		},
+		{
+			name:     "return all rows when nothing matches",
+			names:    []string{"hello", "world"},
+			exclude:  "dog",
+			expected: []string{"hello", "world"},
+		},
+		{
+			name:     "drop matching rows",
+			exclude:  "fun",
+			names:    []string{"apply", "function", "to", "funny", "bone"},
+			expected: []string{"apply", "to", "bone"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rows []*statepb.Row
+			for _, n := range tc.names {
+				rows = append(rows, &statepb.Row{Name: n})
+			}
+			actualRows, err := excludeRows(rows, tc.exclude)
+			var actual []string
+			for _, r := range actualRows {
+				actual = append(actual, r.Name)
+			}
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Error("failed to return expected error")
+			case !reflect.DeepEqual(actual, tc.expected):
+				t.Errorf("actual %s != expected %s", actual, tc.expected)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Allows the tabulator to use base options to remove entire rows that will be filtered out by the UI and summarizer anyway.

/hold (for further testing)