### PR TITLE
Add skip-filter flag for summarizer

### DIFF
--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -39,6 +39,7 @@ type options struct {
 	persistQueue      gcs.Path
 	creds             string
 	confirm           bool
+	skipFilter        bool
 	dashboards        util.Strings
 	concurrency       int
 	wait              time.Duration
@@ -68,6 +69,7 @@ func gatherOptions() options {
 	flag.Var(&o.persistQueue, "persist-queue", "Load previous queue state from gs://path/to/queue-state.json and regularly save to it thereafter")
 	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
 	flag.BoolVar(&o.confirm, "confirm", false, "Upload data if set")
+	flag.BoolVar(&o.skipFilter, "skip-base-options-filter", false, "Skip filtering grid by the tab's base options (if filtered upstream; ie. in Tabulator)")
 	flag.Var(&o.dashboards, "dashboard", "Only update named dashboards if set (repeateable)")
 	flag.IntVar(&o.concurrency, "concurrency", 0, "Manually define the number of dashboards to concurrently update if non-zero")
 	flag.DurationVar(&o.wait, "wait", 0, "Ensure at least this much time has passed since the last loop (exit if zero).")
@@ -147,7 +149,7 @@ func main() {
 		fixers = append(fixers, summarizer.FixPersistent(log, client, path, ticker.C))
 	}
 
-	if err := summarizer.Update(ctx, client, metrics, opt.config, opt.concurrency, opt.tabPathPrefix, opt.summaryPathPrefix, opt.dashboards.Strings(), opt.confirm, opt.wait, fixers...); err != nil {
+	if err := summarizer.Update(ctx, client, metrics, opt.config, opt.concurrency, opt.tabPathPrefix, opt.summaryPathPrefix, opt.dashboards.Strings(), opt.confirm, !opt.skipFilter, opt.wait, fixers...); err != nil {
 		logrus.WithError(err).Error("Could not summarize")
 	}
 }


### PR DESCRIPTION
Adds a flag that allows you to turn off regex filtering (if it's already being done upstream by the tabulator.