### PR TITLE
Give the canary tabulator updater-like resources

### DIFF
--- a/cluster/canary/tabulator.yaml
+++ b/cluster/canary/tabulator.yaml
@@ -36,6 +36,13 @@ spec:
         - --pubsub=k8s-testgrid/canary-test-group-updates
         - --persist-queue=gs://k8s-testgrid-canary/queue/tabulator.json
         - --filter
+        resources:
+          requests:
+            cpu: "30"
+            memory: "75G"
+          limits:
+            cpu: "40"
+            memory: "150G"
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Enabling filtering requires much more memory, since the protos are loaded into memory instead of cloud-copied