### PR TITLE
Revert "Revert "Filter empty columns in production""

### DIFF
--- a/cluster/prod/knative/tabulator.yaml
+++ b/cluster/prod/knative/tabulator.yaml
@@ -36,6 +36,7 @@ spec:
         - --pubsub=knative-tests/test-group-updates
         - --wait=1h
         - --filter
+        - --filter-columns
         resources:
           requests:
             cpu: "30"

--- a/cluster/prod/tabulator.yaml
+++ b/cluster/prod/tabulator.yaml
@@ -36,6 +36,7 @@ spec:
         - --persist-queue=gs://k8s-testgrid/queue/tabulator.json
         - --wait=1h
         - --filter
+        - --filter-columns
         resources:
           requests:
             cpu: "30"


### PR DESCRIPTION
This reverts commit 0241f4dc03b44c488dd94221de654bbc154d9c3b.

/hold
Do not submit until after https://github.com/GoogleCloudPlatform/testgrid/pull/907 is submitted