### PR TITLE
Revert "Revert "Revert "Filter empty columns in production"""

### DIFF
--- a/cluster/prod/knative/tabulator.yaml
+++ b/cluster/prod/knative/tabulator.yaml
@@ -36,7 +36,6 @@ spec:
         - --pubsub=knative-tests/test-group-updates
         - --wait=1h
         - --filter
-        - --filter-columns
         resources:
           requests:
             cpu: "30"

--- a/cluster/prod/tabulator.yaml
+++ b/cluster/prod/tabulator.yaml
@@ -36,7 +36,6 @@ spec:
         - --persist-queue=gs://k8s-testgrid/queue/tabulator.json
         - --wait=1h
         - --filter
-        - --filter-columns
         resources:
           requests:
             cpu: "30"


### PR DESCRIPTION
This reverts commit 6a7fa3b1d15b37d16a46a1b0e3c95cb680788402.

Inflating and deflating the columns (required for this flag) may be deleting alerting data without recalculating it.

/assign @michelle192837