### PR TITLE
Add basic PubSub alerts using Terraform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ node_modules/
 *.iml
 .vscode/*
 /vendor/
+
+## terraform output
+*.tfvars
+*.terraform/
+prow/oss/terraform/state.tf
+*.terraform.lock.hcl

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2022 The TestGrid Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tf = "/google/data/ro/teams/terraform/bin/terraform"
+
+.PHONY: check-install
+check-install:
+ifeq ($(shell $(tf) -version),)
+	@echo "ERROR: terraform is not installed"; exit 1
+endif
+
+.PHONY: init-no-backend
+init-no-backend: check-install
+	$(tf) init --backend=false
+
+.PHONY: validate
+validate: init-no-backend
+	$(tf) validate

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,46 @@
+(Modified from https://github.com/GoogleCloudPlatform/oss-test-infra/tree/master/prow/oss/terraform)
+
+## Terraform
+
+This directory contains terrafrom configurations for provisioning monitoring and alerting stacks on GCP for TestGrid. These are applied manually.
+
+### Prerequisite For Provisioning
+
+-   Terraform 0.13.1
+    [Installation guide](https://www.terraform.io/downloads.html)
+
+-   Authenticate with GCP
+
+    ```shell
+    gcloud auth login && gcloud auth application-default login
+    ```
+
+### Initial Setup (One time action)
+
+This is done once before initial provisioning of monitoring and alerting stacks.
+
+```shell
+    gsutil mb -p k8s-testgrid gs://k8s-testgrid-metrics-terraform
+    gsutil versioning set on gs://k8s-testgrid-metrics-terraform
+```
+
+### Provisioning
+
+1.  Run `terraform init`. Terraform will automatically download the plugins
+    required to execute this code. You only need to do this once per machine.
+
+    ```shell
+    terraform init
+    ```
+
+1.  Validate with:
+
+    ```shell
+    make validate
+    ```
+
+1.  Execute Terraform:
+
+    ```shell
+    terraform apply
+    ```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,43 @@
+# Copyright 2022 The TestGrid Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Store terraform states in GCS
+terraform {
+  backend "gcs" {
+    bucket = "k8s-testgrid-metrics-terraform"
+  }
+}
+
+module "alert" {
+  source = "./modules/alerts"
+
+  project = "k8s-testgrid"
+  # gcloud alpha monitoring channels list --project=k8s-testgrid
+  # grep displayName: Michelle
+  notification_channel_id = "12611470047778396886"
+
+  blackbox_probers = [
+    // Production
+    // Check both the original and the aliased URLs
+    "k8s-testgrid.appspot.com",
+    "testgrid.k8s.io",
+    // Canary
+    "external-canary-dot-k8s-testgrid.appspot.com",
+  ]
+
+  pubsub_topics = [
+    "canary-testgrid",
+    "testgrid",
+  ]
+}

--- a/terraform/modules/alerts/main.tf
+++ b/terraform/modules/alerts/main.tf
@@ -1,0 +1,88 @@
+# Copyright 2022 The TestGrid Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {}
+
+resource "google_monitoring_alert_policy" "probers" {
+  project      = var.project
+  provider     = google-beta  // To include `condition_monitoring_query_language`
+  display_name = "HostDown"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Host is unreachable"
+    condition_monitoring_query_language {
+      duration = "120s"
+      query    = <<-EOT
+      fetch uptime_url
+      | metric 'monitoring.googleapis.com/uptime_check/check_passed'
+      | align next_older(1m)
+      | filter resource.project_id == '${var.project}'
+      | every 1m
+      | group_by [resource.host],
+          [value_check_passed_not_count_true: count_true(not(value.check_passed))]
+      | condition val() > 1 '1'
+      EOT
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  documentation {
+    content   = "Host Down"
+    mime_type = "text/markdown"
+  }
+
+  # gcloud beta monitoring channels list --project=oss-prow
+  notification_channels = ["projects/${var.project}/notificationChannels/${var.notification_channel_id}"]
+}
+
+resource "google_monitoring_alert_policy" "pubsub-unack-too-old" {
+  project      = var.project
+  provider     = google-beta  // To include `condition_monitoring_query_language`
+  for_each     = var.pubsub_topics
+  display_name = "pubsub-unack-too-old/${var.project}/${each.key}"
+  combiner     = "OR" # required
+
+  conditions {
+    display_name = "pubsub-unack-too-old/${var.project}/${each.key}"
+    
+    condition_monitoring_query_language {
+      duration = "60s"
+      query    = <<-EOT
+      fetch pubsub_subscription
+      | metric 'pubsub.googleapis.com/subscription/oldest_unacked_message_age'
+      | filter
+          (metadata.system_labels.topic_id == '${each.key}')
+      | group_by 30m,
+          [value_oldest_unacked_message_age_mean:
+          mean(value.oldest_unacked_message_age)]
+      | every 30m
+      | condition val() > 1.08e+07 's'
+      EOT
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  documentation {
+    content   = "${var.project}: TestGrid is not acknowledging PubSub messages in time.\n\nOncall Playbook: http://go/test-infra-playbook"
+    mime_type = "text/markdown"
+  }
+
+  # gcloud beta monitoring channels list --project=oss-REPLACE
+  notification_channels = ["projects/${var.project}/notificationChannels/${var.notification_channel_id}"]
+}

--- a/terraform/modules/alerts/probers.tf
+++ b/terraform/modules/alerts/probers.tf
@@ -1,0 +1,38 @@
+# Copyright 2022 The TestGrid Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_monitoring_uptime_check_config" "https" {
+  project          = var.project
+  selected_regions = []
+
+  for_each = var.blackbox_probers
+
+  display_name = each.key
+  timeout      = "10s"
+  period       = "60s"
+
+  http_check {
+    port         = "443"
+    use_ssl      = true
+    validate_ssl = true
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = var.project
+      host       = each.key
+    }
+  }
+}

--- a/terraform/modules/alerts/variables.tf
+++ b/terraform/modules/alerts/variables.tf
@@ -1,0 +1,31 @@
+# Copyright 2022 The TestGrid Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  type = string
+}
+
+variable "notification_channel_id" {
+  type = string
+}
+
+variable "blackbox_probers" {
+  type    = set(string)
+  default = []
+}
+
+variable "pubsub_topics" {
+  type    = set(string)
+  default = []
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,22 @@
+# Copyright 2022 The TestGrid Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provider "google" {
+  project     = "k8s-testgrid"
+  region      = "us-west1"
+}
+provider "google-beta" {
+  project     = "k8s-testgrid"
+  region      = "us-west1"
+}


### PR DESCRIPTION
Based on Prow team's work in https://github.com/GoogleCloudPlatform/oss-test-infra/tree/master/prow/oss/terraform.