### PR TITLE
Set alerts on tabulator while filtering columns

### DIFF
--- a/pkg/tabulator/BUILD.bazel
+++ b/pkg/tabulator/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "//util/gcs:go_default_library",
         "//util/gcs/fake:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//testing/protocmp:go_default_library",
     ],

--- a/pkg/tabulator/tabstate.go
+++ b/pkg/tabulator/tabstate.go
@@ -198,7 +198,8 @@ func Update(ctx context.Context, client gcs.ConditionalClient, mets *Metrics, co
 				}
 			}
 			if filter {
-				err := tabulate(ctx, client, tab, *fromPath, *toPath, confirm, dropEmptyCols)
+				groupCfg := cfg.Groups[tab.GetTestGroupName()]
+				err := createTabState(ctx, log, client, tab, groupCfg, *fromPath, *toPath, confirm, dropEmptyCols)
 				if err != nil {
 					return fmt.Errorf("can't calculate state: %w", err)
 				}
@@ -269,49 +270,57 @@ func TabStatePath(configPath gcs.Path, tabPrefix, dashboardName, tabName string)
 	return np, nil
 }
 
-func tabulate(ctx context.Context, client gcs.Client, cfg *configpb.DashboardTab, testGroupPath, tabStatePath gcs.Path, confirm, dropEmptyCols bool) error {
+// tabulate cuts the passed-in grid down to only the part that needs to be displayed by the UI.
+func tabulate(ctx context.Context, log logrus.FieldLogger, grid *statepb.Grid, tabCfg *configpb.DashboardTab, groupCfg *configpb.TestGroup, dropEmptyCols bool) (*statepb.Grid, error) {
+	filterRows, err := filterGrid(tabCfg.GetBaseOptions(), grid.GetRows())
+	if err != nil {
+		return nil, fmt.Errorf("filterGrid: %w", err)
+	}
+	grid.Rows = filterRows
+
+	if dropEmptyCols {
+		// TODO(chases2): Instead of inflate/drop/rewrite, move to inflate/drop/append
+		inflatedGrid, issues, err := updater.InflateGrid(ctx, grid, time.Time{}, time.Now())
+		if err != nil {
+			return nil, fmt.Errorf("inflateGrid: %w", err)
+		}
+
+		inflatedGrid = dropEmptyColumns(inflatedGrid)
+
+		usesK8sClient := groupCfg.UseKubernetesClient || (groupCfg.GetResultSource().GetGcsConfig() != nil)
+		grid = updater.ConstructGrid(log, inflatedGrid, issues, int(tabCfg.GetAlertOptions().GetNumFailuresToAlert()), int(tabCfg.GetAlertOptions().GetNumPassesToDisableAlert()), usesK8sClient, groupCfg.GetUserProperty())
+	}
+	return grid, nil
+}
+
+// createTabState creates the tab state from the group state
+func createTabState(ctx context.Context, log logrus.FieldLogger, client gcs.Client, dashCfg *configpb.DashboardTab, groupCfg *configpb.TestGroup, testGroupPath, tabStatePath gcs.Path, confirm, dropEmptyCols bool) error {
 	rawGrid, _, err := gcs.DownloadGrid(ctx, client, testGroupPath)
 	if err != nil {
 		return fmt.Errorf("downloadGrid(%s): %w", testGroupPath, err)
 	}
 
-	filterRows, err := filterGrid(cfg.GetBaseOptions(), rawGrid.GetRows())
+	grid, err := tabulate(ctx, log, rawGrid, dashCfg, groupCfg, dropEmptyCols)
 	if err != nil {
-		return fmt.Errorf("filterGrid: %w", err)
-	}
-	rawGrid.Rows = filterRows
-
-	if dropEmptyCols {
-		// TODO(chases2): Instead of inflate/drop/rewrite, move to inflate/drop/append
-		inflatedGrid, _, err := updater.InflateGrid(ctx, rawGrid, time.Time{}, time.Now())
-		if err != nil {
-			return fmt.Errorf("inflateGrid: %w", err)
-		}
-
-		inflatedGrid = dropEmptyColumns(inflatedGrid)
-
-		var newGrid statepb.Grid
-		rows := map[string]*statepb.Row{} // For fast target => row lookup
-
-		for _, col := range inflatedGrid {
-			// TODO(chases2): refactor updater.ConstructGrid so that the tabulator also sets alerts, but not other things
-			updater.AppendColumn(&newGrid, rows, col)
-		}
-		rawGrid = &newGrid
+		return fmt.Errorf("tabulate: %w", err)
 	}
 
-	if confirm {
-		buf, err := gcs.MarshalGrid(rawGrid)
-		if err != nil {
-			return fmt.Errorf("marshalGrid: %w", err)
-		}
+	if !confirm {
+		logrus.Debug("Successfully created tab state; discarding")
+		return nil
+	}
 
-		_, err = client.Upload(ctx, tabStatePath, buf, false, "")
-		if err != nil {
-			return fmt.Errorf("client.Upload(%s): %w", tabStatePath, err)
-		}
+	buf, err := gcs.MarshalGrid(grid)
+	if err != nil {
+		return fmt.Errorf("marshalGrid: %w", err)
+	}
+
+	_, err = client.Upload(ctx, tabStatePath, buf, false, "")
+	if err != nil {
+		return fmt.Errorf("client.Upload(%s): %w", tabStatePath, err)
 	}
 	return nil
+
 }
 
 // dropEmptyColumns drops every column in-place that has no results


### PR DESCRIPTION
Fixes bug where alerts are missing when the grid is inflated/deflated in the tabulator by recalculating alerts from the available data.

/lint