### PR TITLE
Remove filter-columns experiment from canary

### DIFF
--- a/cluster/canary/tabulator.yaml
+++ b/cluster/canary/tabulator.yaml
@@ -36,7 +36,6 @@ spec:
         - --pubsub=k8s-testgrid/canary-test-group-updates
         - --persist-queue=gs://k8s-testgrid-canary/queue/tabulator.json
         - --filter
-        - --filter-columns
         resources:
           requests:
             cpu: "30"


### PR DESCRIPTION
/assign @fejta 

Due to https://github.com/GoogleCloudPlatform/testgrid/issues/617, there isn't effective logic ensuring that the alerting settings are identical between tabs and test groups. This issue should be resolved before `--filter-columns` is rolled out everywhere.

Removing this flag so that the canary signal isn't stuck broken.