### PR TITLE
Have tabulator retry later, not instantly

### DIFF
--- a/pkg/tabulator/tabstate.go
+++ b/pkg/tabulator/tabstate.go
@@ -230,8 +230,9 @@ func Update(ctx context.Context, client gcs.ConditionalClient, mets *Metrics, co
 
 				if err := update(log, dashName); err != nil {
 					finish.Fail()
-					q.Fix(dashName, time.Now().Add(freq/2), false)
-					log.WithError(err).Error("Failed to generate tab state")
+					retry := time.Now().Add(freq / 10)
+					q.Fix(dashName, retry, true)
+					log.WithError(err).WithField("retry-at", retry).Error("Failed to generate tab state")
 				} else {
 					finish.Success()
 					log.Info("Built tab state")


### PR DESCRIPTION
The flag passed with Fix determines if a dashboard _can_ be fixed any later. Since this was false, failed dashboards don't retry any later, they just retry over and over again as quickly as the Tabulator can allow.

This change instead puts the dashboard "back on the queue" at a later time (but not much later) to retry later.