### PR TITLE
Move tab alert settings behind a flag

### DIFF
--- a/cmd/tabulator/main.go
+++ b/cmd/tabulator/main.go
@@ -36,19 +36,20 @@ import (
 
 // options configures the updater
 type options struct {
-	config             gcs.Path // gs://path/to/config/proto
-	persistQueue       gcs.Path
-	creds              string
-	confirm            bool
-	filter             bool
-	dropEmptyCols      bool
-	calculateStats     bool
-	dashboards         util.Strings
-	concurrency        int
-	wait               time.Duration
-	gridPathPrefix     string
-	tabStatePathPrefix string
-	pubsub             string
+	config              gcs.Path // gs://path/to/config/proto
+	persistQueue        gcs.Path
+	creds               string
+	confirm             bool
+	filter              bool
+	dropEmptyCols       bool
+	useTabAlertSettings bool
+	calculateStats      bool
+	dashboards          util.Strings
+	concurrency         int
+	wait                time.Duration
+	gridPathPrefix      string
+	tabStatePathPrefix  string
+	pubsub              string
 
 	debug    bool
 	trace    bool
@@ -75,10 +76,11 @@ func gatherOptions() options {
 	flag.Var(&o.persistQueue, "persist-queue", "Load previous queue state from gs://path/to/queue-state.json and regularly save to it thereafter")
 	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
 	flag.BoolVar(&o.confirm, "confirm", false, "Upload data if set")
-	flag.BoolVar(&o.dropEmptyCols, "filter-columns", false, "Drops empty columns after filtering")
-	flag.BoolVar(&o.calculateStats, "column-stats", false, "Calculates stats for broken columns")
 	flag.Var(&o.dashboards, "dashboard", "Only update named dashboards if set (repeateable)")
-	flag.BoolVar(&o.filter, "filter", false, "Filters out data according to the tab's configuration")
+	flag.BoolVar(&o.filter, "filter", false, "Filters out data according to the tab's configuration") // TODO(chases2): Switch to default
+	flag.BoolVar(&o.dropEmptyCols, "filter-columns", false, "Drops empty columns after filtering")    // TODO(chases2): Enable, then remove flag
+	flag.BoolVar(&o.useTabAlertSettings, "tab-alerts", false, "Use newer tab settings while caculating alerts")
+	flag.BoolVar(&o.calculateStats, "column-stats", false, "Calculates stats for broken columns")
 	flag.IntVar(&o.concurrency, "concurrency", 0, "Manually define the number of groups to concurrently update if non-zero")
 	flag.DurationVar(&o.wait, "wait", 0, "Ensure at least this much time has passed since the last loop (exit if zero).")
 
@@ -147,7 +149,7 @@ func main() {
 
 	mets := tabulator.CreateMetrics(prometheus.NewFactory())
 
-	if err := tabulator.Update(ctx, client, mets, opt.config, opt.concurrency, opt.gridPathPrefix, opt.tabStatePathPrefix, opt.dashboards.Strings(), opt.confirm, opt.filter, opt.dropEmptyCols, opt.calculateStats, opt.wait, fixers...); err != nil {
+	if err := tabulator.Update(ctx, client, mets, opt.config, opt.concurrency, opt.gridPathPrefix, opt.tabStatePathPrefix, opt.dashboards.Strings(), opt.confirm, opt.filter, opt.dropEmptyCols, opt.calculateStats, opt.useTabAlertSettings, opt.wait, fixers...); err != nil {
 		logrus.WithError(err).Error("Could not tabulate")
 	}
 }


### PR DESCRIPTION
TestGrid isn't universally ready to calculate alerts based only on tab alert settings (see https://github.com/GoogleCloudPlatform/testgrid/issues/617). Put this feature behind a flag so that empty columns can be dropped before needing to make this changeover.