### PR TITLE
Enable filter-columns on TG Canary

### DIFF
--- a/cluster/canary/tabulator.yaml
+++ b/cluster/canary/tabulator.yaml
@@ -36,6 +36,7 @@ spec:
         - --pubsub=k8s-testgrid/canary-test-group-updates
         - --persist-queue=gs://k8s-testgrid-canary/queue/tabulator.json
         - --filter
+        - --filter-columns
         resources:
           requests:
             cpu: "30"


### PR DESCRIPTION
Tested on a data snapshot; shown to be setting alert data after running Tabulator with this option.

Reverts https://github.com/GoogleCloudPlatform/testgrid/pull/916