### PR TITLE
Set Tabulator cache settings to "verified cache only"

### DIFF
--- a/pkg/merger/merger.go
+++ b/pkg/merger/merger.go
@@ -198,7 +198,7 @@ func MergeAndUpdate(ctx context.Context, client mergeClient, mets *Metrics, list
 		return result, fmt.Errorf("can't marshal merged proto: %w", err)
 	}
 
-	if _, err := client.Upload(ctx, *list.Path, buf, gcs.DefaultACL, "no-cache"); err != nil {
+	if _, err := client.Upload(ctx, *list.Path, buf, gcs.DefaultACL, gcs.NoCache); err != nil {
 		finish.Fail()
 		return result, fmt.Errorf("can't upload merged proto to %s: %w", list.Path, err)
 	}

--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -422,7 +422,7 @@ func writeSummary(ctx context.Context, client gcs.Client, path gcs.Path, sum *su
 	if err != nil {
 		return 0, fmt.Errorf("marshal: %v", err)
 	}
-	_, err = client.Upload(ctx, path, buf, gcs.DefaultACL, "no-cache")
+	_, err = client.Upload(ctx, path, buf, gcs.DefaultACL, gcs.NoCache)
 	return len(buf), err
 }
 

--- a/pkg/tabulator/tabstate.go
+++ b/pkg/tabulator/tabstate.go
@@ -328,7 +328,7 @@ func createTabState(ctx context.Context, log logrus.FieldLogger, client gcs.Clie
 		return fmt.Errorf("marshalGrid: %w", err)
 	}
 
-	_, err = client.Upload(ctx, tabStatePath, buf, false, "")
+	_, err = client.Upload(ctx, tabStatePath, buf, gcs.DefaultACL, gcs.NoCache)
 	if err != nil {
 		return fmt.Errorf("client.Upload(%s): %w", tabStatePath, err)
 	}

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -708,7 +708,7 @@ func InflateDropAppend(ctx context.Context, alog logrus.FieldLogger, client gcs.
 	} else {
 		log.Debug("Writing grid...")
 		// TODO(fejta): configurable cache value
-		if _, err := client.Upload(ctx, gridPath, buf, gcs.DefaultACL, "no-cache"); err != nil {
+		if _, err := client.Upload(ctx, gridPath, buf, gcs.DefaultACL, gcs.NoCache); err != nil {
 			return false, fmt.Errorf("upload %d bytes: %w", len(buf), err)
 		}
 	}

--- a/util/gcs/gcs.go
+++ b/util/gcs/gcs.go
@@ -168,10 +168,13 @@ func calcCRC(buf []byte) uint32 {
 }
 
 const (
-	// DefaultACL for this upload
+	// Use DefaultACL for this upload.
 	DefaultACL = false
-	// PublicRead ACL for this upload.
+	// Use PublicRead ACL for this upload.
 	PublicRead = true
+	// May cache, but only after verifying.
+	// See https://cloud.google.com/storage/docs/metadata#cache-control
+	NoCache = "no-cache"
 )
 
 // Upload writes bytes to the specified Path by converting the client and path into an ObjectHandle.

--- a/util/gcs/local_gcs_test.go
+++ b/util/gcs/local_gcs_test.go
@@ -111,7 +111,7 @@ func TestUpload_UploadsToLocalStorage(t *testing.T) {
 				t.Fatalf("Fatal error with location %v; %v", location, err)
 			}
 
-			_, err = client.Upload(ctx, *location, []byte("some-content"), false, "")
+			_, err = client.Upload(ctx, *location, []byte("some-content"), DefaultACL, NoCache)
 			if tc.ExpectErr && err == nil {
 				t.Error("Expected error, but got none")
 			}

--- a/util/gcs/sort.go
+++ b/util/gcs/sort.go
@@ -136,7 +136,7 @@ func Touch(ctx context.Context, client ConditionalClient, path Path, generation 
 
 	// New group, upload the bytes for this situation.
 	cond.DoesNotExist = true
-	return client.If(&cond, &cond).Upload(ctx, path, genZero, DefaultACL, "no-cache")
+	return client.If(&cond, &cond).Upload(ctx, path, genZero, DefaultACL, NoCache)
 }
 
 // Sort the builds by monotonically decreasing original prefix base name.

--- a/util/queue/persist.go
+++ b/util/queue/persist.go
@@ -109,7 +109,7 @@ func FixPersistent(logr logrus.FieldLogger, client PersistClient, path gcs.Path,
 			if err != nil {
 				return fmt.Errorf("marshal: %v", err)
 			}
-			attrs, err := client.Upload(ctx, path, buf, false, "")
+			attrs, err := client.Upload(ctx, path, buf, gcs.DefaultACL, gcs.NoCache)
 			if err == nil && logSave {
 				logSave = false
 				log.WithField("updated", attrs.Updated).Info("Wrote persistent state")


### PR DESCRIPTION
- Fixes a tabulator bug where old cache values can be served to critical service components
- Fixes (presumably) a similar bug with queue persistence files
- Hopefully makes the "no-cache" string a little less magic. It's not intuitive that no-cache does cache, but returns verified cache entries.