### PR TITLE
Refactor tabulator algorithm to tabulate by test group

### DIFF
--- a/cmd/tabulator/main.go
+++ b/cmd/tabulator/main.go
@@ -44,7 +44,7 @@ type options struct {
 	dropEmptyCols       bool
 	useTabAlertSettings bool
 	calculateStats      bool
-	dashboards          util.Strings
+	groups              util.Strings
 	concurrency         int
 	wait                time.Duration
 	gridPathPrefix      string
@@ -76,7 +76,7 @@ func gatherOptions() options {
 	flag.Var(&o.persistQueue, "persist-queue", "Load previous queue state from gs://path/to/queue-state.json and regularly save to it thereafter")
 	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
 	flag.BoolVar(&o.confirm, "confirm", false, "Upload data if set")
-	flag.Var(&o.dashboards, "dashboard", "Only update named dashboards if set (repeateable)")
+	flag.Var(&o.groups, "group", "Only update named test group if set (repeateable)")
 	flag.BoolVar(&o.filter, "filter", false, "Filters out data according to the tab's configuration") // TODO(chases2): Switch to default
 	flag.BoolVar(&o.dropEmptyCols, "filter-columns", false, "Drops empty columns after filtering")    // TODO(chases2): Enable, then remove flag
 	flag.BoolVar(&o.useTabAlertSettings, "tab-alerts", false, "Use newer tab settings while caculating alerts")
@@ -149,7 +149,7 @@ func main() {
 
 	mets := tabulator.CreateMetrics(prometheus.NewFactory())
 
-	if err := tabulator.Update(ctx, client, mets, opt.config, opt.concurrency, opt.gridPathPrefix, opt.tabStatePathPrefix, opt.dashboards.Strings(), opt.confirm, opt.filter, opt.dropEmptyCols, opt.calculateStats, opt.useTabAlertSettings, opt.wait, fixers...); err != nil {
+	if err := tabulator.Update(ctx, client, mets, opt.config, opt.concurrency, opt.gridPathPrefix, opt.tabStatePathPrefix, opt.groups.Strings(), opt.confirm, opt.filter, opt.dropEmptyCols, opt.calculateStats, opt.useTabAlertSettings, opt.wait, fixers...); err != nil {
 		logrus.WithError(err).Error("Could not tabulate")
 	}
 }

--- a/pkg/tabulator/persist.go
+++ b/pkg/tabulator/persist.go
@@ -30,7 +30,7 @@ import (
 func FixPersistent(log logrus.FieldLogger, client queue.PersistClient, path gcs.Path, tick <-chan time.Time) Fixer {
 	log = log.WithField("path", path)
 	fix := queue.FixPersistent(log, client, path, tick)
-	return func(ctx context.Context, iq *config.DashboardQueue) error {
+	return func(ctx context.Context, iq *config.TestGroupQueue) error {
 		return fix(ctx, &iq.Queue)
 	}
 }

--- a/pkg/tabulator/pubsub.go
+++ b/pkg/tabulator/pubsub.go
@@ -43,7 +43,7 @@ func FixGCS(client pubsub.Subscriber, log logrus.FieldLogger, projID, subID stri
 	if err != nil {
 		return nil, err
 	}
-	return func(ctx context.Context, q *config.DashboardQueue) error {
+	return func(ctx context.Context, q *config.TestGroupQueue) error {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		ch := make(chan *pubsub.Notification)
@@ -70,7 +70,7 @@ func FixGCS(client pubsub.Subscriber, log logrus.FieldLogger, projID, subID stri
 	}, nil
 }
 
-func processGCSNotifications(ctx context.Context, log logrus.FieldLogger, q *config.DashboardQueue, gridPrefix gcs.Path, senders <-chan *pubsub.Notification) error {
+func processGCSNotifications(ctx context.Context, log logrus.FieldLogger, q *config.TestGroupQueue, gridPrefix gcs.Path, senders <-chan *pubsub.Notification) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -90,7 +90,7 @@ func processGCSNotifications(ctx context.Context, log logrus.FieldLogger, q *con
 				"when":         when,
 				"notification": notice,
 			}).Trace("Fixing groups from gcs notification")
-			if err := q.FixTestGroups(when, false, *group); err != nil {
+			if err := q.Fix(*group, when, false); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Generally seems to run faster at various concurrency levels, while using similar amounts of memory.

/assign @fejta 