### PR TITLE
Tune tabulator

### DIFF
--- a/cluster/canary/tabulator.yaml
+++ b/cluster/canary/tabulator.yaml
@@ -41,10 +41,10 @@ spec:
         resources:
           requests:
             cpu: "30"
-            memory: "75G"
+            memory: "25G"
           limits:
             cpu: "40"
-            memory: "150G"
+            memory: "50G"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/cluster/prod/knative/tabulator.yaml
+++ b/cluster/prod/knative/tabulator.yaml
@@ -40,10 +40,10 @@ spec:
         resources:
           requests:
             cpu: "30"
-            memory: "75G"
+            memory: "25G"
           limits:
             cpu: "40"
-            memory: "150G"
+            memory: "50G"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/cluster/prod/tabulator.yaml
+++ b/cluster/prod/tabulator.yaml
@@ -40,10 +40,10 @@ spec:
         resources:
           requests:
             cpu: "30"
-            memory: "75G"
+            memory: "25G"
           limits:
             cpu: "40"
-            memory: "150G"
+            memory: "50G"
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Tabulator takes about 25GiB of memory on first startup, in a burst, and about 10GiB most of the time.

It is using about that much CPU when `--filter-columns` is enabled, though.