### PR TITLE
Concurrently summarize tabs in a dashboard.

### DIFF
--- a/pkg/summarizer/BUILD.bazel
+++ b/pkg/summarizer/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -295,6 +296,7 @@ func TestUpdateDashboard(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tabUpdater := tabUpdatePool(context.Background(), logrus.WithField("name", "pool"), 5)
 		t.Run(tc.name, func(t *testing.T) {
 			finder := func(dash string, tab *configpb.DashboardTab) (*gcs.Path, *configpb.TestGroup, gridReader, error) {
 				name := tab.TestGroupName
@@ -332,7 +334,7 @@ func TestUpdateDashboard(t *testing.T) {
 					},
 				}
 			}
-			updateDashboard(context.Background(), client, tc.dash, &actual, finder)
+			updateDashboard(context.Background(), client, tc.dash, &actual, finder, tabUpdater)
 			if diff := cmp.Diff(tc.expected, &actual, protocmp.Transform()); diff != "" {
 				t.Errorf("updateDashboard() got unexpected diff (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
Rather than sequentially. Also summarize all tabs for the first dashboard
before starting any of the tabs on a second dashboard.