### PR TITLE
Remove filter flag from canary

### DIFF
--- a/cluster/canary/tabulator.yaml
+++ b/cluster/canary/tabulator.yaml
@@ -33,7 +33,6 @@ spec:
         - --column-stats
         - --config=gs://k8s-testgrid-canary/config
         - --confirm
-        - --filter
         - --filter-columns
         - --json-logs
         - --persist-queue=gs://k8s-testgrid-canary/queue/tabulator.json


### PR DESCRIPTION
Default is true, so the flag does nothing.

Cannot be migrated to prod until https://github.com/GoogleCloudPlatform/testgrid/pull/951 merges.