### PR TITLE
Turn on pooled updating in canary.

### DIFF
--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -43,6 +43,7 @@ spec:
         - --group-timeout=20m
         - --json-logs
         - --persist-queue=gs://k8s-testgrid-canary/queue/updater.json
+        - --pooled
         - --reprocess-on-change
         - --subscribe=kubernetes-jenkins=kubernetes-jenkins/testgrid-canary
         - --subscribe=oss-prow=k8s-testgrid/testgrid-canary


### PR DESCRIPTION
This will concurrently download builds in test groups, instead
of serially download builds in concurrent test groups.