### PR TITLE
Improve Iter() performance.

### DIFF
--- a/pkg/summarizer/flakiness_test.go
+++ b/pkg/summarizer/flakiness_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package summarizer
 
 import (
-	"context"
 	"testing"
 
 	statepb "github.com/GoogleCloudPlatform/testgrid/pb/state"
@@ -635,7 +634,7 @@ func TestFailingColumns(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := failingColumns(context.Background(), tc.numColumns, tc.rows)
+			actual := failingColumns(tc.numColumns, tc.rows)
 			if diff := cmp.Diff(tc.expected, actual); diff != "" {
 				t.Errorf("failingColumns(ctx, %v %v) gave unexpected diff (-want +got): %s", tc.numColumns, tc.rows, diff)
 			}

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -2561,31 +2561,19 @@ func TestResultIter(t *testing.T) {
 				statuspb.TestStatus_PASS,
 			},
 		},
-		{
-			name: "cancel aborts early",
-			in: []int32{
-				int32(statuspb.TestStatus_PASS), 50,
-			},
-			cancel: 2,
-			expected: []statuspb.TestStatus{
-				statuspb.TestStatus_PASS,
-				statuspb.TestStatus_PASS,
-			},
-		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			out := resultIter(ctx, tc.in)
+			iter := result.Iter(tc.in)
 			var actual []statuspb.TestStatus
 			var idx int
-			for val := range out {
-				idx++
-				if tc.cancel > 0 && idx == tc.cancel {
-					cancel()
+			for {
+				val, ok := iter()
+				if !ok {
+					return
 				}
+				idx++
 				actual = append(actual, val)
 			}
 			if !reflect.DeepEqual(actual, tc.expected) {

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -1150,13 +1150,16 @@ func constructGridFromGroupConfig(log logrus.FieldLogger, group *configpb.TestGr
 }
 
 func dropEmptyRows(log logrus.FieldLogger, grid *statepb.Grid, rows map[string]*statepb.Row) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	filled := make([]*statepb.Row, 0, len(rows))
 	var dropped int
 	for _, r := range grid.Rows {
 		var found bool
-		for res := range result.Iter(ctx, r.Results) {
+		f := result.Iter(r.Results)
+		for {
+			res, more := f()
+			if !more {
+				break
+			}
 			if res == statuspb.TestStatus_NO_RESULT {
 				continue
 			}
@@ -1334,13 +1337,11 @@ func alertRow(cols []*statepb.Column, row *statepb.Row, failuresToOpen, passesTo
 	if failuresToOpen == 0 {
 		return nil
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	var concurrentFailures int
 	var totalFailures int32
 	var passes int
 	var compressedIdx int
-	ch := result.Iter(ctx, row.Results)
+	f := result.Iter(row.Results)
 	var firstFail *statepb.Column
 	var latestFail *statepb.Column
 	var latestPass *statepb.Column
@@ -1350,7 +1351,7 @@ func alertRow(cols []*statepb.Column, row *statepb.Row, failuresToOpen, passesTo
 	// or else failuresToOpen (alert).
 	for _, col := range cols {
 		// TODO(fejta): ignore old running
-		rawRes := <-ch
+		rawRes, _ := f()
 		res := result.Coalesce(rawRes, result.IgnoreRunning)
 		if res == statuspb.TestStatus_NO_RESULT {
 			if rawRes == statuspb.TestStatus_RUNNING {


### PR DESCRIPTION
Channels are much slower than calling a function

```
1m results:
pkg: github.com/GoogleCloudPlatform/testgrid/internal/result
BenchmarkIterSlow-10            78166888                14.90 ns/op
BenchmarkIterFast-10            759703227                1.559 ns/op

10m results:
pkg: github.com/GoogleCloudPlatform/testgrid/internal/result
BenchmarkIterSlow-10                   1        1360214667 ns/op
BenchmarkIterFast-10            728631373                1.590 ns/op
```