### PR TITLE
Drop --grid-path flag and remaining usage.

### DIFF
--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -71,7 +71,6 @@ func gatherOptions() options {
 	flag.Var(&o.dashboards, "dashboard", "Only update named dashboards if set (repeateable)")
 	flag.IntVar(&o.concurrency, "concurrency", 0, "Manually define the number of dashboards to concurrently update if non-zero")
 	flag.DurationVar(&o.wait, "wait", 0, "Ensure at least this much time has passed since the last loop (exit if zero).")
-	flag.StringVar(&o.gridPathPrefix, "grid-path", "grid", "Deprecated, stop using")
 	flag.StringVar(&o.summaryPathPrefix, "summary-path", "summary", "Write summaries under this GCS path.")
 	flag.StringVar(&o.pubsub, "pubsub", "", "listen for test group updates at project/subscription")
 	flag.StringVar(&o.tabPathPrefix, "tab-path", "tabs", "Read from tab state instead of test group")
@@ -84,7 +83,7 @@ func gatherOptions() options {
 	return o
 }
 
-func gcsFixer(ctx context.Context, projectSub string, configPath gcs.Path, gridPrefix, tabPrefix, credPath string) (summarizer.Fixer, error) {
+func gcsFixer(ctx context.Context, projectSub string, configPath gcs.Path, tabPrefix, credPath string) (summarizer.Fixer, error) {
 	if projectSub == "" {
 		return nil, nil
 	}
@@ -98,7 +97,7 @@ func gcsFixer(ctx context.Context, projectSub string, configPath gcs.Path, gridP
 		logrus.WithError(err).Fatal("Failed to create pubsub client")
 	}
 	client := pubsub.NewClient(pubsubClient)
-	return summarizer.FixGCS(client, logrus.StandardLogger(), projID, subID, configPath, gridPrefix, tabPrefix)
+	return summarizer.FixGCS(client, logrus.StandardLogger(), projID, subID, configPath, tabPrefix)
 }
 
 func main() {
@@ -132,7 +131,7 @@ func main() {
 
 	client := gcs.NewClient(storageClient)
 	metrics := summarizer.CreateMetrics(prometheus.NewFactory())
-	fixer, err := gcsFixer(ctx, opt.pubsub, opt.config, opt.gridPathPrefix, opt.tabPathPrefix, opt.creds)
+	fixer, err := gcsFixer(ctx, opt.pubsub, opt.config, opt.tabPathPrefix, opt.creds)
 	if err != nil {
 		logrus.WithError(err).WithField("subscription", opt.pubsub).Fatal("Failed to configure pubsub")
 	}

--- a/pkg/summarizer/pubsub.go
+++ b/pkg/summarizer/pubsub.go
@@ -35,15 +35,11 @@ import (
 // FixGCS listens for GCS changes to test groups and schedules another update of its dashboards ~immediately.
 //
 // Returns when the context is canceled or a processing error occurs.
-func FixGCS(client pubsub.Subscriber, log logrus.FieldLogger, projID, subID string, configPath gcs.Path, gridPathPrefix, tabPathPrefix string) (Fixer, error) {
-	if tabPathPrefix != "" {
-		gridPathPrefix = tabPathPrefix
+func FixGCS(client pubsub.Subscriber, log logrus.FieldLogger, projID, subID string, configPath gcs.Path, tabPathPrefix string) (Fixer, error) {
+	if !strings.HasSuffix(tabPathPrefix, "/") && tabPathPrefix != "" {
+		tabPathPrefix += "/"
 	}
-
-	if !strings.HasSuffix(gridPathPrefix, "/") && gridPathPrefix != "" {
-		gridPathPrefix += "/"
-	}
-	gridPath, err := configPath.ResolveReference(&url.URL{Path: gridPathPrefix})
+	gridPath, err := configPath.ResolveReference(&url.URL{Path: tabPathPrefix})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The --tab-path is always filled, so updating the fixer accordingly.
No usage of the --grid-path flag.