### PR TITLE
Calculate column stats in prod.

### DIFF
--- a/cluster/prod/tabulator.yaml
+++ b/cluster/prod/tabulator.yaml
@@ -30,6 +30,7 @@ spec:
         - name: metrics
           containerPort: 2112
         args:
+        - --column-stats
         - --config=gs://k8s-testgrid/config
         - --confirm
         - --filter-columns


### PR DESCRIPTION
Works in canary (https://testgrid.k8s.io/sigtestingmisc#test-infra-fuzz has column stats in canary)