### PR TITLE
Truncate testgroup state inline

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -114,6 +114,9 @@ func gatherFlagOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.trace, "trace", false, "Log trace and debug lines if set")
 	fs.BoolVar(&o.jsonLogs, "json-logs", false, "Uses a json logrus formatter when set")
 
+	// TODO(chases2): remove once true everywhere
+	fs.BoolVar(&updater.ShrinkInline, "shrink-inline", false, "Truncate data inline when the size limit is reached")
+
 	fs.Parse(args)
 	return o
 }


### PR DESCRIPTION
Instead of adding a "Truncated" row to indicate truncated columns, simply cut the columns and replace the last cell in each row with an "unknown" marker.