### PR TITLE
Enable features in canary

### DIFF
--- a/cluster/canary/summarizer.yaml
+++ b/cluster/canary/summarizer.yaml
@@ -44,6 +44,7 @@ spec:
         - --json-logs
         - --persist-queue=gs://k8s-testgrid-canary/queue/summarizer-tabs.json
         - --pubsub=k8s-testgrid/canary-tab-updates
+        - --skip-base-options-filter
         - --wait=1h
         resources:
           requests:

--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -43,6 +43,7 @@ spec:
         - --group-timeout=20m
         - --json-logs
         - --persist-queue=gs://k8s-testgrid-canary/queue/updater.json
+        - --shrink-inline
         - --subscribe=kubernetes-jenkins=kubernetes-jenkins/testgrid-canary
         - --subscribe=oss-prow=k8s-testgrid/testgrid-canary
         - --subscribe=istio-prow=k8s-testgrid/testgrid-canary


### PR DESCRIPTION
Enables skipping base options filtering in the summarizer (since that's been done in the tabulator for a while) and inline truncation for the updater.