### PR TITLE
Re-enable filter columns in production

### DIFF
--- a/cluster/prod/knative/tabulator.yaml
+++ b/cluster/prod/knative/tabulator.yaml
@@ -32,7 +32,7 @@ spec:
         args:
         - --config=gs://knative-own-testgrid/config
         - --confirm
-        - --filter-columns=false # TODO(#1001) Return to true when compatible with alerting
+        - --filter-columns
         - --json-logs
         - --persist-queue=gs://knative-own-testgrid/queue/tabulator.json
         - --pubsub=knative-tests/test-group-updates

--- a/cluster/prod/tabulator.yaml
+++ b/cluster/prod/tabulator.yaml
@@ -33,7 +33,7 @@ spec:
         - --column-stats
         - --config=gs://k8s-testgrid/config
         - --confirm
-        - --filter-columns=false # TODO(#1001) Return to true when compatible with alerting\
+        - --filter-columns
         - --json-logs
         - --persist-queue=gs://k8s-testgrid/queue/tabulator.json
         - --pubsub=k8s-testgrid/test-group-updates


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/testgrid/issues/1001 is resolved and alerts appear to be identical across versions

Example:
- https://external-canary-dot-k8s-testgrid.appspot.com/sig-testing-maintenance#ci-janitor
- https://testgrid.k8s.io/sig-testing-maintenance#ci-janitor