### PR TITLE
Stop filtering by regex in prod summarizer

### DIFF
--- a/cluster/prod/knative/summarizer.yaml
+++ b/cluster/prod/knative/summarizer.yaml
@@ -32,6 +32,7 @@ spec:
         - --json-logs
         - --persist-queue=gs://knative-own-testgrid/queue/summarizer-tabs.json
         - --pubsub=knative-tests/tab-updates
+        - --skip-base-options-filter
         - --wait=5m
 ---
 apiVersion: v1

--- a/cluster/prod/summarizer.yaml
+++ b/cluster/prod/summarizer.yaml
@@ -41,6 +41,7 @@ spec:
         - --json-logs
         - --persist-queue=gs://k8s-testgrid/queue/summarizer-tabs.json
         - --pubsub=k8s-testgrid/tab-updates
+        - --skip-base-options-filter
         - --wait=5m
         resources:
           requests:


### PR DESCRIPTION
Summarization appears to be identical in dashboards using `base_options`

Compare:
- https://external-canary-dot-k8s-testgrid.appspot.com/sig-storage-kubernetes#Summary
- https://testgrid.k8s.io/sig-storage-kubernetes#Summary