### PR TITLE
Remove --filter-columns flag

### DIFF
--- a/cluster/canary/tabulator.yaml
+++ b/cluster/canary/tabulator.yaml
@@ -33,7 +33,6 @@ spec:
         - --column-stats
         - --config=gs://k8s-testgrid-canary/config
         - --confirm
-        - --filter-columns
         - --json-logs
         - --persist-queue=gs://k8s-testgrid-canary/queue/tabulator.json
         - --pubsub=k8s-testgrid/canary-test-group-updates

--- a/cluster/prod/knative/tabulator.yaml
+++ b/cluster/prod/knative/tabulator.yaml
@@ -33,7 +33,6 @@ spec:
         - --column-stats
         - --config=gs://knative-own-testgrid/config
         - --confirm
-        - --filter-columns
         - --json-logs
         - --persist-queue=gs://knative-own-testgrid/queue/tabulator.json
         - --pubsub=knative-tests/test-group-updates

--- a/cluster/prod/tabulator.yaml
+++ b/cluster/prod/tabulator.yaml
@@ -33,7 +33,6 @@ spec:
         - --column-stats
         - --config=gs://k8s-testgrid/config
         - --confirm
-        - --filter-columns
         - --json-logs
         - --persist-queue=gs://k8s-testgrid/queue/tabulator.json
         - --pubsub=k8s-testgrid/test-group-updates


### PR DESCRIPTION
Flag is default on, and is already removed in some builds (ex. canary)