### PR TITLE
Remove customizable sorting from updater

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -163,7 +163,7 @@ func main() {
 	})
 	log.Info("Configured concurrency")
 
-	groupUpdater := updater.GCS(ctx, client, opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm, updater.SortStarted)
+	groupUpdater := updater.GCS(ctx, client, opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm)
 
 	mets := updater.CreateMetrics(prometheus.NewFactory())
 

--- a/pb/config/config.proto
+++ b/pb/config/config.proto
@@ -186,7 +186,7 @@ message TestGroup {
   // This is displayed on any dashboard tab backed by this test group.
   repeated Notification notifications = 27;
 
-  reserved 28; // Unused externally (column_sort_by)
+  reserved 28; // Deprecated Field (column_sort_by)
 
   enum PrimaryGrouping {
     PRIMARY_GROUPING_NONE = 0;


### PR DESCRIPTION
Since the updater and tabulator will have to agree on how columns are sorted, this is simplified by removing the rarely-used option to customize column sorting.

Due to this extra merge complexity, future column sorting features should probably be implemented in the frontend instead of the backend.