### PR TITLE
Add TimeStamp field to Result structure

### DIFF
--- a/metadata/junit/junit.go
+++ b/metadata/junit/junit.go
@@ -98,6 +98,7 @@ type Properties struct {
 type Result struct {
 	Name       string      `xml:"name,attr"`
 	Time       float64     `xml:"time,attr"`
+	TimeStamp  string      `xml:"timestamp,attr"`
 	ClassName  string      `xml:"classname,attr"`
 	Output     *string     `xml:"system-out,omitempty"`
 	Error      *string     `xml:"system-err,omitempty"`

--- a/metadata/junit/junit_test.go
+++ b/metadata/junit/junit_test.go
@@ -190,13 +190,13 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name: "parse testsuite correctly",
-			buf:  []byte(`<testsuite><testcase name="hi"/></testsuite>`),
+			buf:  []byte(`<testsuite><testcase name="hi" timestamp="2006-01-02T15:04:05"/></testsuite>`),
 			expected: &Suites{
 				Suites: []Suite{
 					{
 						XMLName: xml.Name{Local: "testsuite"},
 						Results: []Result{
-							{Name: "hi"},
+							{Name: "hi", TimeStamp:"2006-01-02T15:04:05",},
 						},
 					},
 				},


### PR DESCRIPTION
The scope of PR is to add the TimeStamp field for Result structure. The JUnit XML format does not have the timestamp as an attribute.
This field will give us the start time for each test.
It will be used to group all the tests that faill with all the tests that run in the same time.