### PR TITLE
Support bazel format junit files

### DIFF
--- a/util/gcs/read.go
+++ b/util/gcs/read.go
@@ -277,7 +277,7 @@ func ListBuilds(parent context.Context, lister Lister, gcsPath Path, after *Path
 }
 
 // junit_CONTEXT_TIMESTAMP_THREAD.xml
-var re = regexp.MustCompile(`.+/junit((_[^_]+)?(_\d+-\d+)?(_\d+)?|.+)?\.xml$`)
+var re = regexp.MustCompile(`.+/(?:junit((_[^_]+)?(_\d+-\d+)?(_\d+)?|.+)?\.xml|test.xml)$`)
 
 // dropPrefix removes the _ in _CONTEXT to help keep the regexp simple
 func dropPrefix(name string) string {

--- a/util/gcs/read_test.go
+++ b/util/gcs/read_test.go
@@ -674,6 +674,10 @@ func TestParseSuitesMeta(t *testing.T) {
 			input:   "./junit.e2e_suite.3.xml",
 			context: ".e2e_suite.3",
 		},
+		{
+			name:  "bazel format",
+			input: "./test.xml",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This extends the junit discovery regex to support bazel's test.xml
naming scheme. With this bazel users do not need to workaround
testgrid's junit_* prefix requirements and can directly run against
bazel-testlogs/ directory's output.