### PR TITLE
Reduce flakiness in metrics_test.

### DIFF
--- a/util/metrics/metrics_test.go
+++ b/util/metrics/metrics_test.go
@@ -89,7 +89,7 @@ func TestCyclic(t *testing.T) {
 				cycleSeconds: &cycleDuration,
 			}
 
-			fudge := 100 * time.Millisecond
+			fudge := 200 * time.Millisecond
 
 			test.method(cyclic)
 


### PR DESCRIPTION
Increasing fudge factor, since sometimes this test flakes with a value slightly over 100 milliseconds (e.g. 112 or so). 200 should be plenty.