### PR TITLE
Implement tab state extension

### DIFF
--- a/benchmark/tabulator_bench_test.go
+++ b/benchmark/tabulator_bench_test.go
@@ -53,7 +53,7 @@ func BenchmarkTabulator(b *testing.B) {
 
 	mets := tabulator.CreateMetrics(prometheus.NewFactory()) // TODO(chases2): replace with logging metrics factory or teach tabulator to tolerate missing metrics
 
-	if err = tabulator.Update(ctx, client, mets, *cfgPath, 2*runtime.NumCPU(), 4*runtime.NumCPU(), "grid", "tabs", nil, true, true, true, time.Duration(0)); err != nil {
+	if err = tabulator.Update(ctx, client, mets, *cfgPath, 2*runtime.NumCPU(), 4*runtime.NumCPU(), "grid", "tabs", nil, true, true, true, false, time.Duration(0)); err != nil {
 		b.Fatalf("update error: %v", err)
 	}
 }

--- a/cmd/tabulator/main.go
+++ b/cmd/tabulator/main.go
@@ -42,6 +42,7 @@ type options struct {
 	confirm             bool
 	useTabAlertSettings bool
 	calculateStats      bool
+	extendState         bool
 	groups              util.Strings
 	readConcurrency     int
 	writeConcurrency    int
@@ -81,6 +82,7 @@ func gatherOptions() options {
 	flag.Var(&o.groups, "group", "Only update named test group if set (repeateable)")
 	flag.BoolVar(&o.useTabAlertSettings, "tab-alerts", false, "Use newer tab settings while caculating alerts")
 	flag.BoolVar(&o.calculateStats, "column-stats", true, "Calculates stats for broken columns")
+	flag.BoolVar(&o.extendState, "extend", false, "Extend tab state instead of replacing it")
 
 	flag.IntVar(&o.readConcurrency, "read-concurrency", 0, "Manually define the number of groups to read and hold in memory at once if non-zero")
 	flag.IntVar(&o.writeConcurrency, "concurrency", 0, "Manually define the number of tabs to concurrently update if non-zero")
@@ -153,7 +155,7 @@ func main() {
 
 	mets := tabulator.CreateMetrics(prometheus.NewFactory())
 
-	if err := tabulator.Update(ctx, client, mets, opt.config, opt.readConcurrency, opt.writeConcurrency, opt.gridPathPrefix, opt.tabStatePathPrefix, opt.groups.Strings(), opt.confirm, opt.calculateStats, opt.useTabAlertSettings, opt.wait, fixers...); err != nil {
+	if err := tabulator.Update(ctx, client, mets, opt.config, opt.readConcurrency, opt.writeConcurrency, opt.gridPathPrefix, opt.tabStatePathPrefix, opt.groups.Strings(), opt.confirm, opt.calculateStats, opt.useTabAlertSettings, opt.extendState, opt.wait, fixers...); err != nil {
 		logrus.WithError(err).Error("Could not tabulate")
 	}
 }


### PR DESCRIPTION
`--extend` on the Tabulator will now cause the tabulator to extend state with the information in the updater instead of simply overwriting it.

This feature is most useful for tabs with aggressive filtering: that freed up space can be used now to store more history.