### PR TITLE
Throtle concurrency of tabulator to match updater in canary

### DIFF
--- a/cluster/canary/tabulator.yaml
+++ b/cluster/canary/tabulator.yaml
@@ -36,7 +36,9 @@ spec:
         - --json-logs
         - --persist-queue=gs://k8s-testgrid-canary/queue/tabulator.json
         - --pubsub=k8s-testgrid/canary-test-group-updates
+        - --read-concurrency=10
         - --wait=15m
+        - --write-concurrency=10
         resources:
           requests:
             cpu: "30"


### PR DESCRIPTION
We're currently using a concurrency of 65 reading threads and 128 writing threads. The updater is running with a pool of 10 threads. No need to go so hard!

I suspect the tabulator keeping 65 states inflated and in-memory is why the tabulator is running [out of memory](https://github.com/GoogleCloudPlatform/testgrid/issues/1089) and the updater is _well_ under its request.