### PR TITLE
Cache default config as map in API component

### DIFF
--- a/config/cache.go
+++ b/config/cache.go
@@ -30,6 +30,8 @@ import (
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 )
 
+// TODO(slchase): remove
+// This "eventual consistency" isn't as useful for the utilities that are using Read() or ReadGCS(). Complex cases are handled by the snapshot library.
 var (
 	cache     map[string]Config
 	cacheLock sync.RWMutex

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,7 @@ func (e ValidationError) Error() string {
 }
 
 // Normalize lowercases, and removes all non-alphanumeric characters from a string.
+// WARNING: Unless you are validating config or sanitizing API input, avoid using normalization. Bare names are acceptable keys.
 func Normalize(s string) string {
 	regex := regexp.MustCompile("[^a-zA-Z0-9]+")
 	s = regex.ReplaceAllString(s, "")

--- a/pkg/api/v1/BUILD.bazel
+++ b/pkg/api/v1/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "config_cache.go",
         "json.go",
         "server.go",
         "server_fake.go",
@@ -44,17 +45,20 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "config_cache_test.go",
         "config_http_test.go",
         "config_test.go",
         "state_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//config/snapshot:go_default_library",
         "//pb/api/v1:go_default_library",
         "//pb/config:go_default_library",
         "//pb/state:go_default_library",
         "//util/gcs:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@org_golang_google_protobuf//testing/protocmp:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],

--- a/pkg/api/v1/config_cache.go
+++ b/pkg/api/v1/config_cache.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1 (api/v1) is the first versioned implementation of the API
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleCloudPlatform/testgrid/config"
+	"github.com/GoogleCloudPlatform/testgrid/config/snapshot"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+)
+
+const reobservationTime = 2 * time.Minute
+
+// Cached contains a config and a mapping of "normalized" names to actual resources.
+// Avoid using normalized names: normalization is costly and the raw name itself works better as a key.
+// Used within the API to sanitize inputs: ie. "dashboards/mytab" matches "My Tab"
+type cachedConfig struct {
+	Config               *snapshot.Config
+	NormalDashboardGroup map[string]string
+	NormalDashboard      map[string]string
+	NormalDashboardTab   map[string]map[string]string // Normal dashboard name AND normal tab name
+	NormalTestGroup      map[string]string
+	Mutex                sync.RWMutex
+}
+
+func (c *cachedConfig) generateNormalCache() {
+	if c == nil || c.Config == nil {
+		return
+	}
+
+	c.NormalDashboardGroup = make(map[string]string, len(c.Config.DashboardGroups))
+	c.NormalDashboard = make(map[string]string, len(c.Config.Dashboards))
+	c.NormalTestGroup = make(map[string]string, len(c.Config.Groups))
+	c.NormalDashboardTab = make(map[string]map[string]string, len(c.Config.Dashboards))
+
+	for name := range c.Config.DashboardGroups {
+		c.NormalDashboardGroup[config.Normalize(name)] = name
+	}
+
+	for name := range c.Config.Dashboards {
+		normalName := config.Normalize((name))
+		c.NormalDashboard[normalName] = name
+		c.NormalDashboardTab[normalName] = make(map[string]string, len(c.Config.Dashboards[name].DashboardTab))
+		for _, tab := range c.Config.Dashboards[name].DashboardTab {
+			normalTabName := config.Normalize((tab.Name))
+			c.NormalDashboardTab[normalName][normalTabName] = tab.Name
+		}
+	}
+
+	for name := range c.Config.Groups {
+		c.NormalTestGroup[config.Normalize(name)] = name
+	}
+}
+
+func (s *Server) configPath(scope string) (path *gcs.Path, isDefault bool, err error) {
+	if scope != "" {
+		path, err = gcs.NewPath(fmt.Sprintf("%s/%s", scope, "config"))
+		return path, false, err
+	}
+	if s.DefaultBucket != "" {
+		path, err = gcs.NewPath(fmt.Sprintf("%s/%s", s.DefaultBucket, "config"))
+		return path, true, err
+	}
+	return nil, false, errors.New("no testgrid scope")
+}
+
+// getConfig will return a config or an error. The config contains a mutex that you should RLock before reading.
+// Does not expose wrapped errors to the user, instead logging them to the console.
+func (s *Server) getConfig(ctx context.Context, log *logrus.Entry, scope string) (*cachedConfig, error) {
+	configPath, isDefault, err := s.configPath(scope)
+	if err != nil || configPath == nil {
+		return nil, errors.New("Scope not specified")
+	}
+
+	if isDefault {
+		if s.defaultCache == nil || s.defaultCache.Config == nil {
+			log = log.WithField("config-path", configPath.String())
+			configChanged, err := snapshot.Observe(ctx, log, s.Client, *configPath, time.NewTicker(reobservationTime).C)
+			if err != nil {
+				log.WithError(err).Errorf("Can't read default config; check permissions")
+				return nil, fmt.Errorf("Could not read config at %q", configPath.String())
+			}
+
+			s.defaultCache = &cachedConfig{
+				Config: <-configChanged,
+			}
+			s.defaultCache.generateNormalCache()
+
+			log.Info("Observing default config")
+			go func(ctx context.Context) {
+				for {
+					select {
+					case newCfg := <-configChanged:
+						s.defaultCache.Mutex.Lock()
+						s.defaultCache.Config = newCfg
+						s.defaultCache.generateNormalCache()
+						log.Info("Observed config updated")
+						s.defaultCache.Mutex.Unlock()
+					case <-ctx.Done():
+						return
+					}
+				}
+			}(ctx)
+
+		}
+		return s.defaultCache, nil
+	}
+
+	cfgChan, err := snapshot.Observe(ctx, log, s.Client, *configPath, nil)
+	if err != nil {
+		// Do not log; invalid requests will write useless logs.
+		return nil, fmt.Errorf("Could not read config at %q", configPath.String())
+	}
+
+	result := cachedConfig{
+		Config: <-cfgChan,
+	}
+	result.generateNormalCache()
+	return &result, nil
+}

--- a/pkg/api/v1/config_cache_test.go
+++ b/pkg/api/v1/config_cache_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2022 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/testgrid/config/snapshot"
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestGenerateNormalCache(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *snapshot.Config
+		expected *cachedConfig
+	}{
+		{
+			name:     "Generate nothing for nil config",
+			expected: &cachedConfig{},
+		},
+		{
+			name: "Generate empty sets for empty config",
+			cfg:  &snapshot.Config{},
+			expected: &cachedConfig{
+				NormalDashboardGroup: map[string]string{},
+				NormalDashboard:      map[string]string{},
+				NormalTestGroup:      map[string]string{},
+				NormalDashboardTab:   map[string]map[string]string{},
+			},
+		},
+		{
+			name: "Generate normalized names for all things",
+			cfg: &snapshot.Config{
+				DashboardGroups: map[string]*configpb.DashboardGroup{
+					"My Dashboard Group": {Name: "My Dashboard Group"},
+				},
+				Dashboards: map[string]*configpb.Dashboard{
+					"Chessboard ♟️♙": {
+						Name: "Chessboard ♟️♙",
+						DashboardTab: []*configpb.DashboardTab{
+							{Name: "Pawns ♟️"},
+							{Name: "Knights ♞"},
+						},
+					},
+				},
+				Groups: map[string]*configpb.TestGroup{
+					"Groups: 一緒にあるいくつかのこと": {Name: "Groups: 一緒にあるいくつかのこと"},
+				},
+			},
+			expected: &cachedConfig{
+				NormalDashboardGroup: map[string]string{
+					"mydashboardgroup": "My Dashboard Group",
+				},
+				NormalDashboard: map[string]string{
+					"chessboard": "Chessboard ♟️♙",
+				},
+				NormalTestGroup: map[string]string{
+					"groups": "Groups: 一緒にあるいくつかのこと",
+				},
+				NormalDashboardTab: map[string]map[string]string{
+					"chessboard": {
+						"pawns":   "Pawns ♟️",
+						"knights": "Knights ♞",
+					},
+				},
+			},
+		},
+		{
+			name: "Tolerate dashboards with the same normalized tab name",
+			cfg: &snapshot.Config{
+				Dashboards: map[string]*configpb.Dashboard{
+					"Black Pieces": {
+						Name: "Black Pieces",
+						DashboardTab: []*configpb.DashboardTab{
+							{Name: "Pawns ♟️"},
+							{Name: "Knights ♞"},
+						},
+					},
+					"White Pieces": {
+						Name: "White Pieces",
+						DashboardTab: []*configpb.DashboardTab{
+							{Name: "Pawns ♙"},
+							{Name: "Knights ♘"},
+						},
+					},
+				},
+			},
+			expected: &cachedConfig{
+				NormalDashboardGroup: map[string]string{},
+				NormalTestGroup:      map[string]string{},
+				NormalDashboard: map[string]string{
+					"blackpieces": "Black Pieces",
+					"whitepieces": "White Pieces",
+				},
+				NormalDashboardTab: map[string]map[string]string{
+					"blackpieces": {
+						"pawns":   "Pawns ♟️",
+						"knights": "Knights ♞",
+					},
+					"whitepieces": {
+						"pawns":   "Pawns ♙",
+						"knights": "Knights ♘",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := cachedConfig{
+				Config: tc.cfg,
+			}
+			cache.generateNormalCache()
+
+			if diff := cmp.Diff(&cache, tc.expected, cmpopts.IgnoreFields(cachedConfig{}, "Config", "Mutex")); diff != "" {
+				t.Errorf("Unexpected Diff: (-got, +want): %s", diff)
+			}
+		})
+	}
+}
+
+func TestConfigPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultBucket string
+		scopeParam    string
+		expected      *gcs.Path
+		expectDefault bool
+	}{
+		{
+			name:          "Defaults to default",
+			defaultBucket: "gs://example",
+			expected:      getPathOrDie(t, "gs://example/config"),
+			expectDefault: true,
+		},
+		{
+			name:          "Use config if specified",
+			defaultBucket: "gs://wrong",
+			scopeParam:    "gs://example/path",
+			expected:      getPathOrDie(t, "gs://example/path/config"),
+		},
+		{
+			name:       "Do not require a default",
+			scopeParam: "gs://example/path",
+			expected:   getPathOrDie(t, "gs://example/path/config"),
+		},
+		{
+			name: "Return error if no way to find config",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := Server{
+				DefaultBucket: test.defaultBucket,
+			}
+
+			result, isDefault, err := s.configPath(test.scopeParam)
+			if test.expected == nil && err == nil {
+				t.Fatalf("Expected an error, but got none")
+			}
+
+			if test.expectDefault != isDefault {
+				t.Errorf("Default Flag: Want %t, got %t", test.expectDefault, isDefault)
+			}
+
+			if test.expected != nil && result.String() != test.expected.String() {
+				t.Errorf("Want %s, but got %s", test.expected.String(), result.String())
+			}
+		})
+	}
+}

--- a/pkg/api/v1/config_test.go
+++ b/pkg/api/v1/config_test.go
@@ -28,57 +28,6 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
-func TestConfigPath(t *testing.T) {
-	tests := []struct {
-		name          string
-		defaultBucket string
-		scopeParam    string
-		expected      *gcs.Path
-		expectDefault bool
-	}{
-		{
-			name:          "Defaults to default",
-			defaultBucket: "gs://example",
-			expected:      getPathOrDie(t, "gs://example/config"),
-			expectDefault: true,
-		},
-		{
-			name:          "Use config if specified",
-			defaultBucket: "gs://wrong",
-			scopeParam:    "gs://example/path",
-			expected:      getPathOrDie(t, "gs://example/path/config"),
-		},
-		{
-			name:       "Do not require a default",
-			scopeParam: "gs://example/path",
-			expected:   getPathOrDie(t, "gs://example/path/config"),
-		},
-		{
-			name: "Return error if no way to find config",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			s := Server{
-				DefaultBucket: test.defaultBucket,
-			}
-
-			result, isDefault, err := s.configPath(test.scopeParam)
-			if test.expected == nil && err == nil {
-				t.Fatalf("Expected an error, but got none")
-			}
-
-			if test.expectDefault != isDefault {
-				t.Errorf("Default Flag: Want %t, got %t", test.expectDefault, isDefault)
-			}
-
-			if test.expected != nil && result.String() != test.expected.String() {
-				t.Errorf("Want %s, but got %s", test.expected.String(), result.String())
-			}
-		})
-	}
-}
-
 func getPathOrDie(t *testing.T, s string) *gcs.Path {
 	t.Helper()
 	path, err := gcs.NewPath(s)

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	TabPathPrefix            string
 	AccessControlAllowOrigin string
 	Timeout                  time.Duration
+	defaultCache             *cachedConfig
 }
 
 // Ensure the server implementation conforms to the API


### PR DESCRIPTION
Includes #1086; see second commit for review

Keeps a normalization cache for the API component only. For default configs, increases the normalization cost to constant instead of O(dashboard) or O(dashboard * tabs)

For non-default configs, front-loads the normalization needed without benefit. Keeping multiple cached configs in an expiring cache object in a later PR would improve repeated, non-default calls.