### PR TITLE
Add health check to API

### DIFF
--- a/pkg/api/BUILD.bazel
+++ b/pkg/api/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -31,4 +31,10 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["router_http_test.go"],
+    embed = [":go_default_library"],
 )

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -20,6 +20,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -55,6 +56,9 @@ func GetRouters(options RouterOptions, storageClient *storage.Client) (*mux.Rout
 	}
 
 	router := mux.NewRouter()
+	router.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("OK"))
+	})
 	sub1 := router.PathPrefix(v1InfixRef).Subrouter()
 	v1.Route(sub1, *server)
 
@@ -63,7 +67,7 @@ func GetRouters(options RouterOptions, storageClient *storage.Client) (*mux.Rout
 	v1pb.RegisterTestGridDataServer(grpcServer, server)
 	reflection.Register(grpcServer)
 
-	return sub1, grpcServer, nil
+	return router, grpcServer, nil
 }
 
 // GetServer returns a server that serves TestGrid's API

--- a/pkg/api/router_http_test.go
+++ b/pkg/api/router_http_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package api provides code to host an API displaying TestGrid data
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealth(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		expectedCode int
+	}{
+		{
+			name:         "Returns a healthiness check at '/'",
+			path:         "/",
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "Return 404 to nonsense",
+			path:         "/ipa/v1/derp",
+			expectedCode: http.StatusNotFound,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router, _, err := GetRouters(RouterOptions{}, nil)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			request, err := http.NewRequest("GET", test.path, nil)
+			if err != nil {
+				t.Fatalf("Can't form request: %v", err)
+			}
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			if response.Code != test.expectedCode {
+				t.Errorf("Expected %d, but got %d", test.expectedCode, response.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a simple "OK" health check when you hit the API with no path.

Allows Ingresses to recognize the API as "healthy"; default health checks will return 200 instead of 404