### PR TITLE
Implement ignore_skip to exclude skipped results.

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -51,6 +51,7 @@ type options struct {
 	gridPrefix       string
 	subscriptions    util.Strings
 	reprocessList    util.Strings
+	enableIgnoreSkip bool
 
 	debug    bool
 	trace    bool
@@ -110,6 +111,8 @@ func gatherFlagOptions(fs *flag.FlagSet, args ...string) options {
 	fs.DurationVar(&o.buildTimeout, "build-timeout", 3*time.Minute, "Maximum time to wait to read each build")
 	fs.StringVar(&o.gridPrefix, "grid-prefix", "grid", "Join this with the grid name to create the GCS suffix")
 
+	fs.BoolVar(&o.enableIgnoreSkip, "enable-ignore-skip", false, "If true, enable ignore_skip behavior.")
+
 	fs.BoolVar(&o.debug, "debug", false, "Log debug lines if set")
 	fs.BoolVar(&o.trace, "trace", false, "Log trace and debug lines if set")
 	fs.BoolVar(&o.jsonLogs, "json-logs", false, "Uses a json logrus formatter when set")
@@ -160,7 +163,7 @@ func main() {
 	})
 	log.Info("Configured concurrency")
 
-	groupUpdater := updater.GCS(ctx, client, opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm)
+	groupUpdater := updater.GCS(ctx, client, opt.groupTimeout, opt.buildTimeout, opt.buildConcurrency, opt.confirm, opt.enableIgnoreSkip)
 
 	mets := updater.CreateMetrics(prometheus.NewFactory())
 

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -88,7 +88,7 @@ func (mets *Metrics) start() *metrics.CycleReporter {
 type GroupUpdater func(parent context.Context, log logrus.FieldLogger, client gcs.Client, tg *configpb.TestGroup, gridPath gcs.Path) (bool, error)
 
 // GCS returns a GCS-based GroupUpdater, which knows how to process result data stored in GCS.
-func GCS(poolCtx context.Context, colClient gcs.Client, groupTimeout, buildTimeout time.Duration, concurrency int, write bool) GroupUpdater {
+func GCS(poolCtx context.Context, colClient gcs.Client, groupTimeout, buildTimeout time.Duration, concurrency int, write bool, enableIgnoreSkip bool) GroupUpdater {
 	var readResult *resultReader
 	if poolCtx == nil {
 		// TODO(fejta): remove check soon
@@ -103,7 +103,7 @@ func GCS(poolCtx context.Context, colClient gcs.Client, groupTimeout, buildTimeo
 		}
 		ctx, cancel := context.WithTimeout(parent, groupTimeout)
 		defer cancel()
-		gcsColReader := gcsColumnReader(colClient, buildTimeout, readResult)
+		gcsColReader := gcsColumnReader(colClient, buildTimeout, readResult, enableIgnoreSkip)
 		reprocess := 20 * time.Minute // allow 20m for prow to finish uploading artifacts
 		return InflateDropAppend(ctx, log, client, tg, gridPath, write, gcsColReader, reprocess)
 	}

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -95,7 +95,7 @@ func TestGCS(t *testing.T) {
 					}
 				}
 			}()
-			updater := GCS(tc.ctx, nil, 0, 0, 0, false)
+			updater := GCS(tc.ctx, nil, 0, 0, 0, false, false)
 			_, err := updater(ctx, logrus.WithField("case", tc.name), nil, tc.group, gcs.Path{})
 			switch {
 			case err != nil:
@@ -425,7 +425,7 @@ func TestUpdate(t *testing.T) {
 			if tc.groupUpdater == nil {
 				poolCtx, poolCancel := context.WithCancel(context.Background())
 				defer poolCancel()
-				tc.groupUpdater = GCS(poolCtx, client, *tc.groupTimeout, *tc.buildTimeout, tc.buildConcurrency, !tc.skipConfirm)
+				tc.groupUpdater = GCS(poolCtx, client, *tc.groupTimeout, *tc.buildTimeout, tc.buildConcurrency, !tc.skipConfirm, false)
 			}
 			err := Update(
 				ctx,
@@ -2159,7 +2159,7 @@ func TestInflateDropAppend(t *testing.T) {
 			}
 			client.Lister[buildsPath] = fi
 
-			colReader := gcsColumnReader(client, *tc.buildTimeout, readResult)
+			colReader := gcsColumnReader(client, *tc.buildTimeout, readResult, false)
 			if tc.colReader != nil {
 				colReader = tc.colReader(tc.builds)
 			}


### PR DESCRIPTION
This is flag-guarded so the behavior will not kick in until the flag is set on deployment. Adding this so ignored results properly get excluded when specified in config.