### PR TITLE
Added nanos to timestamp when converting

### DIFF
--- a/pkg/api/v1/summary.go
+++ b/pkg/api/v1/summary.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -47,16 +48,20 @@ var (
 
 // convertSummary converts the tab summary from storage format (summary.proto) to wire format (data.proto)
 func convertSummary(tabSummary *summarypb.DashboardTabSummary) *apipb.TabSummary {
+	RSeconds, RNanos := math.Modf(tabSummary.LastRunTimestamp)
+	USeconds, UNanos := math.Modf(tabSummary.LastUpdateTimestamp)
 	return &apipb.TabSummary{
 		DashboardName:         tabSummary.DashboardName,
 		TabName:               tabSummary.DashboardTabName,
 		OverallStatus:         tabStatusStr[tabSummary.OverallStatus],
 		DetailedStatusMessage: tabSummary.Status,
 		LastRunTimestamp: &timestamp.Timestamp{
-			Seconds: int64(tabSummary.LastRunTimestamp),
+			Seconds: int64(RSeconds),
+			Nanos:   int32(RNanos * 1e9),
 		},
 		LastUpdateTimestamp: &timestamp.Timestamp{
-			Seconds: int64(tabSummary.LastUpdateTimestamp),
+			Seconds: int64(USeconds),
+			Nanos:   int32(UNanos * 1e9),
 		},
 		LatestPassingBuild: tabSummary.LatestGreen,
 	}

--- a/pkg/api/v1/summary.go
+++ b/pkg/api/v1/summary.go
@@ -48,20 +48,20 @@ var (
 
 // convertSummary converts the tab summary from storage format (summary.proto) to wire format (data.proto)
 func convertSummary(tabSummary *summarypb.DashboardTabSummary) *apipb.TabSummary {
-	RSeconds, RNanos := math.Modf(tabSummary.LastRunTimestamp)
-	USeconds, UNanos := math.Modf(tabSummary.LastUpdateTimestamp)
+	LastRunSeconds, LastRunNanos := math.Modf(tabSummary.LastRunTimestamp)
+	LastUpdateSeconds, LastUpdateNanos := math.Modf(tabSummary.LastUpdateTimestamp)
 	return &apipb.TabSummary{
 		DashboardName:         tabSummary.DashboardName,
 		TabName:               tabSummary.DashboardTabName,
 		OverallStatus:         tabStatusStr[tabSummary.OverallStatus],
 		DetailedStatusMessage: tabSummary.Status,
 		LastRunTimestamp: &timestamp.Timestamp{
-			Seconds: int64(RSeconds),
-			Nanos:   int32(RNanos * 1e9),
+			Seconds: int64(LastRunSeconds),
+			Nanos:   int32(LastRunNanos * 1e9),
 		},
 		LastUpdateTimestamp: &timestamp.Timestamp{
-			Seconds: int64(USeconds),
-			Nanos:   int32(UNanos * 1e9),
+			Seconds: int64(LastUpdateSeconds),
+			Nanos:   int32(LastUpdateNanos * 1e9),
 		},
 		LatestPassingBuild: tabSummary.LatestGreen,
 	}

--- a/pkg/api/v1/summary_test.go
+++ b/pkg/api/v1/summary_test.go
@@ -103,8 +103,8 @@ func TestListTabSummaries(t *testing.T) {
 							Status:              "1/7 tests are passing!",
 							OverallStatus:       summarypb.DashboardTabSummary_FLAKY,
 							LatestGreen:         "Hulk",
-							LastUpdateTimestamp: float64(915166800),
-							LastRunTimestamp:    float64(915166800),
+							LastUpdateTimestamp: float64(916166800.916166782),
+							LastRunTimestamp:    float64(916166800.916166782),
 						},
 						{
 							DashboardName:       "Marco",
@@ -112,8 +112,8 @@ func TestListTabSummaries(t *testing.T) {
 							Status:              "1/7 tests are failing!",
 							OverallStatus:       summarypb.DashboardTabSummary_ACCEPTABLE,
 							LatestGreen:         "Lantern",
-							LastUpdateTimestamp: float64(916166800),
-							LastRunTimestamp:    float64(916166800),
+							LastUpdateTimestamp: float64(916166800.916166782),
+							LastRunTimestamp:    float64(916166800.916166782),
 						},
 					},
 				},
@@ -131,9 +131,11 @@ func TestListTabSummaries(t *testing.T) {
 						LatestPassingBuild:    "Hulk",
 						LastRunTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
+							Nanos:   916166782,
 						},
 						LastUpdateTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
+							Nanos:   916166782,
 						},
 					},
 					{
@@ -144,9 +146,11 @@ func TestListTabSummaries(t *testing.T) {
 						LatestPassingBuild:    "Lantern",
 						LastRunTimestamp: &timestamp.Timestamp{
 							Seconds: 916166800,
+							Nanos:   0,
 						},
 						LastUpdateTimestamp: &timestamp.Timestamp{
 							Seconds: 916166800,
+							Nanos:   0,
 						},
 					},
 				},
@@ -351,9 +355,11 @@ func GetTabSummary(t *testing.T) {
 					LatestPassingBuild:    "Hulk",
 					LastRunTimestamp: &timestamp.Timestamp{
 						Seconds: 915166800,
+						Nanos:   0,
 					},
 					LastUpdateTimestamp: &timestamp.Timestamp{
 						Seconds: 915166800,
+						Nanos:   0,
 					},
 				},
 			},
@@ -487,9 +493,11 @@ func TestListTabSummariesHTTP(t *testing.T) {
 						LatestPassingBuild:    "Hulk",
 						LastUpdateTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
+							Nanos:   0,
 						},
 						LastRunTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
+							Nanos:   0,
 						},
 					},
 					{
@@ -500,9 +508,11 @@ func TestListTabSummariesHTTP(t *testing.T) {
 						LatestPassingBuild:    "Lantern",
 						LastUpdateTimestamp: &timestamp.Timestamp{
 							Seconds: 916166800,
+							Nanos:   0,
 						},
 						LastRunTimestamp: &timestamp.Timestamp{
 							Seconds: 916166800,
+							Nanos:   0,
 						},
 					},
 				},
@@ -552,9 +562,11 @@ func TestListTabSummariesHTTP(t *testing.T) {
 						LatestPassingBuild:    "Hulk",
 						LastUpdateTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
+							Nanos:   0,
 						},
 						LastRunTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
+							Nanos:   0,
 						},
 					},
 				},

--- a/pkg/api/v1/summary_test.go
+++ b/pkg/api/v1/summary_test.go
@@ -89,6 +89,14 @@ func TestListTabSummaries(t *testing.T) {
 									Name:          "polo-2",
 									TestGroupName: "tiramisu",
 								},
+								{
+									Name:          "polo-3",
+									TestGroupName: "donut",
+								},
+								{
+									Name:          "polo-4",
+									TestGroupName: "brownie",
+								},
 							},
 						},
 					},
@@ -103,17 +111,35 @@ func TestListTabSummaries(t *testing.T) {
 							Status:              "1/7 tests are passing!",
 							OverallStatus:       summarypb.DashboardTabSummary_FLAKY,
 							LatestGreen:         "Hulk",
-							LastUpdateTimestamp: float64(916166800.916166782),
-							LastRunTimestamp:    float64(916166800.916166782),
+							LastUpdateTimestamp: float64(915166800.916166782),
+							LastRunTimestamp:    float64(915166800.916166782),
 						},
 						{
 							DashboardName:       "Marco",
 							DashboardTabName:    "polo-2",
+							Status:              "1/7 tests are passing!",
+							OverallStatus:       summarypb.DashboardTabSummary_ACCEPTABLE,
+							LatestGreen:         "Lantern",
+							LastUpdateTimestamp: float64(0.1),
+							LastRunTimestamp:    float64(0.1),
+						},
+						{
+							DashboardName:       "Marco",
+							DashboardTabName:    "polo-3",
+							Status:              "1/7 tests are passing!",
+							OverallStatus:       summarypb.DashboardTabSummary_ACCEPTABLE,
+							LatestGreen:         "Hulk",
+							LastUpdateTimestamp: float64(916166800),
+							LastRunTimestamp:    float64(916166800),
+						},
+						{
+							DashboardName:       "Marco",
+							DashboardTabName:    "polo-4",
 							Status:              "1/7 tests are failing!",
 							OverallStatus:       summarypb.DashboardTabSummary_ACCEPTABLE,
 							LatestGreen:         "Lantern",
-							LastUpdateTimestamp: float64(916166800.916166782),
-							LastRunTimestamp:    float64(916166800.916166782),
+							LastUpdateTimestamp: float64(0.916166782),
+							LastRunTimestamp:    float64(0.916166782),
 						},
 					},
 				},
@@ -141,16 +167,40 @@ func TestListTabSummaries(t *testing.T) {
 					{
 						DashboardName:         "Marco",
 						TabName:               "polo-2",
+						DetailedStatusMessage: "1/7 tests are passing!",
+						OverallStatus:         "ACCEPTABLE",
+						LatestPassingBuild:    "Lantern",
+						LastRunTimestamp: &timestamp.Timestamp{
+							Nanos: 100000000,
+						},
+						LastUpdateTimestamp: &timestamp.Timestamp{
+							Nanos: 100000000,
+						},
+					},
+					{
+						DashboardName:         "Marco",
+						TabName:               "polo-3",
+						DetailedStatusMessage: "1/7 tests are passing!",
+						OverallStatus:         "ACCEPTABLE",
+						LatestPassingBuild:    "Hulk",
+						LastRunTimestamp: &timestamp.Timestamp{
+							Seconds: 916166800,
+						},
+						LastUpdateTimestamp: &timestamp.Timestamp{
+							Seconds: 916166800,
+						},
+					},
+					{
+						DashboardName:         "Marco",
+						TabName:               "polo-4",
 						DetailedStatusMessage: "1/7 tests are failing!",
 						OverallStatus:         "ACCEPTABLE",
 						LatestPassingBuild:    "Lantern",
 						LastRunTimestamp: &timestamp.Timestamp{
-							Seconds: 916166800,
-							Nanos:   0,
+							Nanos: 916166782,
 						},
 						LastUpdateTimestamp: &timestamp.Timestamp{
-							Seconds: 916166800,
-							Nanos:   0,
+							Nanos: 916166782,
 						},
 					},
 				},
@@ -355,11 +405,9 @@ func GetTabSummary(t *testing.T) {
 					LatestPassingBuild:    "Hulk",
 					LastRunTimestamp: &timestamp.Timestamp{
 						Seconds: 915166800,
-						Nanos:   0,
 					},
 					LastUpdateTimestamp: &timestamp.Timestamp{
 						Seconds: 915166800,
-						Nanos:   0,
 					},
 				},
 			},
@@ -493,11 +541,9 @@ func TestListTabSummariesHTTP(t *testing.T) {
 						LatestPassingBuild:    "Hulk",
 						LastUpdateTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
-							Nanos:   0,
 						},
 						LastRunTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
-							Nanos:   0,
 						},
 					},
 					{
@@ -508,11 +554,9 @@ func TestListTabSummariesHTTP(t *testing.T) {
 						LatestPassingBuild:    "Lantern",
 						LastUpdateTimestamp: &timestamp.Timestamp{
 							Seconds: 916166800,
-							Nanos:   0,
 						},
 						LastRunTimestamp: &timestamp.Timestamp{
 							Seconds: 916166800,
-							Nanos:   0,
 						},
 					},
 				},
@@ -562,11 +606,9 @@ func TestListTabSummariesHTTP(t *testing.T) {
 						LatestPassingBuild:    "Hulk",
 						LastUpdateTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
-							Nanos:   0,
 						},
 						LastRunTimestamp: &timestamp.Timestamp{
 							Seconds: 915166800,
-							Nanos:   0,
 						},
 					},
 				},


### PR DESCRIPTION
Added `Nanos` to the `timestamp` in `convertSummary` function
Fixes: #1124