### PR TITLE
Add a tab summary component and associated stories

### DIFF
--- a/web/custom-elements.json
+++ b/web/custom-elements.json
@@ -179,8 +179,32 @@
       "path": "stories/tab-summary.stories.ts",
       "declarations": [
         {
-          "kind": "function",
+          "kind": "variable",
           "name": "Passing"
+        },
+        {
+          "kind": "variable",
+          "name": "Flaky"
+        },
+        {
+          "kind": "variable",
+          "name": "Failing"
+        },
+        {
+          "kind": "variable",
+          "name": "Stale"
+        },
+        {
+          "kind": "variable",
+          "name": "Broken"
+        },
+        {
+          "kind": "variable",
+          "name": "Pending"
+        },
+        {
+          "kind": "variable",
+          "name": "Acceptable"
         }
       ],
       "exports": [
@@ -196,6 +220,54 @@
           "name": "Passing",
           "declaration": {
             "name": "Passing",
+            "module": "stories/tab-summary.stories.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Flaky",
+          "declaration": {
+            "name": "Flaky",
+            "module": "stories/tab-summary.stories.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Failing",
+          "declaration": {
+            "name": "Failing",
+            "module": "stories/tab-summary.stories.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Stale",
+          "declaration": {
+            "name": "Stale",
+            "module": "stories/tab-summary.stories.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Broken",
+          "declaration": {
+            "name": "Broken",
+            "module": "stories/tab-summary.stories.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Pending",
+          "declaration": {
+            "name": "Pending",
+            "module": "stories/tab-summary.stories.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Acceptable",
+          "declaration": {
+            "name": "Acceptable",
             "module": "stories/tab-summary.stories.ts"
           }
         }
@@ -236,6 +308,12 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/06d29c57.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/1d1f8f99.js",
       "declarations": [],
       "exports": []
@@ -248,7 +326,25 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/2ca18063.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/3802ddf3.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/3936f309.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/3ab98a47.js",
       "declarations": [],
       "exports": []
     },
@@ -278,6 +374,12 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/52d63ff7.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/530d819e.js",
       "declarations": [],
       "exports": []
@@ -291,6 +393,12 @@
     {
       "kind": "javascript-module",
       "path": "storybook-static/646dbe71.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/64a4cd00.js",
       "declarations": [],
       "exports": []
     },
@@ -786,7 +894,497 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/8a96e35f.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/8f56c693.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "e",
+          "type": {
+            "text": "object"
+          },
+          "default": "{}"
+        },
+        {
+          "kind": "variable",
+          "name": "t"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "u"
+            },
+            {
+              "name": "l"
+            },
+            {
+              "name": "p"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            },
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            },
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "e",
+          "declaration": {
+            "name": "t",
+            "module": "storybook-static/8f56c693.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "e",
+          "declaration": {
+            "name": "t",
+            "module": "storybook-static/8f56c693.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/99be43df.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/9cfc154a.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/c2c1b651.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/cb30324f.js",
       "declarations": [],
       "exports": []
     },
@@ -1258,9 +1856,493 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/d5c827b1.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/d6204f1f.js",
       "declarations": [],
       "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/d6c2bcc5.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/daf0d74e.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/e0aa853b.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "e",
+          "type": {
+            "text": "object"
+          },
+          "default": "{}"
+        },
+        {
+          "kind": "variable",
+          "name": "t"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "u"
+            },
+            {
+              "name": "l"
+            },
+            {
+              "name": "p"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            },
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            },
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "e",
+          "declaration": {
+            "name": "t",
+            "module": "storybook-static/e0aa853b.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "e",
+          "declaration": {
+            "name": "t",
+            "module": "storybook-static/e0aa853b.js"
+          }
+        }
+      ]
     },
     {
       "kind": "javascript-module",
@@ -1271,6 +2353,12 @@
     {
       "kind": "javascript-module",
       "path": "storybook-static/ee5c08da.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/eea081fb.js",
       "declarations": [],
       "exports": []
     },
@@ -1401,8 +2489,32 @@
       "path": "out-tsc/stories/tab-summary.stories.js",
       "declarations": [
         {
-          "kind": "function",
+          "kind": "variable",
           "name": "Passing"
+        },
+        {
+          "kind": "variable",
+          "name": "Flaky"
+        },
+        {
+          "kind": "variable",
+          "name": "Failing"
+        },
+        {
+          "kind": "variable",
+          "name": "Stale"
+        },
+        {
+          "kind": "variable",
+          "name": "Broken"
+        },
+        {
+          "kind": "variable",
+          "name": "Pending"
+        },
+        {
+          "kind": "variable",
+          "name": "Acceptable"
         }
       ],
       "exports": [
@@ -1418,6 +2530,54 @@
           "name": "Passing",
           "declaration": {
             "name": "Passing",
+            "module": "out-tsc/stories/tab-summary.stories.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Flaky",
+          "declaration": {
+            "name": "Flaky",
+            "module": "out-tsc/stories/tab-summary.stories.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Failing",
+          "declaration": {
+            "name": "Failing",
+            "module": "out-tsc/stories/tab-summary.stories.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Stale",
+          "declaration": {
+            "name": "Stale",
+            "module": "out-tsc/stories/tab-summary.stories.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Broken",
+          "declaration": {
+            "name": "Broken",
+            "module": "out-tsc/stories/tab-summary.stories.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Pending",
+          "declaration": {
+            "name": "Pending",
+            "module": "out-tsc/stories/tab-summary.stories.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Acceptable",
+          "declaration": {
+            "name": "Acceptable",
             "module": "out-tsc/stories/tab-summary.stories.js"
           }
         }
@@ -1515,6 +2675,66 @@
           "declaration": {
             "name": "Timestamp",
             "module": "src/gen/google/protobuf/timestamp.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/gen/pb/custom_evaluator/custom_evaluator.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "RuleSet",
+          "default": "new RuleSet$Type()"
+        },
+        {
+          "kind": "variable",
+          "name": "Rule",
+          "default": "new Rule$Type()"
+        },
+        {
+          "kind": "variable",
+          "name": "TestResultComparison",
+          "default": "new TestResultComparison$Type()"
+        },
+        {
+          "kind": "variable",
+          "name": "Comparison",
+          "default": "new Comparison$Type()"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RuleSet",
+          "declaration": {
+            "name": "RuleSet",
+            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Rule",
+          "declaration": {
+            "name": "Rule",
+            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestResultComparison",
+          "declaration": {
+            "name": "TestResultComparison",
+            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Comparison",
+          "declaration": {
+            "name": "Comparison",
+            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
           }
         }
       ]
@@ -1848,66 +3068,6 @@
           "declaration": {
             "name": "DefaultConfiguration",
             "module": "src/gen/pb/config/config.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/gen/pb/custom_evaluator/custom_evaluator.ts",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "RuleSet",
-          "default": "new RuleSet$Type()"
-        },
-        {
-          "kind": "variable",
-          "name": "Rule",
-          "default": "new Rule$Type()"
-        },
-        {
-          "kind": "variable",
-          "name": "TestResultComparison",
-          "default": "new TestResultComparison$Type()"
-        },
-        {
-          "kind": "variable",
-          "name": "Comparison",
-          "default": "new Comparison$Type()"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "RuleSet",
-          "declaration": {
-            "name": "RuleSet",
-            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "Rule",
-          "declaration": {
-            "name": "Rule",
-            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "TestResultComparison",
-          "declaration": {
-            "name": "TestResultComparison",
-            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "Comparison",
-          "declaration": {
-            "name": "Comparison",
-            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
           }
         }
       ]

--- a/web/custom-elements.json
+++ b/web/custom-elements.json
@@ -176,6 +176,33 @@
     },
     {
       "kind": "javascript-module",
+      "path": "stories/tab-summary.stories.ts",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "Passing"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "default",
+          "declaration": {
+            "module": "stories/tab-summary.stories.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Passing",
+          "declaration": {
+            "name": "Passing",
+            "module": "stories/tab-summary.stories.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "stories/testgrid-index.stories.ts",
       "declarations": [
         {
@@ -221,6 +248,18 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/3936f309.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/3f77a615.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/4b568637.js",
       "declarations": [],
       "exports": []
@@ -251,9 +290,499 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/646dbe71.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/6736214d.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/72552c1e.js",
       "declarations": [],
       "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/7d4714e7.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/81fdbf5a.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/8494735a.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "e",
+          "type": {
+            "text": "object"
+          },
+          "default": "{}"
+        },
+        {
+          "kind": "variable",
+          "name": "t"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "u"
+            },
+            {
+              "name": "l"
+            },
+            {
+              "name": "p"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            },
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            },
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "e",
+          "declaration": {
+            "name": "t",
+            "module": "storybook-static/8494735a.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "e",
+          "declaration": {
+            "name": "t",
+            "module": "storybook-static/8494735a.js"
+          }
+        }
+      ]
     },
     {
       "kind": "javascript-module",
@@ -747,6 +1276,12 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/ff87b586.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "coverage/lcov-report/block-navigation.js",
       "declarations": [],
       "exports": []
@@ -857,6 +1392,33 @@
           "declaration": {
             "name": "TabSummary",
             "module": "out-tsc/src/tab-summary.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "out-tsc/stories/tab-summary.stories.js",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "Passing"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "default",
+          "declaration": {
+            "module": "out-tsc/stories/tab-summary.stories.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Passing",
+          "declaration": {
+            "name": "Passing",
+            "module": "out-tsc/stories/tab-summary.stories.js"
           }
         }
       ]

--- a/web/custom-elements.json
+++ b/web/custom-elements.json
@@ -314,9 +314,481 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/0b308eb4.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/1d1f8f99.js",
       "declarations": [],
       "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/21cd4d48.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "e",
+          "type": {
+            "text": "object"
+          },
+          "default": "{}"
+        },
+        {
+          "kind": "variable",
+          "name": "t"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "u"
+            },
+            {
+              "name": "l"
+            },
+            {
+              "name": "p"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            },
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            },
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "e"
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            },
+            {
+              "name": "o"
+            },
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            },
+            {
+              "name": "r"
+            },
+            {
+              "name": "n"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "t",
+          "parameters": [
+            {
+              "name": "r"
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "e",
+          "parameters": [
+            {
+              "name": "t"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "e",
+          "declaration": {
+            "name": "t",
+            "module": "storybook-static/21cd4d48.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "e",
+          "declaration": {
+            "name": "t",
+            "module": "storybook-static/21cd4d48.js"
+          }
+        }
+      ]
     },
     {
       "kind": "javascript-module",
@@ -351,6 +823,12 @@
     {
       "kind": "javascript-module",
       "path": "storybook-static/3f77a615.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/48fabb7d.js",
       "declarations": [],
       "exports": []
     },
@@ -392,6 +870,18 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/5ba9ef1a.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/5c936e56.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/646dbe71.js",
       "declarations": [],
       "exports": []
@@ -405,6 +895,12 @@
     {
       "kind": "javascript-module",
       "path": "storybook-static/6736214d.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/714f802d.js",
       "declarations": [],
       "exports": []
     },
@@ -1378,7 +1874,19 @@
     },
     {
       "kind": "javascript-module",
+      "path": "storybook-static/aa782482.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/c2c1b651.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/c509a3c6.js",
       "declarations": [],
       "exports": []
     },
@@ -2681,66 +3189,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/gen/pb/custom_evaluator/custom_evaluator.ts",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "RuleSet",
-          "default": "new RuleSet$Type()"
-        },
-        {
-          "kind": "variable",
-          "name": "Rule",
-          "default": "new Rule$Type()"
-        },
-        {
-          "kind": "variable",
-          "name": "TestResultComparison",
-          "default": "new TestResultComparison$Type()"
-        },
-        {
-          "kind": "variable",
-          "name": "Comparison",
-          "default": "new Comparison$Type()"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "RuleSet",
-          "declaration": {
-            "name": "RuleSet",
-            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "Rule",
-          "declaration": {
-            "name": "Rule",
-            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "TestResultComparison",
-          "declaration": {
-            "name": "TestResultComparison",
-            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "Comparison",
-          "declaration": {
-            "name": "Comparison",
-            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/gen/pb/config/config.ts",
       "declarations": [
         {
@@ -3068,6 +3516,66 @@
           "declaration": {
             "name": "DefaultConfiguration",
             "module": "src/gen/pb/config/config.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/gen/pb/custom_evaluator/custom_evaluator.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "RuleSet",
+          "default": "new RuleSet$Type()"
+        },
+        {
+          "kind": "variable",
+          "name": "Rule",
+          "default": "new Rule$Type()"
+        },
+        {
+          "kind": "variable",
+          "name": "TestResultComparison",
+          "default": "new TestResultComparison$Type()"
+        },
+        {
+          "kind": "variable",
+          "name": "Comparison",
+          "default": "new Comparison$Type()"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RuleSet",
+          "declaration": {
+            "name": "RuleSet",
+            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Rule",
+          "declaration": {
+            "name": "Rule",
+            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "TestResultComparison",
+          "declaration": {
+            "name": "TestResultComparison",
+            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Comparison",
+          "declaration": {
+            "name": "Comparison",
+            "module": "src/gen/pb/custom_evaluator/custom_evaluator.ts"
           }
         }
       ]

--- a/web/src/tab-summary.ts
+++ b/web/src/tab-summary.ts
@@ -71,8 +71,6 @@ export class TabSummary extends LitElement {
       color: #fff;
     }
 
-    // TODO(sultan-duisenbay) - move shared styles to a separate file.
-    /* Colors for the tab status icons. */
     .PENDING {
       background-color: #cc8200;
     }

--- a/web/stories/tab-summary.stories.ts
+++ b/web/stories/tab-summary.stories.ts
@@ -1,0 +1,24 @@
+import { html } from 'lit';
+import '../src/tab-summary.js';
+import { TabSummaryInfo } from '../src/dashboard-summary.js';
+
+export default {
+  title: 'Tab summary',
+  component: 'tab-summary',
+};
+const passing: TabSummaryInfo = {
+  icon: 'done',
+  name: 'TEST',
+  overallStatus: 'PASSING',
+  detailedStatusMsg: 'Very detailed message',
+  lastRunTimestamp: 'yesterday',
+  lastUpdateTimestamp: 'today',
+  latestGreenBuild: 'HULK!',
+};
+export const Passing = () =>
+  html`<link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    /><tab-summary .info=${passing}></tab-summary>`;
+// export const Secondary = () => html`<demo-button .background="#ff0" .label="😄👍😍💯"></demo-button>`;
+// export const Tertiary = () => html`<demo-button .background="#ff0" .label="📚📕📈🤓"></demo-button>`;

--- a/web/stories/tab-summary.stories.ts
+++ b/web/stories/tab-summary.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, TemplateResult } from 'lit';
 import '../src/tab-summary.js';
 import { TabSummaryInfo } from '../src/dashboard-summary.js';
 
@@ -6,19 +6,54 @@ export default {
   title: 'Tab summary',
   component: 'tab-summary',
 };
-const passing: TabSummaryInfo = {
-  icon: 'done',
-  name: 'TEST',
-  overallStatus: 'PASSING',
-  detailedStatusMsg: 'Very detailed message',
-  lastRunTimestamp: 'yesterday',
-  lastUpdateTimestamp: 'today',
-  latestGreenBuild: 'HULK!',
-};
-export const Passing = () =>
-  html`<link
+
+interface Story<T> {
+  (args: T): TemplateResult;
+  args?: T;
+}
+
+interface Args {
+  icon: string;
+  overallStatus: string;
+}
+
+const Template: Story<Args> = ({
+  icon = 'done',
+  overallStatus = 'PASSING',
+}: Args) => {
+  const tsi: TabSummaryInfo = {
+    icon,
+    name: 'TEST',
+    overallStatus,
+    detailedStatusMsg: 'Very detailed message',
+    lastRunTimestamp: 'yesterday',
+    lastUpdateTimestamp: 'today',
+    latestGreenBuild: 'HULK!',
+  };
+
+  return html`<link
       rel="stylesheet"
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
-    /><tab-summary .info=${passing}></tab-summary>`;
-// export const Secondary = () => html`<demo-button .background="#ff0" .label="😄👍😍💯"></demo-button>`;
-// export const Tertiary = () => html`<demo-button .background="#ff0" .label="📚📕📈🤓"></demo-button>`;
+    />
+    <tab-summary .info=${tsi}></tab-summary>`;
+};
+
+export const Passing = Template.bind({});
+
+export const Flaky = Template.bind({});
+Flaky.args = { icon: 'remove_circle_outline', overallStatus: 'FLAKY' };
+
+export const Failing = Template.bind({});
+Failing.args = { icon: 'warning', overallStatus: 'FAILING' };
+
+export const Stale = Template.bind({});
+Stale.args = { icon: 'error_outline', overallStatus: 'STALE' };
+
+export const Broken = Template.bind({});
+Broken.args = { icon: 'broken_image', overallStatus: 'BROKEN' };
+
+export const Pending = Template.bind({});
+Pending.args = { icon: 'schedule', overallStatus: 'PENDING' };
+
+export const Acceptable = Template.bind({});
+Acceptable.args = { icon: 'add_circle_outline', overallStatus: 'ACCEPTABLE' };

--- a/web/stories/testgrid-index.stories.ts
+++ b/web/stories/testgrid-index.stories.ts
@@ -4,15 +4,15 @@ import '../src/TestgridIndex.js';
 export default {
   title: 'Index',
   component: 'testgrid-index',
-  // argTypes: {
-  //   backgroundColor: { control: 'color' },
-  // },
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
 };
 
 interface Story<T> {
   (args: T): TemplateResult;
   args?: Partial<T>;
-  // argTypes?: Record<string, unknown>;
+  argTypes?: Record<string, unknown>;
 }
 
 interface ArgTypes {

--- a/web/stories/testgrid-index.stories.ts
+++ b/web/stories/testgrid-index.stories.ts
@@ -4,15 +4,15 @@ import '../src/TestgridIndex.js';
 export default {
   title: 'Index',
   component: 'testgrid-index',
-  argTypes: {
-    backgroundColor: { control: 'color' },
-  },
+  // argTypes: {
+  //   backgroundColor: { control: 'color' },
+  // },
 };
 
 interface Story<T> {
   (args: T): TemplateResult;
   args?: Partial<T>;
-  argTypes?: Record<string, unknown>;
+  // argTypes?: Record<string, unknown>;
 }
 
 interface ArgTypes {


### PR DESCRIPTION
Added the tab summary component to the existing storybook. Created a separate story for each possible status.

Please refer to the screenshtot
![Screenshot from 2023-02-23 22-39-13](https://user-images.githubusercontent.com/111793812/221047062-09b2c7e6-aec1-4ac7-9a63-f694caa5b676.png)
