### PR TITLE
Update README files under cmd/ with common tips and commands.

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,0 +1,43 @@
+# TestGrid Components
+
+The `cmd` directory contains the main files for TestGrid components, and documentation for how to
+run them. For specifics on a particular component, see the subdirectory for that component.
+
+## Tips for running locally
+
+### Google Cloud Storage (GCS) Authentication
+
+If you're using files from GCS and you hit an authentication or 'unauthorized' error in logs, run:
+```gcloud auth application-default login```
+
+Most components will automatically find and use the credentials generated from this.
+
+### Common Flags
+
+Most components have similar flags and defaults. Here's a few you can expect to use:
+- Run `bazelisk run //cmd/$COMPONENT -- --help` for full flag list and descriptions.
+- `--config` specifies the path to a valid [config proto]. It can take a:
+  - local file: e.g. `/tmp/testgrid/my-config.pb`
+  - GCS (Google Cloud Storage) file: e.g. `gs://my-bucket/my-config.pb`
+- `--confirm`, if true, writes data to the same base path as your `--config`.
+  - Without this, it's "dry-run` by default and doesn't write data anywhere.
+- `--wait`, if true, runs the component continuously until force-quit, waiting the specified time
+  before beginning another cycle.
+  - Without this, it will run once and exit.
+- `--debug` or `--trace` print debug-level or trace-level logs, respectively.
+  - Without this, only logs at info-level or higher will be displayed.
+  - Debug logs tend to be useful for development or debugging.
+  - Trace logs can be _very_ noisy, and tend to be useful for debugging something very specific.
+
+### Developing and Testing
+
+Most of the TestGrid libraries used for these components live under the `pkg/` directory.
+- e.g. `cmd/updater` library code is under `pkg/updater`
+
+To run unit tests for a particular component, run:
+
+```shell
+COMPONENT={component} # e.g. 'updater', 'summarizer', etc. 
+bazelisk test //cmd/$COMPONENT/... # Runs unit tests for the main/binary, like flag-parsing or default arguments
+bazelisk test //pkg/$COMPONENT/... # Runs unit tests for library code
+```

--- a/cmd/api/README.md
+++ b/cmd/api/README.md
@@ -1,14 +1,24 @@
-## TestGrid API
+# API
 
-The TestGrid API controller exposes TestGrid data publicly that could otherwise be viewed through the UI.
+This component exposes TestGrid data publicly that could otherwise be viewed through the UI.
 
-### Usage
+## Local development
+See also [common tips](/cmd/README.md) for running locally.
 
 The surface of the API is described in this (proto definition)[/pb/api/v1/data.proto]. Usage is similar between protocols.
 
 You may want to set `--scope=gs://your-bucket`. This will set this as the server's default; otherwise you'll be required to specify with each call.
 
-#### HTTP
+If you're using this for developing in the `web/` directory, optionally set `--allowed-origin=*` to avoid
+CORS issues.
+
+```bash
+bazelisk run //cmd/api -- \
+  # --scope=gs://your-bucket
+  # --allowed-origin=*
+```
+
+### HTTP
 
 Use the `--http-port` option to set the listening port. Default is 8080.
 
@@ -16,7 +26,7 @@ You can specify further with URL parameters: `?scope=gs://your-bucket`.
 
 `curl localhost:8080/api/v1/dashboards`
 
-#### gRPC
+### gRPC
 
 Use the `--grpc-port` option to set the listening port. Default is 50051.
 

--- a/cmd/config_merger/README.md
+++ b/cmd/config_merger/README.md
@@ -1,6 +1,14 @@
 # Config Merger
-The config merger combines two or more configurations into a single TestGrid
-configuration.
+This component validates and combines two or more [config proto] files into a single TestGrid
+configuration (also a config proto). This config is used by basically every other component in TestGrid.
+
+## Local development
+See also [common tips](/cmd/README.md) for running locally.
+
+```bash
+  --config-list=/tmp/testgrid/my-config-list.yaml \  # See 'Configuration List' below for details.
+  # --confirm \
+```
 
 ## Configuration List
 The config merger requires a YAML file containing:
@@ -27,3 +35,5 @@ is added as a prefix, giving precedence by alphabetical order.
 
 For example, if both configurations in the example above contain a dashboard 
 named `"foo"`, the red dashboard will be renamed to `"red-foo"`.
+
+[config proto]: /pb/config/config.proto

--- a/cmd/state_comparer/README.md
+++ b/cmd/state_comparer/README.md
@@ -7,8 +7,8 @@ You should have two directories set up: one each for the states you want to comp
 
 ```shell
 # Example basic run:
-bazel run //cmd/state_comparer -- --first="/tmp/cmp/first/" --second="/tmp/cmp/second/" --diff-ratio-ok=0.3
+bazelisk run //cmd/state_comparer -- --first="/tmp/cmp/first/" --second="/tmp/cmp/second/" --diff-ratio-ok=0.3
 
 # Example detailed/advanced run:
-bazel run //cmd/state_comparer -- --first="/tmp/tgcmp/first/" --second="/tmp/tgcmp/second/" --diff-ratio-ok=0.3 --test-group-url="http://testgrid-canary/q/testgroup/" --config="/tmp/cmp/config" --debug
+bazelisk run //cmd/state_comparer -- --first="/tmp/tgcmp/first/" --second="/tmp/tgcmp/second/" --diff-ratio-ok=0.3 --test-group-url="http://testgrid-canary/q/testgroup/" --config="/tmp/cmp/config" --debug
 ```

--- a/cmd/summarizer/README.md
+++ b/cmd/summarizer/README.md
@@ -1,49 +1,19 @@
-# Testgrid Summarizer
-The Testgrid Summarizer creates test result summaries for the Testgrid
-dashboards and tables. It continuously writes summaries owned by the
-Update Master.
+# Summarizer
 
-## Workflow
-The `Update Master` will parse all the groups and request the `Update Servers` to aggregate test results. When the update cycle is done, the `Update Master` will run post-update jobs, which will trigger the `Summarizer` to create the summary object.
+This component reads dashboard-tab-based [state proto] files and summarizes them into a [summary proto].
 
-## Highlevel Design
-The `Summarizer` implements the key functions to convert aggregated results into the appropriate summary format, and continuously writes/reads summaries owned by the `Update Master` to/from storage. This will be a standalone service for all flavor of Testgrid clusters to use for test result translation. The summarizer server will implement the gRPC server component.
+These protos are read by the frontend (e.g. https://testgrid.k8s.io)
 
-```golang
-type Summarizer struct {}
-func (s *Summarizer) TableToSummary(...) (...) {}
-func (s *Summarizer) SummaryToClientObject(...) (...) {}
-func (s *Summarizer) GetStatusForDashboard(...) (...) {}
+## Local development
+See also [common tips](/cmd/README.md) for running locally.
 
-type Storage struct{}
-func (s *Storage) SaveSummaryObject() {}
-func (s *Storage) RestoreSummaryObject() {}
-func (s *Storage) NormalizeObjectName() {}
-
-type SummarizerServer struct {}
-func (s *SummarizerServer) GetSummary(...) (...) {}
-func (s *SummarizerServer) GetDashboardStatus(...) (...) {}
+```bash
+# --config can take a local file (e.g. `/tmp/testgrid/config`) or GCS file (e.g. `gs://my-testgrid-bucket/config`)
+bazelisk run //cmd/summarizer -- \
+  --config=gs://my-testgrid-bucket/somewhere/config \
+  # --dashboards=foo,bar \  # If specified, only summarize these dashboards. 
+  # --debug \
+  # --confirm \
 ```
 
-## Implementation Breakdown
-The Summarizer component will be implemented in two stages:
-
-1. The translation of test results to summary objects. This will implement most of the Summarizer object and the SummarizerServer. When stage 1 is ready, we should have a standalone server running and serving on-demand test result translation from a remote gRPC client. This section is implemented by [PR #13132](https://github.com/kubernetes/test-infra/pull/13132)
-1. The storage of summary. This will implement the Storage object and integrate it with the Summarizer. When stage 2 is ready, we should be able to store data to a permanent storage location to avoid recomputing some summary data, which will improve the overall system efficiency.
-
-## Developer Guide
-To run all the tests for the summarizer component.
-```
-test-infra/testgrid/cmd/summarizer $ bazel test ...
-```
-
-To run the server.
-```
-test-infra/testgrid/cmd/summarizer $ bazel run :summarizer
-```
-
-To run the example client.
-```
-test-infra/testgrid/cmd/summarizer/example $ bazel run :example
-```
-
+[summary proto]: pb/summary/summary.proto

--- a/cmd/tabulator/README.md
+++ b/cmd/tabulator/README.md
@@ -1,0 +1,27 @@
+
+# Tabulator
+
+This component reads test-group-based [state proto] files, combines them with dashboard tab
+configuration, and produces tab-based [state proto] files.
+
+The TestGrid frontend reads these protos and converts them to JSON, which the
+javascript UI reads and renders on the screen.
+
+These protos are read by:
+- The frontend (e.g. [testgrid.k8s.io](https://testgrid.k8s.io))
+- The [Summarizer] component
+
+## Local development
+See also [common tips](/cmd/README.md) for running locally.
+
+```bash
+# --config can take a local file (e.g. `/tmp/testgrid/config`) or GCS file (e.g. `gs://my-testgrid-bucket/config`)
+bazelisk run //cmd/tabulator -- \
+  --config=gs://my-testgrid-bucket/somewhere/config \
+  # --groups=foo,bar \  # If specified, only tabulate these test groups.
+  # --debug \
+  # --confirm \
+```
+
+[state proto]: /pb/state/state.proto
+[Summarizer]: /cmd/summarizer

--- a/cmd/updater/README.md
+++ b/cmd/updater/README.md
@@ -3,27 +3,19 @@
 
 This component is responsible for compiling collated GCS results into a [state proto].
 
-The testgrid frontend reads these protos, converts them to JSON which the
-javascript UI reads and renders on the screen.
+These protos are read by the [Tabulator] component.
 
 ## Local development
+See also [common tips](/cmd/README.md) for running locally.
 
 ```bash
+# --config can take a local file (e.g. `/tmp/testgrid/config`) or GCS file (e.g. `gs://my-testgrid-bucket/config`)
 bazelisk run //cmd/updater -- \
   --config=gs://my-testgrid-bucket/somewhere/config \
-  # --wait=10m \
-  # --test-group=foo \
+  # --test-group=foo,bar \  # If specified, only update these test groups.
   # --debug \
   # --confirm \
 ```
-
-See `bazelisk run //cmd/updater -- --help` for full flag list and descriptions.
-
-
-### Authentication
-
-Use `gcloud auth application-default login` in order to create credentials
-that golang will automatically recognize.
 
 ### Debugging
 
@@ -32,8 +24,7 @@ The two most useful flags are `--test-group=foo` and `--confirm=false` (default)
 Setting the `--test-group` flag tells the client to only update a specific group.
 This is useful when debugging problems in a specific group.
 
-The `--confirm` flag controls whether anything is written to GCS.
-Nothing is written by default.
+The `--confirm` flag controls whether any data is written. Nothing is written by default.
 
 
 ## Update cycles
@@ -63,3 +54,4 @@ If the `--wait` flag is unset, the job returns at this time.
 Otherwise it repeats after sleeping for that duration.
 
 [state proto]: /pb/state/state.proto
+[Tabulator]: /cmd/tabulator


### PR DESCRIPTION
I gave these a basic pass that these will run, though if you spot any issues please let me know.

Also cleaned up some old docs from when we were migrating, and tried to make these more consistent (with common tips, etc. in the cmd/ README instead of individual component READMEs).

Ref #1120 