### PR TITLE
Log more on 'too old' cols when processing started.json

### DIFF
--- a/pkg/updater/read_test.go
+++ b/pkg/updater/read_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"net/url"
 	"sort"
 	"sync"
@@ -526,9 +527,9 @@ func TestReadColumns(t *testing.T) {
 				GcsPrefix: "bucket/path/to/build/",
 			},
 			expected: []InflatedColumn{
-				ancientColumn("10", .01, nil),
-				ancientColumn("11", .02, nil),
-				ancientColumn("12", .03, nil),
+				ancientColumn("10", .01, nil, fmt.Sprintf("build too old; started %v before %v)", now+10, now+13)),
+				ancientColumn("11", .02, nil, fmt.Sprintf("build too old; started %v before %v)", now+11, now+13)),
+				ancientColumn("12", .03, nil, fmt.Sprintf("build too old; started %v before %v)", now+12, now+13)),
 				{
 					Column: &statepb.Column{
 						Build:   "13",

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -601,6 +601,7 @@ func InflateDropAppend(ctx context.Context, alog logrus.FieldLogger, client gcs.
 	}
 
 	stop := time.Now().Add(-dur)
+	log = log.WithField("stop", stop)
 
 	var oldCols []InflatedColumn
 	var issues map[string][]string


### PR DESCRIPTION
Trying to log more info when we hit https://github.com/GoogleCloudPlatform/testgrid/issues/1116. It's unclear what times the Updater is dealing with, so make it clear exactly what it's comparing.