### PR TITLE
deps: bump bitbucket.org/creachadair/stringset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/GoogleCloudPlatform/testgrid
 
 require (
-	bitbucket.org/creachadair/stringset v0.0.9
+	bitbucket.org/creachadair/stringset v0.0.11
 	cloud.google.com/go/pubsub v1.22.2
 	cloud.google.com/go/storage v1.22.1
 	github.com/client9/misspell v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-bitbucket.org/creachadair/stringset v0.0.9 h1:L4vld9nzPt90UZNrXjNelTshD74ps4P5NGs3Iq6yN3o=
-bitbucket.org/creachadair/stringset v0.0.9/go.mod h1:t+4WcQ4+PXTa8aQdNKe40ZP6iwesoMFWAxPGd3UGjyY=
+bitbucket.org/creachadair/stringset v0.0.11 h1:6Sv4CCv14Wm+OipW4f3tWOb0SQVpBDLW0knnJqUnmZ8=
+bitbucket.org/creachadair/stringset v0.0.11/go.mod h1:wh0BHewFe+j0HrzWz7KcGbSNpFzWwnpmgPRlB57U5jU=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -100,7 +100,6 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/creachadair/staticfile v0.1.3/go.mod h1:a3qySzCIXEprDGxk6tSxSI+dBBdLzqeBOMhZ+o2d3pM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/repos.bzl
+++ b/repos.bzl
@@ -152,14 +152,6 @@ def go_repositories():
     )
 
     go_repository(
-        name = "com_github_creachadair_staticfile",
-        build_file_generation = "on",
-        build_file_proto_mode = "disable",
-        importpath = "github.com/creachadair/staticfile",
-        sum = "h1:RhyrMgi7IQn3GejgmGtFuCec58vboEMt5CH6N3ulRJk=",
-        version = "v0.1.3",
-    )
-    go_repository(
         name = "com_github_davecgh_go_spew",
         build_file_generation = "on",
         build_file_proto_mode = "disable",
@@ -1109,8 +1101,8 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "bitbucket.org/creachadair/stringset",
-        sum = "h1:L4vld9nzPt90UZNrXjNelTshD74ps4P5NGs3Iq6yN3o=",
-        version = "v0.0.9",
+        sum = "h1:6Sv4CCv14Wm+OipW4f3tWOb0SQVpBDLW0knnJqUnmZ8=",
+        version = "v0.0.11",
     )
     go_repository(
         name = "org_golang_google_api",


### PR DESCRIPTION
The `v0.0.9` has a broken dep on a removed GH repo https://github.com/creachadair/staticfile

```
go: github.com/GoogleCloudPlatform/testgrid@v0.0.155 requires
	bitbucket.org/creachadair/stringset@v0.0.9 requires
	github.com/creachadair/staticfile@v0.1.3: reading github.com/creachadair/staticfile/go.mod at revision v0.1.3: git ls-remote -q origin in /home/afri/Projects/RH/go/pkg/mod/cache/vcs/7f22b487ea423648f3bb75e35ac5adb1ede8f500fbd46b975ca494a23a598447: exit status 128:
	fatal: could not read Username for 'https://github.com': terminal prompts disabled
Confirm the import path was entered correctly.
If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
```
