### PR TITLE
Move API from Gorilla to Chi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	cloud.google.com/go/storage v1.22.1
 	github.com/client9/misspell v0.3.4
 	github.com/fvbommel/sortorder v1.0.1
+	github.com/go-chi/chi v1.5.4
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.1.2
-	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqF
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi v1.5.4 h1:QHdzF2szwjqVV4wmByUnTcsbIg7UGaQ0tPF2t5GcAIs=
+github.com/go-chi/chi v1.5.4/go.mod h1:uaf8YgoFazUOkPBG7fxPftUylNumIev9awIWOENIuEg=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -234,8 +236,6 @@ github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/go-type-adapters v1.0.0 h1:9XdMn+d/G57qq1s8dNc5IesGCXHf6V2HZ2JwRxfA2tA=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/pkg/api/BUILD.bazel
+++ b/pkg/api/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "//pb/api/v1:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//util/gcs:go_default_library",
-        "@com_github_gorilla_mux//:go_default_library",
+        "@com_github_go_chi_chi//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//reflection:go_default_library",

--- a/pkg/api/v1/BUILD.bazel
+++ b/pkg/api/v1/BUILD.bazel
@@ -23,7 +23,7 @@ go_library(
         "//pkg/summarizer:go_default_library",
         "//pkg/tabulator:go_default_library",
         "//util/gcs:go_default_library",
-        "@com_github_gorilla_mux//:go_default_library",
+        "@com_github_go_chi_chi//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",

--- a/pkg/api/v1/config.go
+++ b/pkg/api/v1/config.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleCloudPlatform/testgrid/config"
@@ -113,11 +113,9 @@ func (s *Server) GetDashboardGroup(ctx context.Context, req *apipb.GetDashboardG
 // GetDashboardGroupHTTP returns a given dashboard group
 // Response json: GetDashboardGroupResponse
 func (s Server) GetDashboardGroupHTTP(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-
 	req := apipb.GetDashboardGroupRequest{
 		Scope:          r.URL.Query().Get(scopeParam),
-		DashboardGroup: vars["dashboard-group"],
+		DashboardGroup: chi.URLParam(r, "dashboard-group"),
 	}
 	resp, err := s.GetDashboardGroup(r.Context(), &req)
 	if err != nil {
@@ -195,11 +193,9 @@ func (s *Server) GetDashboard(ctx context.Context, req *apipb.GetDashboardReques
 // GetDashboardHTTP returns a given dashboard
 // Response json: GetDashboardResponse
 func (s Server) GetDashboardHTTP(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-
 	req := apipb.GetDashboardRequest{
 		Scope:     r.URL.Query().Get(scopeParam),
-		Dashboard: vars["dashboard"],
+		Dashboard: chi.URLParam(r, "dashboard"),
 	}
 	resp, err := s.GetDashboard(r.Context(), &req)
 	if err != nil {
@@ -242,10 +238,9 @@ func (s *Server) ListDashboardTabs(ctx context.Context, req *apipb.ListDashboard
 // ListDashboardTabsHTTP returns a given dashboard tabs
 // Response json: ListDashboardTabsResponse
 func (s Server) ListDashboardTabsHTTP(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
 	req := apipb.ListDashboardTabsRequest{
 		Scope:     r.URL.Query().Get(scopeParam),
-		Dashboard: vars["dashboard"],
+		Dashboard: chi.URLParam(r, "dashboard"),
 	}
 
 	resp, err := s.ListDashboardTabs(r.Context(), &req)

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -22,7 +22,7 @@ import (
 
 	apipb "github.com/GoogleCloudPlatform/testgrid/pb/api/v1"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi"
 )
 
 // Server contains the necessary settings and i/o objects needed to serve this api
@@ -41,20 +41,20 @@ var _ apipb.TestGridDataServer = (*Server)(nil)
 
 // Route applies all the v1 API functions provided by the Server to the Router given.
 // If the router is nil, a new one is instantiated.
-func Route(r *mux.Router, s Server) *mux.Router {
+func Route(r *chi.Mux, s Server) *chi.Mux {
 	if r == nil {
-		r = mux.NewRouter()
+		r = chi.NewRouter()
 	}
-	r.HandleFunc("/dashboard-groups", s.ListDashboardGroupHTTP).Methods("GET")
-	r.HandleFunc("/dashboard-groups/{dashboard-group}", s.GetDashboardGroupHTTP).Methods("GET")
-	r.HandleFunc("/dashboards", s.ListDashboardsHTTP).Methods("GET")
-	r.HandleFunc("/dashboards/{dashboard}/tabs", s.ListDashboardTabsHTTP).Methods("GET")
-	r.HandleFunc("/dashboards/{dashboard}", s.GetDashboardHTTP).Methods("GET")
+	r.Get("/dashboard-groups", s.ListDashboardGroupHTTP)
+	r.Get("/dashboard-groups/{dashboard-group}", s.GetDashboardGroupHTTP)
+	r.Get("/dashboards", s.ListDashboardsHTTP)
+	r.Get("/dashboards/{dashboard}/tabs", s.ListDashboardTabsHTTP)
+	r.Get("/dashboards/{dashboard}", s.GetDashboardHTTP)
 
-	r.HandleFunc("/dashboards/{dashboard}/tabs/{tab}/headers", s.ListHeadersHTTP).Methods("GET")
-	r.HandleFunc("/dashboards/{dashboard}/tabs/{tab}/rows", s.ListRowsHTTP).Methods("GET")
+	r.Get("/dashboards/{dashboard}/tabs/{tab}/headers", s.ListHeadersHTTP)
+	r.Get("/dashboards/{dashboard}/tabs/{tab}/rows", s.ListRowsHTTP)
 
-	r.HandleFunc("/dashboards/{dashboard}/tab-summaries", s.ListTabSummariesHTTP).Methods("GET")
-	r.HandleFunc("/dashboards/{dashboard}/tab-summaries/{tab}", s.GetTabSummaryHTTP).Methods("GET")
+	r.Get("/dashboards/{dashboard}/tab-summaries", s.ListTabSummariesHTTP)
+	r.Get("/dashboards/{dashboard}/tab-summaries/{tab}", s.GetTabSummaryHTTP)
 	return r
 }

--- a/pkg/api/v1/state.go
+++ b/pkg/api/v1/state.go
@@ -23,8 +23,8 @@ import (
 	"math"
 	"net/http"
 
+	"github.com/go-chi/chi"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleCloudPlatform/testgrid/config"
@@ -140,11 +140,10 @@ func (s *Server) ListHeaders(ctx context.Context, req *apipb.ListHeadersRequest)
 // ListHeadersHTTP returns dashboard tab headers
 // Response json: ListHeadersResponse
 func (s Server) ListHeadersHTTP(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
 	req := apipb.ListHeadersRequest{
 		Scope:     r.URL.Query().Get(scopeParam),
-		Dashboard: vars["dashboard"],
-		Tab:       vars["tab"],
+		Dashboard: chi.URLParam(r, "dashboard"),
+		Tab:       chi.URLParam(r, "tab"),
 	}
 	resp, err := s.ListHeaders(r.Context(), &req)
 	if err != nil {
@@ -211,11 +210,10 @@ func (s *Server) ListRows(ctx context.Context, req *apipb.ListRowsRequest) (*api
 // ListRowsHTTP returns dashboard tab rows
 // Response json: ListRowsResponse
 func (s Server) ListRowsHTTP(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
 	req := apipb.ListRowsRequest{
 		Scope:     r.URL.Query().Get(scopeParam),
-		Dashboard: vars["dashboard"],
-		Tab:       vars["tab"],
+		Dashboard: chi.URLParam(r, "dashboard"),
+		Tab:       chi.URLParam(r, "tab"),
 	}
 	resp, err := s.ListRows(r.Context(), &req)
 	if err != nil {

--- a/pkg/api/v1/summary.go
+++ b/pkg/api/v1/summary.go
@@ -22,7 +22,7 @@ import (
 	"math"
 	"net/http"
 
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/sirupsen/logrus"
@@ -131,10 +131,9 @@ func (s *Server) ListTabSummaries(ctx context.Context, req *apipb.ListTabSummari
 // ListTabSummariesHTTP returns the list of tab summaries as a json.
 // Response json: ListTabSummariesResponse
 func (s Server) ListTabSummariesHTTP(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
 	req := apipb.ListTabSummariesRequest{
 		Scope:     r.URL.Query().Get(scopeParam),
-		Dashboard: vars["dashboard"],
+		Dashboard: chi.URLParam(r, "dashboard"),
 	}
 	resp, err := s.ListTabSummaries(r.Context(), &req)
 	if err != nil {
@@ -197,11 +196,10 @@ func (s *Server) GetTabSummary(ctx context.Context, req *apipb.GetTabSummaryRequ
 // GetTabSummaryHTTP returns the tab summary as a json.
 // Response json: GetTabSummaryResponse
 func (s Server) GetTabSummaryHTTP(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
 	req := apipb.GetTabSummaryRequest{
 		Scope:     r.URL.Query().Get(scopeParam),
-		Dashboard: vars["dashboard"],
-		Tab:       vars["tab"],
+		Dashboard: chi.URLParam(r, "dashboard"),
+		Tab:       chi.URLParam(r, "tab"),
 	}
 	resp, err := s.GetTabSummary(r.Context(), &req)
 	if err != nil {

--- a/repos.bzl
+++ b/repos.bzl
@@ -244,6 +244,15 @@ def go_repositories():
         version = "v1.0.0",
     )
     go_repository(
+        name = "com_github_go_chi_chi",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/go-chi/chi",
+        sum = "h1:QHdzF2szwjqVV4wmByUnTcsbIg7UGaQ0tPF2t5GcAIs=",
+        version = "v1.5.4",
+    )
+
+    go_repository(
         name = "com_github_go_gl_glfw",
         build_file_generation = "on",
         build_file_proto_mode = "disable",
@@ -476,14 +485,6 @@ def go_repositories():
         version = "v1.0.0",
     )
 
-    go_repository(
-        name = "com_github_gorilla_mux",
-        build_file_generation = "on",
-        build_file_proto_mode = "disable",
-        importpath = "github.com/gorilla/mux",
-        sum = "h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=",
-        version = "v1.8.0",
-    )
     go_repository(
         name = "com_github_grpc_ecosystem_grpc_gateway",
         build_file_generation = "on",


### PR DESCRIPTION
- Gorilla Mux is [archived](https://github.com/gorilla#gorilla-toolkit)
- The only features we're using are URL variables and subrouters, so a lighter-weight library is good, but using the http.ServeMux built-in isn't _quite_ enough.