### PR TITLE
Improve the tests

### DIFF
--- a/web/src/testgrid-index.ts
+++ b/web/src/testgrid-index.ts
@@ -93,49 +93,59 @@ export class TestgridIndex extends LitElement {
 
   // function to get dashboards
   async getDashboards() {
-    this.dashboards = ['Loading...'];
+    try{
+      fetch(`http://${host}/api/v1/dashboards`).then(
+        async response => {
+          const resp = ListDashboardResponse.fromJson(await response.json());
+          const dashboards: string[] = [];
 
-    fetch(`http://${host}/api/v1/dashboards`).then(async response => {
-      const resp = ListDashboardResponse.fromJson(await response.json());
+          resp.dashboards.forEach(db => {
+            dashboards.push(db.name);
+          });
 
-      this.dashboards = [];
-
-      resp.dashboards.forEach(db => {
-        this.dashboards.push(db.name);
-      });
-    });
+          this.dashboards = dashboards;
+        }
+      );
+    } catch (error) {
+      console.log(`failed to fetch: ${error}`);
+    }
   }
 
   // function to get dashboard groups
   async getDashboardGroups() {
-    this.dashboardGroups = ['Loading...'];
+    try{
+      fetch(`http://${host}/api/v1/dashboard-groups`).then(
+        async response => {
+          const resp = ListDashboardGroupResponse.fromJson(await response.json());
 
-    fetch(`http://${host}/api/v1/dashboard-groups`).then(async response => {
-      const resp = ListDashboardGroupResponse.fromJson(await response.json());
+          const dashboardGroups: string[] = [];
 
-      this.dashboardGroups = [];
+          resp.dashboardGroups.forEach(db => {
+            dashboardGroups.push(db.name);
+          });
 
-      resp.dashboardGroups.forEach(db => {
-        this.dashboardGroups.push(db.name);
-      });
-    });
+          this.dashboardGroups = dashboardGroups;
+        }
+      );
+    } catch(error){
+      console.log(`failed to fetch: ${error}`);
+    }
   }
 
   // function to get respective dashboards of dashboard group
   async getRespectiveDashboards(name: string) {
     this.show = false;
-    // this.respectiveDashboards = ['Loading...'];
     try {
       fetch(`http://${host}/api/v1/dashboard-groups/${name}`).then(
         async response => {
           const resp = ListDashboardResponse.fromJson(await response.json());
-
-          this.respectiveDashboards = [];
+          const respectiveDashboards: string[] = [];
 
           resp.dashboards.forEach(ts => {
-            this.respectiveDashboards.push(ts.name);
+            respectiveDashboards.push(ts.name);
           });
-          console.log(this.respectiveDashboards);
+
+          this.respectiveDashboards = respectiveDashboards;
         }
       );
     } catch (error) {

--- a/web/src/testgrid-router.ts
+++ b/web/src/testgrid-router.ts
@@ -17,7 +17,8 @@ export class TestgridRouter extends LitElement{
         },
     ])
 
-    firstUpdated() {
+    connectedCallback() {
+        super.connectedCallback();
         window.addEventListener('location-changed', () => {
             this.router.goto(location.pathname);
         });

--- a/web/web-test-runner.config.mjs
+++ b/web/web-test-runner.config.mjs
@@ -21,6 +21,14 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
     return true;
   },
 
+  /** configure test timeout */
+  testFramework: {
+    config: {
+      ui: 'bdd',
+      timeout: '10000',
+    },
+  },
+
   /** Compile JS for older browsers. Requires @web/dev-server-esbuild plugin */
   // esbuildTarget: 'auto',
 


### PR DESCRIPTION
fixes #1182 

Improve the existing test cases for `testgrid-index` custom element.

### Notable changes
- Remove the `Loading...` entry from the dashboard groups and dashboard properties. This was causing the tests to succeed before correctly rendering with the data from API
- populate a placeholder array instead of pushing into the property array, thus triggering the update multiple items
- Correcting the tests and avoid the flakiness by introducing some timeouts
- Add a test case for checking navigation
- Configure web test runner to have a larger timeout