### PR TITLE
Return all cells in API with proper run-length decoding.

### DIFF
--- a/pkg/api/v1/state_test.go
+++ b/pkg/api/v1/state_test.go
@@ -394,6 +394,77 @@ func TestListRows(t *testing.T) {
 			},
 		},
 		{
+			name: "Returns correct rows with blank cells",
+			config: map[string]*pb.Configuration{
+				"gs://default/config": {
+					Dashboards: []*pb.Dashboard{
+						{
+							Name: "Dashboard1",
+							DashboardTab: []*pb.DashboardTab{
+								{
+									Name:          "tab 1",
+									TestGroupName: "testgroupname",
+								},
+							},
+						},
+					},
+				},
+			},
+			grid: map[string]*statepb.Grid{
+				"gs://default/tabs/Dashboard1/tab%201": {
+					Rows: []*statepb.Row{
+						{
+							Name:     "tabrow1",
+							Id:       "tabrow1",
+							Results:  []int32{1, 2, 0, 2, 1, 1, 0, 3, 1, 1},
+							CellIds:  []string{"cell-1", "cell-2", "cell-5", "cell-9"},
+							Messages: []string{"", "", "hello", "no"},
+							Icons:    []string{"", "", "H", "N"},
+						},
+					},
+				},
+			},
+			req: &apipb.ListRowsRequest{
+				Scope:     "gs://default",
+				Dashboard: "dashboard1",
+				Tab:       "tab1",
+			},
+			want: &apipb.ListRowsResponse{
+				Rows: []*apipb.ListRowsResponse_Row{
+					{
+						Name: "tabrow1",
+						Cells: []*apipb.ListRowsResponse_Cell{
+							{
+								Result: 1,
+								CellId: "cell-1",
+							},
+							{
+								Result: 1,
+								CellId: "cell-2",
+							},
+							{},
+							{},
+							{
+								Result:  1,
+								CellId:  "cell-5",
+								Message: "hello",
+								Icon:    "H",
+							},
+							{},
+							{},
+							{},
+							{
+								Result:  1,
+								CellId:  "cell-9",
+								Message: "no",
+								Icon:    "N",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Returns tab from tab state",
 			config: map[string]*pb.Configuration{
 				"gs://default/config": {


### PR DESCRIPTION
Otherwise, we only return as many cells as there are non-blank cells, which artificially limits the number of cells returned for each row.

Adjusts the index used for messages/cell IDs/icons, since these are only filled in once per non-blank status.  (see https://github.com/GoogleCloudPlatform/testgrid/blob/358f270ad26e8a270cafebfdb8098aa72b54b533/pkg/updater/updater.go#L1200).