### PR TITLE
Alert stale tab when no rows exist.

### DIFF
--- a/pkg/summarizer/summary.go
+++ b/pkg/summarizer/summary.go
@@ -719,7 +719,7 @@ func updateTab(ctx context.Context, tab *configpb.DashboardTab, group *configpb.
 	grid.Rows = filterMethods(grid.Rows)
 
 	latest, latestSeconds := latestRun(grid.Columns)
-	alert := staleAlert(mod, latest, staleHours(tab))
+	alert := staleAlert(mod, latest, staleHours(tab), len(grid.Rows))
 	failures := failingTestSummaries(grid.Rows)
 	colsCells, brokenState := gridMetrics(len(grid.Columns), grid.Rows, recent, tab.BrokenColumnThreshold, features, tab.GetStatusCustomizationOptions())
 	metrics := tabMetrics(colsCells)
@@ -820,14 +820,14 @@ func latestRun(columns []*statepb.Column) (time.Time, int64) {
 const noRuns = "no completed results"
 
 // staleAlert returns an explanatory message if the latest results are stale.
-func staleAlert(mod, ran time.Time, stale time.Duration) string {
+func staleAlert(mod, ran time.Time, stale time.Duration, rows int) string {
 	if mod.IsZero() {
 		return "no stored results"
 	}
 	if stale == 0 {
 		return ""
 	}
-	if ran.IsZero() {
+	if ran.IsZero() || rows == 0 { // Has no columns and/or no rows.
 		return noRuns
 	}
 	now := time.Now()

--- a/pkg/summarizer/summary_test.go
+++ b/pkg/summarizer/summary_test.go
@@ -1521,6 +1521,7 @@ func TestStaleAlert(t *testing.T) {
 		mod   time.Time
 		ran   time.Time
 		dur   time.Duration
+		rows  int
 		alert bool
 	}{
 		{
@@ -1528,12 +1529,14 @@ func TestStaleAlert(t *testing.T) {
 			mod:  time.Now().Add(-5 * time.Minute),
 			ran:  time.Now().Add(-10 * time.Minute),
 			dur:  time.Hour,
+			rows: 10,
 		},
 		{
 			name:  "unmodified alerts",
 			mod:   time.Now().Add(-5 * time.Hour),
 			ran:   time.Now(),
 			dur:   time.Hour,
+			rows:  10,
 			alert: true,
 		},
 		{
@@ -1541,12 +1544,22 @@ func TestStaleAlert(t *testing.T) {
 			mod:   time.Now(),
 			ran:   time.Now().Add(-5 * time.Hour),
 			dur:   time.Hour,
+			rows:  10,
 			alert: true,
 		},
 		{
 			name:  "no runs alerts",
 			mod:   time.Now(),
 			dur:   time.Hour,
+			rows:  10,
+			alert: true,
+		},
+		{
+			name:  "no rows alerts",
+			mod:   time.Now().Add(-5 * time.Minute),
+			ran:   time.Now().Add(-10 * time.Minute),
+			dur:   time.Hour,
+			rows:  0,
 			alert: true,
 		},
 		{
@@ -1561,7 +1574,7 @@ func TestStaleAlert(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := staleAlert(tc.mod, tc.ran, tc.dur)
+			actual := staleAlert(tc.mod, tc.ran, tc.dur, tc.rows)
 			if actual != "" && !tc.alert {
 				t.Errorf("unexpected stale alert: %s", actual)
 			}


### PR DESCRIPTION
It's possible to have a grid with a column (see https://github.com/GoogleCloudPlatform/testgrid/blob/6ad903765c1a60491ea661d268780aa0e0de71ea/pkg/tabulator/tabstate.go#L445, which keeps a column if the grid would otherwise be empty) but no rows. This is fine, but the stale alert doesn't account for this at the moment. Update it to alert when no rows exist, in addition to the other reasons a tab might be stale.