### PR TITLE
Add new pod monitors for metrics on GMP.

### DIFF
--- a/cluster/canary/monitoring.yaml
+++ b/cluster/canary/monitoring.yaml
@@ -61,3 +61,59 @@ spec:
     matchLabels:
       app: testgrid
       component: updater
+---
+# These will be consumed by GKE Managed Prometheus(GMP) services in the cluster.
+# See: https://cloud.google.com/stackdriver/docs/managed-prometheus.
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitoring
+metadata:
+  labels:
+    app: testgrid-metrics
+    component: config-merger
+  name: config-merger
+  namespace: testgrid-canary
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: testgrid
+      component: config-merger
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitoring
+metadata:
+  labels:
+    app: testgrid-metrics
+    component: summarizer
+  name: summarizer
+  namespace: testgrid-canary
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: testgrid
+      component: summarizer
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitoring
+metadata:
+  labels:
+    app: testgrid-metrics
+    component: updater
+  name: updater
+  namespace: testgrid-canary
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: testgrid
+      component: updater

--- a/cluster/prod/monitoring.yaml
+++ b/cluster/prod/monitoring.yaml
@@ -61,3 +61,59 @@ spec:
     matchLabels:
       app: testgrid
       component: updater
+---
+# These will be consumed by GKE Managed Prometheus(GMP) services in the cluster.
+# See: https://cloud.google.com/stackdriver/docs/managed-prometheus.
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitoring
+metadata:
+  labels:
+    app: testgrid-metrics
+    component: config-merger
+  name: config-merger
+  namespace: testgrid
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: testgrid
+      component: config-merger
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitoring
+metadata:
+  labels:
+    app: testgrid-metrics
+    component: summarizer
+  name: summarizer
+  namespace: testgrid
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: testgrid
+      component: summarizer
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitoring
+metadata:
+  labels:
+    app: testgrid-metrics
+    component: updater
+  name: updater
+  namespace: testgrid
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: testgrid
+      component: updater


### PR DESCRIPTION
Following https://cloud.google.com/stackdriver/docs/solutions/gke/gmp-migration to migrate us to managed prometheus so our metrics work again ^^