### PR TITLE
Process raw results from Resultstore

### DIFF
--- a/pkg/updater/resultstore/client.go
+++ b/pkg/updater/resultstore/client.go
@@ -134,9 +134,19 @@ func (c *DownloadClient) FetchInvocation(ctx context.Context, log logrus.FieldLo
 		"invocation.id",
 		"invocation.timing",
 		"invocation.status_attributes",
+		"invocation.properties",
+		"invocation.invocation_attributes",
 		"targets.id",
 		"targets.timing",
 		"targets.status_attributes",
+		"targets.properties",
+		"actions.id",
+		"actions.timing",
+		"actions.properties",
+		"actions.status_attributes",
+		"actions.test_action",
+		"configured_targets.id",
+		"configured_targets.test_attributes",
 	)
 	for {
 		req := &resultstore.ExportInvocationRequest{


### PR DESCRIPTION
Added the logic to process raw results from Resultstore for easier grouping and conversion into InflatedColumn in the future.

### Notable changes
- Added extra fields to fieldmask (actions & configured targets)
- Converted fetched results to singleActionTargetResults (with targetID as a key)
- Set the column Name and Build to invocationID for now
- Added unit tests for processRawResult (which performs the conversion)