### PR TITLE
feat: #resultstore - add cell metrics

### DIFF
--- a/pkg/updater/resultstore/BUILD.bazel
+++ b/pkg/updater/resultstore/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_protobuf//testing/protocmp:go_default_library",
+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Add a feature to  calculate the cell metrics from properties as well as the duration in minutes.

Includes unit tests