### PR TITLE
Update junit.go to allow more data to be extracted

### DIFF
--- a/metadata/junit/junit.go
+++ b/metadata/junit/junit.go
@@ -106,7 +106,7 @@ type Result struct {
         Errored    *Errored    `xml:"error,omitempty"`
         Failure    *Failure    `xml:"failure,omitempty"`
         Skipped    *Skipped    `xml:"skipped,omitempty"`
-        Status     string      `xml:"status,omitempty"`
+        Status     string      `xml:"status,attr"`
         Properties *Properties `xml:"properties,omitempty"`
 }
 

--- a/metadata/junit/junit.go
+++ b/metadata/junit/junit.go
@@ -61,16 +61,18 @@ func (s *Suites) Truncate(max int) {
 
 // Suite holds <testsuite/> results
 type Suite struct {
-	XMLName  xml.Name `xml:"testsuite"`
-	Suites   []Suite  `xml:"testsuite"`
-	Name     string   `xml:"name,attr"`
-	Time     float64  `xml:"time,attr"` // Seconds
-	Failures int      `xml:"failures,attr"`
-	Tests    int      `xml:"tests,attr"`
-	Results  []Result `xml:"testcase"`
-	/*
-	* <properties><property name="go.version" value="go1.8.3"/></properties>
-	 */
+        XMLName    xml.Name    `xml:"testsuite"`
+        Suites     []Suite     `xml:"testsuite"`
+        Name       string      `xml:"name,attr"`
+        Properties *Properties `xml:"properties,omitempty"`
+        Time       float64     `xml:"time,attr"` // Seconds
+        TimeStamp  string      `xml:"timestamp,attr"`
+        Failures   int         `xml:"failures,attr"`
+        Tests      int         `xml:"tests,attr"`
+        Disabled   int         `xml:"disabled,attr"`
+        Skipped    int         `xml:"skipped,attr"`
+        Errors     int         `xml:"errors,attr"`
+        Results    []Result    `xml:"testcase"`
 }
 
 // Truncate ensures that strings do not exceed the specified length.
@@ -96,15 +98,16 @@ type Properties struct {
 
 // Result holds <testcase/> results
 type Result struct {
-	Name       string      `xml:"name,attr"`
-	Time       float64     `xml:"time,attr"`
-	ClassName  string      `xml:"classname,attr"`
-	Output     *string     `xml:"system-out,omitempty"`
-	Error      *string     `xml:"system-err,omitempty"`
-	Errored    *Errored    `xml:"error,omitempty"`
-	Failure    *Failure    `xml:"failure,omitempty"`
-	Skipped    *Skipped    `xml:"skipped,omitempty"`
-	Properties *Properties `xml:"properties,omitempty"`
+        Name       string      `xml:"name,attr"`
+        Time       float64     `xml:"time,attr"`
+        ClassName  string      `xml:"classname,attr"`
+        Output     *string     `xml:"system-out,omitempty"`
+        Error      *string     `xml:"system-err,omitempty"`
+        Errored    *Errored    `xml:"error,omitempty"`
+        Failure    *Failure    `xml:"failure,omitempty"`
+        Skipped    *Skipped    `xml:"skipped,omitempty"`
+        Status     string      `xml:"status,omitempty"`
+        Properties *Properties `xml:"properties,omitempty"`
 }
 
 // Errored holds <error/> elements.


### PR DESCRIPTION
Properties is available for testsuite, not for result in all prow jobs I checked.For now, add properties to Suite only for the safety purpose.