### PR TITLE
Update junit.go to allow more data to be extracted.

### DIFF
--- a/metadata/junit/junit.go
+++ b/metadata/junit/junit.go
@@ -61,16 +61,18 @@ func (s *Suites) Truncate(max int) {
 
 // Suite holds <testsuite/> results
 type Suite struct {
-	XMLName  xml.Name `xml:"testsuite"`
-	Suites   []Suite  `xml:"testsuite"`
-	Name     string   `xml:"name,attr"`
-	Time     float64  `xml:"time,attr"` // Seconds
-	Failures int      `xml:"failures,attr"`
-	Tests    int      `xml:"tests,attr"`
-	Results  []Result `xml:"testcase"`
-	/*
-	* <properties><property name="go.version" value="go1.8.3"/></properties>
-	 */
+	XMLName    xml.Name    `xml:"testsuite"`
+	Suites     []Suite     `xml:"testsuite"`
+	Name       string      `xml:"name,attr"`
+	Properties *Properties `xml:"properties,omitempty"`
+	Time       float64     `xml:"time,attr"` // Seconds
+	TimeStamp  string      `xml:"timestamp,attr"`
+	Failures   int         `xml:"failures,attr"`
+	Tests      int         `xml:"tests,attr"`
+	Disabled   int         `xml:"disabled,attr"`
+	Skipped    int         `xml:"skipped,attr"`
+	Errors     int         `xml:"errors,attr"`
+	Results    []Result    `xml:"testcase"`
 }
 
 // Truncate ensures that strings do not exceed the specified length.
@@ -104,6 +106,7 @@ type Result struct {
 	Errored    *Errored    `xml:"error,omitempty"`
 	Failure    *Failure    `xml:"failure,omitempty"`
 	Skipped    *Skipped    `xml:"skipped,omitempty"`
+	Status     string      `xml:"status,attr"`
 	Properties *Properties `xml:"properties,omitempty"`
 }
 

--- a/metadata/junit/junit_test.go
+++ b/metadata/junit/junit_test.go
@@ -206,8 +206,11 @@ func TestParse(t *testing.T) {
 			name: "parse testsuites correctly",
 			buf: []byte(`
                         <testsuites>
-                            <testsuite name="fun">
+                            <testsuite name="fun" tests="10" disabled="1" skipped="2" errors="3" failures="4" time="100.1" timestamp="2023-08-28T17:15:04">
                                 <testsuite name="knee">
+				    <properties>
+					<property name="SuiteSucceeded" value="true"></property>
+                                    </properties>
                                     <testcase name="bone" time="6" />
                                     <testcase name="head" time="3" >
 										<failure type="failure" message="failure message attribute"> failure message body </failure>
@@ -216,7 +219,7 @@ func TestParse(t *testing.T) {
 										<error type="error" message="error message attribute"> error message body </error>
 									</testcase>
                                 </testsuite>
-                                <testcase name="word" time="7" />
+				<testcase name="word"  classname="E2E Suite" status="skipped" time="7"></testcase>
                             </testsuite>
                         </testsuites>
                         `),
@@ -224,12 +227,27 @@ func TestParse(t *testing.T) {
 				XMLName: xml.Name{Local: "testsuites"},
 				Suites: []Suite{
 					{
-						XMLName: xml.Name{Local: "testsuite"},
-						Name:    "fun",
+						XMLName:   xml.Name{Local: "testsuite"},
+						Name:      "fun",
+						Failures:  4,
+						Tests:     10,
+						Disabled:  1,
+						Skipped:   2,
+						Errors:    3,
+						Time:      100.1,
+						TimeStamp: "2023-08-28T17:15:04",
 						Suites: []Suite{
 							{
 								XMLName: xml.Name{Local: "testsuite"},
 								Name:    "knee",
+								Properties: &Properties{
+									[]Property{
+										{
+											Name:  "SuiteSucceeded",
+											Value: "true",
+										},
+									},
+								},
 								Results: []Result{
 									{
 										Name: "bone",
@@ -250,8 +268,10 @@ func TestParse(t *testing.T) {
 						},
 						Results: []Result{
 							{
-								Name: "word",
-								Time: 7,
+								Name:      "word",
+								Time:      7,
+								ClassName: "E2E Suite",
+								Status:    "skipped",
 							},
 						},
 					},


### PR DESCRIPTION
Properties is available for testsuite, not for result in all prow jobs I checked. For now, add properties to Suite only for the safety purpose.
	modified:   junit.go
	modified:   junit_test.go