### PR TITLE
Add links for alerts, and utilities to process link templates.

### DIFF
--- a/pkg/summarizer/BUILD.bazel
+++ b/pkg/summarizer/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/summarizer/analyzers:go_default_library",
         "//pkg/summarizer/common:go_default_library",
         "//pkg/tabulator:go_default_library",
+        "//util:go_default_library",
         "//util/gcs:go_default_library",
         "//util/metrics:go_default_library",
         "//util/queue:go_default_library",

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -1,14 +1,18 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
+        "links.go",
         "log.go",
         "strings.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/util",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
+    deps = [
+        "//pb/config:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
 )
 
 filegroup(
@@ -28,4 +32,15 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["links_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pb/config:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
+    ],
 )

--- a/util/links.go
+++ b/util/links.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2023 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+)
+
+// Utility functions to correctly parse link templates.
+
+var (
+	// All tokens.
+	tokenRe = regexp.MustCompile(`<[^<>]*>`)
+
+	// Find the raw encode token: `<encode:[text]>`.
+	encodeTokenRe = regexp.MustCompile(`<encode:[^<>]*>`)
+	encodeRe      = regexp.MustCompile(`<encode:([^<>]*)>`)
+
+	// Substitute a particular custom column value for this token.
+	// TODO: Handle start/end columns (for custom columns and build IDs).
+	CustomColumnRe = regexp.MustCompile(`<custom-\d+>`)
+
+	// Simple tokens.
+	TestStatus      = "<test-status>"
+	TestID          = "<test-id>"
+	WorkflowID      = "<workflow-id>"
+	WorkflowName    = "<workflow-name>"
+	TestName        = "<test-name>"
+	DisplayName     = "<display-name>"
+	MethodName      = "<method-name>"
+	TestURL         = "<test-url>"
+	BuildID         = "<build-id>"
+	BugComponent    = "<bug-component>"
+	Owner           = "<owner>"
+	Cc              = "<cc>"
+	GcsPrefix       = "<gcs-prefix>"
+	Environment     = "<environment>" // dashboard tab name
+	ResultsExplorer = "<results-explorer>"
+	CodeSearchPath  = "<cs-path>"
+)
+
+// Tokens returns the unique list of all Tokens that could be replaced in this template.
+func Tokens(template *configpb.LinkTemplate) []string {
+	allTokens := map[string]bool{}
+	for _, token := range tokenRe.FindAllString(template.GetUrl(), -1) {
+		allTokens[token] = true
+	}
+	for _, option := range template.GetOptions() {
+		for _, token := range tokenRe.FindAllString(option.GetKey(), -1) {
+			allTokens[token] = true
+		}
+		for _, token := range tokenRe.FindAllString(option.GetValue(), -1) {
+			allTokens[token] = true
+		}
+	}
+	var keys []string
+	for k := range allTokens {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// ExpandTemplate expands the given link template with given parameters.
+func ExpandTemplate(template *configpb.LinkTemplate, parameters map[string]string) (string, error) {
+	rawUrl := expandTemplateString(template.GetUrl(), parameters, false)
+	baseUrl, err := url.Parse(rawUrl)
+	if err != nil {
+		return "", err
+	}
+	options := url.Values{}
+	for _, optionTemplate := range template.GetOptions() {
+		k := expandTemplateString(optionTemplate.GetKey(), parameters, true)
+		v := expandTemplateString(optionTemplate.GetValue(), parameters, true)
+		options.Add(k, v)
+	}
+	baseUrl.RawQuery = options.Encode()
+	return baseUrl.String(), nil
+}
+
+// expandTemplateString substitutes given parameters into the given link template.
+func expandTemplateString(template string, parameters map[string]string, isQuery bool) string {
+	// TODO: Handle start/end tokens.
+	// Substitute parameters for simple tokens.
+	for token, value := range parameters {
+		template = strings.ReplaceAll(template, token, value)
+	}
+	escape := url.PathEscape
+	if isQuery {
+		// Don't encode here; options.Encode() will do that.
+		escape = func(s string) string { return s }
+	}
+	// Encode specified parameters.
+	return encodeTokenRe.ReplaceAllStringFunc(
+		template,
+		func(token string) string {
+			submatches := encodeRe.FindStringSubmatch(token)
+			if len(submatches) <= 1 {
+				return ""
+			}
+			return escape(submatches[1])
+		},
+	)
+}

--- a/util/links_test.go
+++ b/util/links_test.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2023 The TestGrid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestTokens(t *testing.T) {
+	cases := []struct {
+		name     string
+		template *configpb.LinkTemplate
+		want     []string
+	}{
+		{
+			name:     "nil",
+			template: nil,
+			want:     nil,
+		},
+		{
+			name:     "empty",
+			template: &configpb.LinkTemplate{},
+			want:     nil,
+		},
+		{
+			name: "basically works",
+			template: &configpb.LinkTemplate{
+				Url: "https://test.com/<workflow-name>/<workflow-id>/<test-id>/<test-name>",
+				Options: []*configpb.LinkOptionsTemplate{
+					{
+						Key:   "prefix",
+						Value: "<gcs-prefix>",
+					},
+					{
+						Key:   "build",
+						Value: "<build-id>",
+					},
+					{
+						Key:   "prop",
+						Value: "<my-prop>",
+					},
+				},
+			},
+			want: []string{WorkflowName, WorkflowID, TestID, TestName, GcsPrefix, BuildID, "<my-prop>"},
+		},
+		{
+			name: "duplicate tokens",
+			template: &configpb.LinkTemplate{
+				Url: "https://test.com/<workflow-name>/<workflow-id>/<test-id>/<test-id>",
+				Options: []*configpb.LinkOptionsTemplate{
+					{
+						Key:   "workflow",
+						Value: "<workflow-name>",
+					},
+				},
+			},
+			want: []string{WorkflowName, WorkflowID, TestID},
+		},
+		{
+			name: "encode",
+			template: &configpb.LinkTemplate{
+				Url: "https://test.com/<encode:<workflow-name>>",
+				Options: []*configpb.LinkOptionsTemplate{
+					{
+						Key:   "workflow-id",
+						Value: "<encode:<workflow-id>>",
+					},
+				},
+			},
+			want: []string{WorkflowName, WorkflowID},
+		},
+		{
+			name: "invalid",
+			template: &configpb.LinkTemplate{
+				Url: "http://test.com/<oh-no",
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Tokens(tc.template)
+			if diff := cmp.Diff(tc.want, got, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+				t.Errorf("Tokens(%v) differed (-want, +got): %s", tc.template, diff)
+			}
+		})
+	}
+}
+
+func TestExpandTemplate(t *testing.T) {
+	cases := []struct {
+		name       string
+		template   *configpb.LinkTemplate
+		parameters map[string]string
+		err        bool
+		want       string
+	}{
+		{
+			name:       "nil",
+			template:   nil,
+			parameters: nil,
+			want:       "",
+		},
+		{
+			name: "nil parameters",
+			template: &configpb.LinkTemplate{
+				Url: "https://test.com/<workflow-name>/<workflow-id>/<test-id>/<test-name>",
+				Options: []*configpb.LinkOptionsTemplate{
+					{
+						Key:   "prefix",
+						Value: "<gcs-prefix>",
+					},
+					{
+						Key:   "build",
+						Value: "<build-id>",
+					},
+					{
+						Key:   "prop",
+						Value: "<my-prop>",
+					},
+				},
+			},
+			parameters: nil,
+			want:       "https://test.com/%3Cworkflow-name%3E/%3Cworkflow-id%3E/%3Ctest-id%3E/%3Ctest-name%3E?build=%3Cbuild-id%3E&prefix=%3Cgcs-prefix%3E&prop=%3Cmy-prop%3E",
+		},
+		{
+			name:       "empty",
+			template:   &configpb.LinkTemplate{},
+			parameters: map[string]string{},
+			want:       "",
+		},
+		{
+			name: "basically works",
+			template: &configpb.LinkTemplate{
+				Url: "https://test.com/<workflow-name>/<workflow-id>/<test-id>/<test-name>",
+				Options: []*configpb.LinkOptionsTemplate{
+					{
+						Key:   "prefix",
+						Value: "<gcs-prefix>",
+					},
+					{
+						Key:   "build",
+						Value: "<build-id>",
+					},
+					{
+						Key:   "prop",
+						Value: "<my-prop>",
+					},
+				},
+			},
+			parameters: map[string]string{
+				WorkflowName: "//my-workflow",
+				WorkflowID:   "workflow-id-1",
+				TestID:       "test-id-1",
+				TestName:     "//path/to:my-test",
+				GcsPrefix:    "my-bucket/has/results",
+				BuildID:      "build-1",
+				"<my-prop>":  "foo",
+			},
+			want: "https://test.com///my-workflow/workflow-id-1/test-id-1///path/to:my-test?build=build-1&prefix=my-bucket%2Fhas%2Fresults&prop=foo",
+		},
+		{
+			name: "invalid url",
+			template: &configpb.LinkTemplate{
+				Url: "https://test.com%+",
+				Options: []*configpb.LinkOptionsTemplate{
+					{
+						Key:   "prop",
+						Value: "%+<my-prop>",
+					},
+				},
+			},
+			parameters: map[string]string{
+				"<my-prop>": "foo",
+			},
+			err: true,
+		},
+		{
+			name: "duplicate tokens",
+			template: &configpb.LinkTemplate{
+				Url: "https://test.com/<test-id>/<test-id>",
+				Options: []*configpb.LinkOptionsTemplate{
+					{
+						Key:   "workflow",
+						Value: "<workflow-name>",
+					},
+					{
+						Key:   "workflow-name",
+						Value: "<workflow-name>",
+					},
+				},
+			},
+			parameters: map[string]string{
+				WorkflowName: "//my-workflow",
+				WorkflowID:   "workflow-id-1",
+				TestID:       "test-id-1",
+				TestName:     "//path/to:my-test",
+				GcsPrefix:    "my-bucket/has/results",
+				BuildID:      "build-1",
+				"<my-prop>":  "foo",
+			},
+			want: "https://test.com/test-id-1/test-id-1?workflow=%2F%2Fmy-workflow&workflow-name=%2F%2Fmy-workflow",
+		},
+		{
+			name: "encode",
+			template: &configpb.LinkTemplate{
+				Url: "https://test.com/<encode:<workflow-name>>",
+				Options: []*configpb.LinkOptionsTemplate{
+					{
+						Key:   "workflow",
+						Value: "<encode:<workflow-name>>",
+					},
+				},
+			},
+			parameters: map[string]string{
+				WorkflowName: "//my-workfl@w",
+			},
+			want: "https://test.com/%2F%2Fmy-workfl@w?workflow=%2F%2Fmy-workfl%40w",
+		},
+		{
+			name: "invalid",
+			template: &configpb.LinkTemplate{
+				Url: "http://test.com/<workflow-name",
+			},
+			parameters: map[string]string{
+				WorkflowName: "//my-workflow",
+			},
+			want: "http://test.com/%3Cworkflow-name",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExpandTemplate(tc.template, tc.parameters)
+			if tc.err && err == nil {
+				t.Errorf("ExpandTemplate() did not error as expected.")
+			} else if !tc.err && err != nil {
+				t.Errorf("ExpandTemplate() errored unexpectedly: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ExpandTemplate() differed (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestExpandTemplateString(t *testing.T) {
+	cases := []struct {
+		name        string
+		templateStr string
+		parameters  map[string]string
+		isQuery     bool
+		want        string
+	}{
+		{
+			name:        "empty",
+			templateStr: "",
+			parameters:  nil,
+			want:        "",
+		},
+		{
+			name:        "nil parameters",
+			templateStr: "https://test.com/<workflow-name>/<workflow-id>/<test-id>/<test-name>",
+			parameters:  nil,
+			want:        "https://test.com/<workflow-name>/<workflow-id>/<test-id>/<test-name>",
+		},
+		{
+			name:        "basically works",
+			templateStr: "https://test.com/<workflow-name>/<workflow-id>/<test-id>/<test-name>/<my-prop>",
+			parameters: map[string]string{
+				WorkflowName: "//my-workflow",
+				WorkflowID:   "workflow-id-1",
+				TestID:       "test-id-1",
+				TestName:     "//path/to:my-test",
+				"<my-prop>":  "foo",
+			},
+			want: "https://test.com///my-workflow/workflow-id-1/test-id-1///path/to:my-test/foo",
+		},
+		{
+			name:        "duplicate tokens",
+			templateStr: "https://test.com/<test-id>/<test-id>",
+			parameters: map[string]string{
+				TestID: "test-id-1",
+			},
+			want: "https://test.com/test-id-1/test-id-1",
+		},
+		{
+			name:        "encode",
+			templateStr: "https://test.com/<encode:<workflow-name>>",
+			parameters: map[string]string{
+				WorkflowName: "//my-workfl@w",
+			},
+			want: "https://test.com/%2F%2Fmy-workfl@w",
+		},
+		{
+			name:        "encode query",
+			templateStr: "<encode:<workflow-name>>",
+			parameters: map[string]string{
+				WorkflowName: "//my-workfl@w",
+			},
+			isQuery: true,
+			want:    "//my-workfl@w",
+		},
+		{
+			name:        "invalid",
+			templateStr: "http://test.com/<workflow-name",
+			parameters: map[string]string{
+				WorkflowName: "//my-workflow",
+			},
+			want: "http://test.com/<workflow-name",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := expandTemplateString(tc.templateStr, tc.parameters, tc.isQuery)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("expandTemplateString() differed (-want, +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The frontend currently processes links, but any components that want to use links (like Summarizer or downstream components) can't really do so. Replicate the logic for link-template parsing so we can make use of the user-specified links instead of hard-coded ones.