### PR TITLE
Add retry when snapshotting configuration.

### DIFF
--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -100,14 +100,16 @@ func Test_ReadGCS(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cache = test.currentCache
 			client := fake.Client{
-				Opener: fake.Opener{},
+				Opener: fake.Opener{
+					Paths: map[gcs.Path]fake.Object{},
+				},
 			}
 			expectedAttrs := &storage.ReaderObjectAttrs{
 				LastModified: test.remoteLastModified,
 				Generation:   test.remoteGeneration,
 			}
 
-			client.Opener[mustPath("gs://example")] = fake.Object{
+			client.Opener.Paths[mustPath("gs://example")] = fake.Object{
 				Data:  string(test.remoteData),
 				Attrs: expectedAttrs,
 			}

--- a/config/snapshot/BUILD.bazel
+++ b/config/snapshot/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//config:go_default_library",
         "//pb/config:go_default_library",
         "//util/gcs:go_default_library",
+        "@com_github_sethvargo_go_retry//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
     ],

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.3.0
+	github.com/sethvargo/go-retry v0.2.4
 	github.com/sirupsen/logrus v1.9.3
 	google.golang.org/api v0.134.0
 	google.golang.org/genproto v0.0.0-20230731193218-e0aa005b6bdf

--- a/go.sum
+++ b/go.sum
@@ -1152,6 +1152,8 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
+github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=
+github.com/sethvargo/go-retry v0.2.4/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/pkg/updater/persist_test.go
+++ b/pkg/updater/persist_test.go
@@ -223,7 +223,9 @@ func TestFixPersistent(t *testing.T) {
 				Uploader: fake.Uploader{},
 				Client: fake.Client{
 					Opener: fake.Opener{
-						*path: tc.currently,
+						Paths: map[gcs.Path]fake.Object{
+							*path: tc.currently,
+						},
 					},
 				},
 			}

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -389,13 +389,15 @@ func TestUpdate(t *testing.T) {
 					Uploader: fakeUploader{},
 					Client: fakeClient{
 						Lister: fakeLister{},
-						Opener: fakeOpener{},
+						Opener: fakeOpener{
+							Paths: map[gcs.Path]fake.Object{},
+						},
 					},
 				},
 				Lock: &sync.RWMutex{},
 			}
 
-			client.Opener[configPath] = fakeObject{
+			client.Opener.Paths[configPath] = fakeObject{
 				Data: func() string {
 					b, err := config.MarshalBytes(tc.config)
 					if err != nil {
@@ -2028,13 +2030,15 @@ func TestInflateDropAppend(t *testing.T) {
 					Uploader: fakeUploader{},
 					Client: fakeClient{
 						Lister: fakeLister{},
-						Opener: fakeOpener{},
+						Opener: fakeOpener{
+							Paths: map[gcs.Path]fake.Object{},
+						},
 					},
 				},
 			}
 
 			if tc.current != nil {
-				client.Opener[uploadPath] = *tc.current
+				client.Opener.Paths[uploadPath] = *tc.current
 			}
 
 			buildsPath := newPathOrDie("gs://" + tc.group.GcsPrefix)
@@ -2079,13 +2083,15 @@ func TestInflateDropAppend(t *testing.T) {
 				}
 				t.Logf("InflateDropAppend() generated a binary diff (-want +got):\n%s", diff)
 				fakeDownloader := fakeOpener{
-					uploadPath: {Data: string(actual[uploadPath].Buf)},
+					Paths: map[gcs.Path]fake.Object{
+						uploadPath: {Data: string(actual[uploadPath].Buf)},
+					},
 				}
 				actualGrid, _, err := gcs.DownloadGrid(ctx, fakeDownloader, uploadPath)
 				if err != nil {
 					t.Errorf("actual gcs.DownloadGrid() got unexpected error: %v", err)
 				}
-				fakeDownloader[uploadPath] = fakeObject{Data: string(tc.expected.Buf)}
+				fakeDownloader.Paths[uploadPath] = fakeObject{Data: string(tc.expected.Buf)}
 				expectedGrid, _, err := gcs.DownloadGrid(ctx, fakeDownloader, uploadPath)
 				if err != nil {
 					t.Errorf("expected gcs.DownloadGrid() got unexpected error: %v", err)

--- a/repos.bzl
+++ b/repos.bzl
@@ -1227,6 +1227,14 @@ def go_repositories():
         sum = "h1:K1Xf3bKttbF+koVGaX5xngRIZ5bVjbmPnaxE/dR08uY=",
         version = "v0.0.0-20201230142125-a7e3863a1245",
     )
+    go_repository(
+        name = "com_github_sethvargo_go_retry",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/sethvargo/go-retry",
+        sum = "h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=",
+        version = "v0.2.4",
+    )
 
     go_repository(
         name = "com_github_sirupsen_logrus",

--- a/util/queue/persist_test.go
+++ b/util/queue/persist_test.go
@@ -181,7 +181,9 @@ func TestFixPersistent(t *testing.T) {
 				Uploader: fake.Uploader{},
 				Client: fake.Client{
 					Opener: fake.Opener{
-						*path: tc.currently,
+						Paths: map[gcs.Path]fake.Object{
+							*path: tc.currently,
+						},
 					},
 				},
 			}


### PR DESCRIPTION
Adding a quick retry to mitigate issues where the configuration is (temporarily) not available on startup.

Added a unit test for this as well (probably could be cleaner, but it should verify that the retry actually works).

ETA: The actual change to add a retry is in config_snapshot.go. Everything else is an update to add a unit test for the retry, and enhance the storage fake to allow that (with a lock to prevent data races on map reads/writes for the fake Opener).