### PR TITLE
Clarify message for missing podinfo.json.

### DIFF
--- a/util/gcs/read.go
+++ b/util/gcs/read.go
@@ -44,9 +44,9 @@ type PodInfo struct {
 
 const (
 	// MissingPodInfo appears when builds complete without a podinfo.json report.
-	MissingPodInfo = "podinfo.json not found, please install prow's GCS reporter"
+	MissingPodInfo = "podinfo.json not found in job artifacts (has not uploaded, or Prow's GCS reporter is not enabled)."
 	// NoPodUtils appears when builds run without decoration.
-	NoPodUtils = "not using decoration, please set decorate: true on prowjob"
+	NoPodUtils = "Decoration is not enabled; set `decorate: true` on Prowjob."
 )
 
 func truncate(s string, max int) string {


### PR DESCRIPTION
TestGrid expects that podinfo.json is uploaded by the time that
finished.json is, and will either report it as a running/pending
status if finished.json isn't uploaded yet, or as a failure if it is.

The message that appears on the <job>.Pod cell isn't clear about this
case, so updating the message to include it. (The previous case
mentioned, where Prow's GCS reporter isn't enabled, still applies, but
podinfo.json can fail to be uploaded for other reasons as well).