### PR TITLE
Fixing a panic when recording column headers in alerts.

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -1342,6 +1342,13 @@ func alertRow(cols []*statepb.Column, row *statepb.Row, failuresToOpen, passesTo
 		compressedIdx++
 
 		for i := 0; i < len(columnHeader); i++ {
+			if i >= len(col.Extra) {
+				logrus.WithFields(logrus.Fields{
+					"started":                 time.Unix(0, int64(col.GetStarted()*float64(time.Millisecond))),
+					"additionalColumnHeaders": col.GetExtra(),
+				}).Trace("Insufficient column header values to record.")
+				break
+			}
 			if columnHeader[i].Label != "" {
 				customColumnHeaders[columnHeader[i].Label] = col.Extra[i]
 			} else if columnHeader[i].Property != "" {

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -4995,6 +4995,28 @@ func TestAlertRow(t *testing.T) {
 			property:  "some-prop",
 			expected:  alertInfo(4, "very wrong", "hello", "very wrong", nil, columns[5], columns[2], nil, false, nil),
 		},
+		{
+			name: "insufficient column header values",
+			columnHeader: append(
+				defaultColumnHeaders,
+				&configpb.TestGroup_ColumnHeader{
+					Property: "extra-key",
+				},
+			),
+			row: &statepb.Row{
+				Results: []int32{
+					int32(statuspb.TestStatus_PASS), 2,
+					int32(statuspb.TestStatus_FAIL), 4,
+				},
+				Messages:     []string{"no", "no again", "very wrong", "yes", "hi", "hello"},
+				CellIds:      []string{"no", "no again", "very wrong", "yes", "hi", "hello"},
+				UserProperty: []string{"prop0"},
+			},
+			failOpen:  3,
+			passClose: 3,
+			property:  "some-prop",
+			expected:  alertInfo(4, "very wrong", "hello", "very wrong", nil, columns[5], columns[2], nil, false, customColumnHeaders),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
A recent update to Summarizer records column header values (specifically, the 'extra' or 'custom' column header values) when recording metadata about alerted rows. We missed a case where, if there are fewer values recorded than the current number of custom column headers configured for the tab, we hit an out of index issue. (This is a legitimate case that can happen when new custom column headers are added).

Quick-fixed this by checking the length of column header values before recording them, and an additional unit test to verify this case. (We made this change internally, and I've verified it works already).