### PR TITLE
Report missing podinfo.json as PASS_WITH_SKIPS.

### DIFF
--- a/pkg/updater/gcs.go
+++ b/pkg/updater/gcs.go
@@ -459,7 +459,7 @@ func podInfoCell(result gcsResult) Cell {
 	case msg == gcs.MissingPodInfo && time.Now().Before(result.deadline()):
 		status = statuspb.TestStatus_RUNNING // Try and reprocess it next time.
 	case msg == gcs.MissingPodInfo:
-		status = statuspb.TestStatus_UNKNOWN // Probably won't receive it.
+		status = statuspb.TestStatus_PASS_WITH_SKIPS // Probably won't receive it.
 	case pass:
 		status = statuspb.TestStatus_PASS
 	default:

--- a/pkg/updater/gcs_test.go
+++ b/pkg/updater/gcs_test.go
@@ -2041,7 +2041,7 @@ func TestPodInfoCell(t *testing.T) {
 			},
 			expected: func() Cell {
 				c := podInfoMissingCell
-				c.Result = statuspb.TestStatus_UNKNOWN
+				c.Result = statuspb.TestStatus_PASS_WITH_SKIPS
 				return c
 			}(),
 		},
@@ -2059,7 +2059,7 @@ func TestPodInfoCell(t *testing.T) {
 			},
 			expected: func() Cell {
 				c := podInfoMissingCell
-				c.Result = statuspb.TestStatus_UNKNOWN
+				c.Result = statuspb.TestStatus_PASS_WITH_SKIPS
 				return c
 			}(),
 		},


### PR DESCRIPTION
It's not expected that podinfo.json is always uploaded from Prow, or that it's an error if it doesn't update. Instead of a neutral status (which affects the tab status in TestGrid), mark this as passing with skips so there's still an informational message, but it doesn't flag the tab as failing or flaky.