### PR TITLE
Capture configured target stats from ResultStore.

### DIFF
--- a/pkg/updater/resultstore/client.go
+++ b/pkg/updater/resultstore/client.go
@@ -148,7 +148,9 @@ func (c *DownloadClient) FetchInvocation(ctx context.Context, log logrus.FieldLo
 		"actions.status_attributes",
 		"actions.test_action",
 		"configured_targets.id",
+		"configured_targets.status_attributes",
 		"configured_targets.test_attributes",
+		"configured_targets.timing",
 	)
 	for {
 		req := &resultstore.ExportInvocationRequest{


### PR DESCRIPTION
Forgot to add field masks for fetching configured target stats from ResultStore. Without this, status and timing info don't get fetched when downloading results.