### PR TITLE
Use SearchConfiguredTargets when searching targets.

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pb/config:go_default_library",
+        "//pkg/updater/resultstore/query:go_default_library",
         "//util/gcs:go_default_library",
         "//util/queue:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"github.com/GoogleCloudPlatform/testgrid/pkg/updater/resultstore/query"
 	multierror "github.com/hashicorp/go-multierror"
 )
 
@@ -268,6 +269,9 @@ func validateResultStoreSource(tg *configpb.TestGroup) error {
 		// Can't leave project ID blank.
 		if rs.GetProject() == "" {
 			return errors.New("project ID in resultstore_config cannot be empty")
+		}
+		if _, err := query.TranslateQuery(rs.GetQuery()); err != nil {
+			return fmt.Errorf("invalid ResultStore query %q: %v", rs.GetQuery(), err)
 		}
 	}
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -499,6 +499,47 @@ func TestValidateResultStoreSource(t *testing.T) {
 			err: false,
 		},
 		{
+			name: "valid query",
+			tg: &configpb.TestGroup{
+				ResultSource: &configpb.TestGroup_ResultSource{
+					ResultSourceConfig: &configpb.TestGroup_ResultSource_ResultstoreConfig{
+						ResultstoreConfig: &configpb.ResultStoreConfig{
+							Project: "my-project",
+							Query:   `target:"my-job"`,
+						},
+					},
+				},
+			},
+			err: false,
+		},
+		{
+			name: "invalid query",
+			tg: &configpb.TestGroup{
+				ResultSource: &configpb.TestGroup_ResultSource{
+					ResultSourceConfig: &configpb.TestGroup_ResultSource_ResultstoreConfig{
+						ResultstoreConfig: &configpb.ResultStoreConfig{
+							Project: "my-project",
+							Query:   `label:foo bar`,
+						},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "query without project",
+			tg: &configpb.TestGroup{
+				ResultSource: &configpb.TestGroup_ResultSource{
+					ResultSourceConfig: &configpb.TestGroup_ResultSource_ResultstoreConfig{
+						ResultstoreConfig: &configpb.ResultStoreConfig{
+							Query: `target:"my-job"`,
+						},
+					},
+				},
+			},
+			err: true,
+		},
+		{
 			name: "gcs_prefix and ResultStore defined",
 			tg: &configpb.TestGroup{
 				GcsPrefix: "/my-bucket/logs",

--- a/pkg/updater/resultstore/BUILD.bazel
+++ b/pkg/updater/resultstore/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "client.go",
-        "query.go",
         "resultstore.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/testgrid/pkg/updater/resultstore",
@@ -15,6 +14,7 @@ go_library(
         "//pb/state:go_default_library",
         "//pb/test_status:go_default_library",
         "//pkg/updater:go_default_library",
+        "//pkg/updater/resultstore/query:go_default_library",
         "//util/gcs:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@go_googleapis//google/devtools/resultstore/v2:resultstore_go_proto",
@@ -28,10 +28,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = [
-        "query_test.go",
-        "resultstore_test.go",
-    ],
+    srcs = ["resultstore_test.go"],
     embed = [":go_default_library"],
     deps = [
         "//pb/config:go_default_library",
@@ -59,7 +56,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//pkg/updater/resultstore/query:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/pkg/updater/resultstore/query/BUILD.bazel
+++ b/pkg/updater/resultstore/query/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["query.go"],
+    importpath = "github.com/GoogleCloudPlatform/testgrid/pkg/updater/resultstore/query",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["query_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/updater/resultstore/query/query.go
+++ b/pkg/updater/resultstore/query/query.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resultstore
+package query
 
 import (
 	"fmt"
@@ -47,7 +47,7 @@ var (
 	queryRe = regexp.MustCompile(`^target:".*"$`)
 )
 
-func translateQuery(simpleQuery string) (string, error) {
+func TranslateQuery(simpleQuery string) (string, error) {
 	if simpleQuery == "" {
 		return "", nil
 	}

--- a/pkg/updater/resultstore/query/query_test.go
+++ b/pkg/updater/resultstore/query/query_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resultstore
+package query
 
 import (
 	"testing"
@@ -135,7 +135,7 @@ func TestTranslateQuery(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := translateQuery(tc.query)
+			got, err := TranslateQuery(tc.query)
 			if tc.want != got {
 				t.Errorf("translateQuery(%q) differed; got %q, want %q", tc.query, got, tc.want)
 			}

--- a/pkg/updater/resultstore/resultstore.go
+++ b/pkg/updater/resultstore/resultstore.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/testgrid/pkg/updater"
+	"github.com/GoogleCloudPlatform/testgrid/pkg/updater/resultstore/query"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 	"github.com/sirupsen/logrus"
 
@@ -890,7 +891,10 @@ func queryAfter(query string, when time.Time) string {
 }
 
 const (
+	// Use this when searching invocations, e.g. if query does not search for a target.
 	prowLabel = `invocation_attributes.labels:"prow"`
+	// Use this when searching for a configured target, e.g. if query contains `target:"<target>"`.
+	prowTargetLabel = `invocation.invocation_attributes.labels:"prow"`
 )
 
 func queryProw(baseQuery string, stop time.Time) (string, error) {
@@ -898,11 +902,11 @@ func queryProw(baseQuery string, stop time.Time) (string, error) {
 	if baseQuery == "" {
 		return queryAfter(prowLabel, stop), nil
 	}
-	query, err := translateQuery(baseQuery)
+	query, err := query.TranslateQuery(baseQuery)
 	if err != nil {
 		return "", err
 	}
-	return queryAfter(fmt.Sprintf("%s %s", query, prowLabel), stop), nil
+	return queryAfter(fmt.Sprintf("%s %s", query, prowTargetLabel), stop), nil
 }
 
 func search(ctx context.Context, log logrus.FieldLogger, client *DownloadClient, rsConfig *configpb.ResultStoreConfig, stop time.Time) ([]string, error) {


### PR DESCRIPTION
If searching for a target (as opposed to labels or other identifiers), we want to search for those results using a difference method (SearchConfiguredTargets, rather than SearchInvocations). Add the search method and use it if the query contains a target atom (and update the Prow label accordingly for this search).

Moved the query code into a separate package so it can be used in config validation without a circular dependency.