### PR TITLE
Fix race on timer in util.queue.

### DIFF
--- a/util/queue/queue.go
+++ b/util/queue/queue.go
@@ -214,12 +214,10 @@ func (q *Queue) sleep(d time.Duration) {
 		log.Debug("Sleeping...")
 	}
 	sleep := time.NewTimer(d)
+	defer sleep.Stop()
 	start := time.Now()
 	select {
 	case <-q.signal:
-		if !sleep.Stop() {
-			<-sleep.C
-		}
 		dur := time.Now().Sub(start)
 		log := log.WithField("after", dur.Round(time.Millisecond))
 		switch {


### PR DESCRIPTION
We're hitting an issue occasionally where Tabulator will stall out, which seems to be caused by the queue getting stuck during 'sleep()', likely because the timer channel has already been pulled from in the second select case, and the wait on receiving a value from the timer channel after timer.Stop() fails will block indefinitely.

Instead, ensure that timer.Stop() is definitely called, but don't bother to drain or close the channel. (Note that timer.Stop() doesn't stop the channel, but it should be cleaned up due to being out of scope once sleep() completes).