### PR TITLE
Specify auto-project detection for PubSub.

### DIFF
--- a/cmd/summarizer/main.go
+++ b/cmd/summarizer/main.go
@@ -96,7 +96,7 @@ func gcsFixer(ctx context.Context, projectSub string, configPath gcs.Path, tabPr
 		return nil, errors.New("malformed project/subscription")
 	}
 	projID, subID := parts[0], parts[1]
-	pubsubClient, err := gpubsub.NewClient(ctx, "", option.WithCredentialsFile(credPath))
+	pubsubClient, err := gpubsub.NewClient(ctx, gpubsub.DetectProjectID, option.WithCredentialsFile(credPath))
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create pubsub client")
 	}

--- a/cmd/tabulator/main.go
+++ b/cmd/tabulator/main.go
@@ -183,7 +183,7 @@ func gcsFixer(ctx context.Context, projectSub string, configPath gcs.Path, gridP
 		return nil, errors.New("malformed project/subscription")
 	}
 	projID, subID := parts[0], parts[1]
-	pubsubClient, err := gpubsub.NewClient(ctx, "", option.WithCredentialsFile(credPath))
+	pubsubClient, err := gpubsub.NewClient(ctx, gpubsub.DetectProjectID, option.WithCredentialsFile(credPath))
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create pubsub client")
 	}

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -215,7 +215,7 @@ func main() {
 
 	mets := updater.CreateMetrics(prometheus.NewFactory())
 
-	pubsubClient, err := gpubsub.NewClient(ctx, "", option.WithCredentialsFile(opt.creds))
+	pubsubClient, err := gpubsub.NewClient(ctx, gpubsub.DetectProjectID, option.WithCredentialsFile(opt.creds))
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create pubsub client")
 	}


### PR DESCRIPTION
In pubsub v1.32, a breaking change made it so specifying a blank project results in an error, rather than automatically detecting the project as it did before. Instead, specify the sentinel value for detecting the project automatically.

See
https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv1.32.0.

Note that an update a while back upgraded the pubsub module version from v1.22.2 to v1.33.0.

Verified locally that this change fixes some startup failures that exist on the current images. (This should be fixed the next time images are built and the autobump includes them in configs).