### PR TITLE
Subscribe to gs://kubernetes-ci-logs updates.

### DIFF
--- a/cluster/canary/updater.yaml
+++ b/cluster/canary/updater.yaml
@@ -46,6 +46,7 @@ spec:
         - --subscribe=kubernetes-jenkins=kubernetes-jenkins/testgrid-canary
         - --subscribe=oss-prow=k8s-testgrid/testgrid-canary
         - --subscribe=istio-prow=k8s-testgrid/testgrid-canary
+        - --subscribe=kubernetes-ci-logs=k8s-testgrid/testgrid-canary-kubernetes-ci-logs
         - --wait=4h
         resources:
           requests:

--- a/cluster/prod/updater.yaml
+++ b/cluster/prod/updater.yaml
@@ -46,6 +46,7 @@ spec:
         - --subscribe=kubernetes-jenkins=kubernetes-jenkins/testgrid
         - --subscribe=oss-prow=k8s-testgrid/testgrid
         - --subscribe=istio-prow=k8s-testgrid/testgrid
+        - --subscribe=kubernetes-ci-logs=k8s-testgrid/testgrid-kubernetes-ci-logs
         - --wait=2h
         resources:
           requests:

--- a/cluster/setup-pubsub.sh
+++ b/cluster/setup-pubsub.sh
@@ -24,10 +24,10 @@ goog_buckets=(
 
 goog_topic=projects/k8s-testgrid/topics/prow-updates
 
-k8s_topic=projects/kubernetes-jenkins/topics/prow-updates
+k8s_topic=projects/k8s-infra-prow/topics/kubernetes-ci-logs-updates
 
 k8s_buckets=(
-    gs://kubernetes-jenkins
+    gs://kubernetes-ci-logs
 )
 
 dir=$(dirname "$0")
@@ -75,7 +75,7 @@ while getopts "lst" flag; do
     case "$flag" in
         s)
             apply-subscription "$goog_topic" k8s-testgrid testgrid testgrid-canary
-            apply-subscription "$k8s_topic" kubernetes-jenkins testgrid testgrid-canary
+            apply-subscription "$k8s_topic" k8s-testgrid testgrid-kubernetes-ci-logs testgrid-canary-kubernetes-ci-logs
             something=yes
             ;;
         t)

--- a/cluster/setup-testgrid-pubsub.sh
+++ b/cluster/setup-testgrid-pubsub.sh
@@ -33,8 +33,8 @@ log() {
 apply() {
     log "$create_topic" -t "$topic" -p '' "$bucket"
 
-    log "$create_sub" -t "$topic" -b "$bot" -p "$project" -f "$group_prefix" "$group_sub"
-    log "$create_sub" -t "$topic" -b "$bot" -p "$project" -f "$tab_prefix" "$tab_sub"
+    log "$create_sub" -t "$topic" -b "$bot" -p "$project" -f "hasPrefix(attributes.name, \"$group_prefix\")" "$group_sub"
+    log "$create_sub" -t "$topic" -b "$bot" -p "$project" -f "hasPrefix(attributes.name, \"$tab_prefix\")" "$tab_sub"
 }
 
 project=k8s-testgrid
@@ -43,8 +43,8 @@ bucket=gs://k8s-testgrid
 topic="projects/$project/topics/testgrid"
 group_sub=test-group-updates
 tab_sub=tab-updates
-group_prefix=""
-tab_prefix=""
+group_prefix="grid/"
+tab_prefix="tabs/"
 bot=serviceAccount:updater@k8s-testgrid.iam.gserviceaccount.com
 apply
 


### PR DESCRIPTION
Includes two changes:
- Add a canary and prod subscription on gs://kubernetes-ci-logs to the PubSub setup script. (And run it so the new subscriptions are registered on k8s-testgrid. This should eventually get replaced with Terraform setup, but that's probably better to do later if/when we migrate to a separate setup for Kubernetes).
- Add the subscriptions to the Updater config, so the Updater responds to updates on gs://kubernetes-ci-logs (same as it does for gs://kubernetes-jenkins).

Ref https://github.com/kubernetes/test-infra/issues/33386
(That will be fixed once these changes make it to prod).