### PR TITLE
Allow label/target search for ResultStore sources.

### DIFF
--- a/pkg/updater/resultstore/query/query.go
+++ b/pkg/updater/resultstore/query/query.go
@@ -17,47 +17,76 @@ limitations under the License.
 package query
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 )
 
-func translateAtom(simpleAtom string) (string, error) {
-	if simpleAtom == "" {
-		return "", nil
-	}
-	// For now, we expect an atom with the exact form `target:"<target>"`
-	// Split the `key:value` atom.
-	parts := strings.SplitN(simpleAtom, ":", 2)
-	if len(parts) != 2 {
-		return "", fmt.Errorf("unrecognized atom %q", simpleAtom)
-	}
-	key := strings.TrimSpace(parts[0])
-	val := strings.Trim(strings.TrimSpace(parts[1]), `"`)
+type keyValue struct {
+	key   string
+	value string
+}
 
+func translateAtom(simpleAtom keyValue, queryTarget bool) (string, error) {
+	if simpleAtom.key == "" {
+		return "", errors.New("missing key")
+	}
+	if simpleAtom.value == "" {
+		return "", errors.New("missing value")
+	}
 	switch {
-	case key == "target":
-		return fmt.Sprintf(`id.target_id="%s"`, val), nil
+	case simpleAtom.key == "label" && queryTarget:
+		return fmt.Sprintf(`invocation.invocation_attributes.labels:"%s"`, simpleAtom.value), nil
+	case simpleAtom.key == "label":
+		return fmt.Sprintf(`invocation_attributes.labels:"%s"`, simpleAtom.value), nil
+	case simpleAtom.key == "target":
+		return fmt.Sprintf(`id.target_id="%s"`, simpleAtom.value), nil
 	default:
-		return "", fmt.Errorf("unrecognized atom key %q", key)
+		return "", fmt.Errorf("unknown type of atom %q", simpleAtom.key)
 	}
 }
 
 var (
-	queryRe = regexp.MustCompile(`^target:".*"$`)
+	// Captures any atoms of the form `label:"<label>"` or `target:"<target>"`.
+	atomReStr = `(?P<atom>(?P<key>label|target):"(?P<value>.+?)")`
+	atomRe    = regexp.MustCompile(atomReStr)
+	// A query can only have atoms (above), separated by spaces.
+	queryRe = regexp.MustCompile(`^(`+atomReStr+` *)+$`)
 )
 
+// TranslateQuery translates a simple query (similar to the syntax of searching invocations in the
+// UI) to a query for searching via API.
+// More at https://github.com/googleapis/googleapis/blob/master/google/devtools/resultstore/v2/resultstore_download.proto.
+//
+// This expects a query consisting of any number of space-separated `label:"<label>"` or
+// `target:"<target>"` atoms.
 func TranslateQuery(simpleQuery string) (string, error) {
 	if simpleQuery == "" {
 		return "", nil
 	}
-	// For now, we expect a query with a single atom, with the exact form `target:"<target>"`
 	if !queryRe.MatchString(simpleQuery) {
-		return "", fmt.Errorf("invalid query %q: must match %q", simpleQuery, queryRe.String())
+		return "", fmt.Errorf("query must consist of only space-separated `label:\"<label>\"` or `target:\"<target>\"` atoms")
 	}
-	query, err := translateAtom(simpleQuery)
-	if err != nil {
-		return "", fmt.Errorf("invalid query %q: %v", simpleQuery, err)
+	var simpleAtoms []keyValue
+	var queryTarget bool
+	matches := atomRe.FindAllStringSubmatch(simpleQuery, -1)
+	for _, match := range matches {
+		if len(match) != 4 {
+			return "", fmt.Errorf("atom %v: want 4 submatches (full match, atom, key, value), but got %d", match, len(match))
+		}
+		simpleAtoms = append(simpleAtoms, keyValue{match[2], match[3]})
+		if match[2] == "target" {
+			queryTarget = true
+		}
 	}
-	return query, nil
+	var atoms []string
+	for _, simpleAtom := range simpleAtoms {
+		atom, err := translateAtom(simpleAtom, queryTarget)
+		if err != nil {
+			return "", fmt.Errorf("atom %v: %v", simpleAtom, err)
+		}
+		atoms = append(atoms, atom)
+	}
+	return strings.Join(atoms, " "), nil
 }

--- a/pkg/updater/resultstore/query/query_test.go
+++ b/pkg/updater/resultstore/query/query_test.go
@@ -22,63 +22,54 @@ import (
 
 func TestTranslateAtom(t *testing.T) {
 	cases := []struct {
-		name      string
-		atom      string
-		want      string
-		wantError bool
+		name        string
+		atom        keyValue
+		queryTarget bool
+		want        string
+		wantError   bool
 	}{
 		{
 			name: "empty",
-			atom: "",
+			atom: keyValue{"", ""},
 			want: "",
 		},
 		{
 			name: "basic",
-			atom: `target:"//my-target"`,
+			atom: keyValue{"target", "//my-target"},
 			want: `id.target_id="//my-target"`,
 		},
 		{
-			name:      "case-sensitive key",
-			atom:      `TARGET:"//MY-TARGET"`,
-			wantError: true,
+			name: "case-sensitive key",
+			atom: keyValue{"TARGET", "//MY-TARGET"},
+			want: "",
 		},
 		{
 			name: "multiple colons",
-			atom: `target:"//path/to:my-target"`,
+			atom: keyValue{"target", "//path/to:my-target"},
 			want: `id.target_id="//path/to:my-target"`,
 		},
 		{
-			name: "unquoted",
-			atom: `target://my-target`,
-			want: `id.target_id="//my-target"`,
+			name: "missing key",
+			atom: keyValue{"", "//path/to:my-target"},
+			want: "",
 		},
 		{
-			name: "partial quotes",
-			atom: `target://my-target"`,
-			want: `id.target_id="//my-target"`,
+			name: "missing value",
+			atom: keyValue{"target", ""},
+			want: "",
 		},
 		{
-			name:      "not enough parts",
-			atom:      "target",
-			wantError: true,
-		},
-		{
-			name:      "unknown atom",
-			atom:      "label:foo",
-			wantError: true,
+			name: "unknown atom",
+			atom: keyValue{"custom-property", "foo"},
+			want: "",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := translateAtom(tc.atom)
+			got := translateAtom(tc.atom, tc.queryTarget)
 			if tc.want != got {
-				t.Errorf("translateAtom(%q) differed; got %q, want %q", tc.atom, got, tc.want)
-			}
-			if err == nil && tc.wantError {
-				t.Errorf("translateAtom(%q) did not error as expected", tc.atom)
-			} else if err != nil && !tc.wantError {
-				t.Errorf("translateAtom(%q) errored unexpectedly: %v", tc.atom, err)
+				t.Errorf("translateAtom(%q, %t) differed; got %q, want %q", tc.atom, tc.queryTarget, got, tc.want)
 			}
 		})
 	}

--- a/pkg/updater/resultstore/resultstore_test.go
+++ b/pkg/updater/resultstore/resultstore_test.go
@@ -203,30 +203,32 @@ func TestColumnReader(t *testing.T) {
 	oneMonthConfig := &configpb.TestGroup{
 		Name:          "a-test-group",
 		DaysOfResults: 30,
+		ResultSource: &configpb.TestGroup_ResultSource{
+			ResultSourceConfig: &configpb.TestGroup_ResultSource_ResultstoreConfig{
+				ResultstoreConfig: &configpb.ResultStoreConfig{
+					Query: `label:"foo"`,
+				},
+			},
+		},
 	}
 	now := time.Now()
 	oneDayAgo := now.AddDate(0, 0, -1)
 	twoDaysAgo := now.AddDate(0, 0, -2)
 	threeDaysAgo := now.AddDate(0, 0, -3)
 	oneMonthAgo := now.AddDate(0, 0, -30)
-	testQueryAfter := queryAfter(prowLabel, oneMonthAgo)
+	testQueryAfter := queryAfter(`invocation_attributes.labels:"foo"`, oneMonthAgo)
 	cases := []struct {
 		name    string
 		client  *fakeClient
-		tg      *configpb.TestGroup
 		want    []updater.InflatedColumn
 		wantErr bool
 	}{
 		{
 			name:    "empty",
-			tg:      oneMonthConfig,
 			wantErr: true,
 		},
 		{
 			name: "basic",
-			tg: &configpb.TestGroup{
-				DaysOfResults: 30,
-			},
 			client: &fakeClient{
 				searches: map[string][]string{
 					testQueryAfter: {"id-1", "id-2"},
@@ -351,7 +353,6 @@ func TestColumnReader(t *testing.T) {
 		},
 		{
 			name: "no results from query",
-			tg:   oneMonthConfig,
 			client: &fakeClient{
 				searches: map[string][]string{},
 				invocations: map[string]FetchResult{
@@ -2595,15 +2596,15 @@ func TestQueryAfter(t *testing.T) {
 		},
 		{
 			name:  "zero",
-			query: prowLabel,
+			query: `invocation_attributes.labels:"foo"`,
 			when:  time.Time{},
-			want:  "invocation_attributes.labels:\"prow\" timing.start_time>=\"0001-01-01T00:00:00Z\"",
+			want:  `invocation_attributes.labels:"foo" timing.start_time>="0001-01-01T00:00:00Z"`,
 		},
 		{
 			name:  "basic",
-			query: prowLabel,
+			query: `invocation_attributes.labels:"foo"`,
 			when:  now,
-			want:  fmt.Sprintf("invocation_attributes.labels:\"prow\" timing.start_time>=\"%s\"", now.UTC().Format(time.RFC3339)),
+			want:  fmt.Sprintf(`invocation_attributes.labels:"foo" timing.start_time>="%s"`, now.UTC().Format(time.RFC3339)),
 		},
 	}
 	for _, tc := range cases {
@@ -2616,63 +2617,10 @@ func TestQueryAfter(t *testing.T) {
 	}
 }
 
-func TestQueryProw(t *testing.T) {
-	now := time.Now()
-	cases := []struct {
-		name      string
-		query     string
-		when      time.Time
-		want      string
-		wantError bool
-	}{
-		{
-			name: "empty",
-			want: "invocation_attributes.labels:\"prow\" timing.start_time>=\"0001-01-01T00:00:00Z\"",
-		},
-		{
-			name:  "zero",
-			query: "",
-			when:  time.Time{},
-			want:  "invocation_attributes.labels:\"prow\" timing.start_time>=\"0001-01-01T00:00:00Z\"",
-		},
-		{
-			name:  "basic",
-			query: "",
-			when:  now,
-			want:  fmt.Sprintf("invocation_attributes.labels:\"prow\" timing.start_time>=\"%s\"", now.UTC().Format(time.RFC3339)),
-		},
-		{
-			name:  "target",
-			query: `target:"my-job"`,
-			when:  now,
-			want:  fmt.Sprintf("id.target_id=\"my-job\" invocation.invocation_attributes.labels:\"prow\" timing.start_time>=\"%s\"", now.UTC().Format(time.RFC3339)),
-		},
-		{
-			name:      "invalid query",
-			query:     `label:foo bar`,
-			when:      now,
-			wantError: true,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := queryProw(tc.query, tc.when)
-			if !tc.wantError && err != nil {
-				t.Errorf("queryProw(%q, %v) errored: %v", tc.query, tc.when, err)
-			} else if tc.wantError && err == nil {
-				t.Errorf("queryProw(%q, %v) did not error as expected", tc.query, tc.when)
-			}
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("queryProw(%q, %v) differed (-want, +got): %s", tc.query, tc.when, diff)
-			}
-		})
-	}
-}
-
 func TestSearch(t *testing.T) {
 	twoDaysAgo := time.Now().AddDate(0, 0, -2)
-	testQueryAfter := queryAfter(prowLabel, twoDaysAgo)
-	testTargetQueryAfter, _ := queryProw(`target:"my-job"`, twoDaysAgo)
+	testQueryAfter := queryAfter(`invocation_attributes.labels:"foo"`, twoDaysAgo)
+	testTargetQueryAfter := queryAfter(`id.target_id="my-job"`, twoDaysAgo)
 	cases := []struct {
 		name     string
 		stop     time.Time
@@ -2695,6 +2643,7 @@ func TestSearch(t *testing.T) {
 			name: "no results",
 			rsConfig: &configpb.ResultStoreConfig{
 				Project: "my-project",
+				Query: `label:foo`,
 			},
 			client:  &fakeClient{},
 			wantErr: true,
@@ -2703,6 +2652,7 @@ func TestSearch(t *testing.T) {
 			name: "basic",
 			rsConfig: &configpb.ResultStoreConfig{
 				Project: "my-project",
+				Query: `label:"foo"`,
 			},
 			client: &fakeClient{
 				searches: map[string][]string{


### PR DESCRIPTION
Instead of requiring `label:"prow"` in queries, allow any number of label or target atoms in a query. (This still limits the queries we accept, but it should work for most simple uses of ResultStore sources).

Test: Unit tests, and verified with a local instance of TestGrid that a ResultStore source config will pick up results from ResultStore correctly.