### PR TITLE
Add request and limits for testgrid-api deployments

### DIFF
--- a/cluster/canary/api.yaml
+++ b/cluster/canary/api.yaml
@@ -30,6 +30,13 @@ spec:
         - --allowed-origin=*
         - --scope=gs://k8s-testgrid-canary
         - --port=8080
+        resources:
+          requests: 
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "2"
+            memory: "4Gi"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/cluster/prod/api.yaml
+++ b/cluster/prod/api.yaml
@@ -30,6 +30,13 @@ spec:
         - --allowed-origin=*
         - --scope=gs://k8s-testgrid
         - --port=8080
+        resources:
+          requests: 
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "2"
+            memory: "4Gi"
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Add resource requests and limits to testgrid-api deployments (canary and prod)

Solves: https://github.com/kubernetes-sigs/testgrid/issues/84 